### PR TITLE
Add Codex app support via Hermes GPT MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0b1 - 2026-07-09
+
+- Added the first Codex integration batch: a curated MCP stdio server at `hermes-gpt mcp` (also available as `hermes-gpt codex mcp`).
+- Added `hermes-gpt codex install`, `uninstall`, `doctor`, and `print-config` with idempotent, backup-first TOML fallback handling.
+- Added Codex-focused planning, local vision path validation, web extraction SSRF protections, dry-run cron planning, skill drafting, and gateway diagnostics.
+- Added explicit Codex/MCP capability gates plus strict write gates for cron and skill writes.
+- Added recursive response redaction for provider keys, GitHub tokens, cookies/session values, bearer tokens, and private keys.
+
 ## 0.4.0 - 2026-07-09
 
 - Added env-gated Hermes tool wrappers: `hermes_vision_analyze` (HERMES_GPT_ENABLE_VISION), `hermes_web_search` / `hermes_web_extract` (HERMES_GPT_ENABLE_WEB).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Or clone from [GitHub](https://github.com/asimons81/hermes-gpt).
 
 This is a **local-dev release**.
 
+## Codex App / Codex CLI Support
+
+The first v0.5.0 batch adds a local Codex connector built on MCP. It is a curated tool surface for planning, local vision analysis, web search/extraction, cron planning, skill drafts, and gateway diagnostics; it does not modify Codex itself or bypass its permissions.
+
+```powershell
+$env:HERMES_GPT_ENABLE_CODEX="1"
+$env:HERMES_GPT_ENABLE_MCP="1"
+hermes-gpt codex install
+hermes-gpt codex doctor
+```
+
+The installer prefers `codex mcp add` when available and otherwise creates a backup before adding only the Hermes GPT entry. Use `hermes-gpt codex install --project` for `<repo>/.codex/config.toml`, and `hermes-gpt codex uninstall` to remove only that entry. Full setup, safety gates, and troubleshooting live in [docs/codex.md](docs/codex.md).
+
 ## What's New in v0.4.0
 
 v0.4.0 is the Tool Surface Expansion release. It adds env-gated Hermes tool wrappers, a cron creation operator tool, and ships the first external contribution.

--- a/codex_config.py
+++ b/codex_config.py
@@ -1,0 +1,322 @@
+"""Safe, idempotent Codex MCP configuration and doctor helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import operator_policy as op_policy
+from codex_core import ENABLE_CODEX_ENV, ENABLE_MCP_ENV, redact_value
+
+
+SERVER_NAME = "hermes-gpt"
+DEFAULT_STARTUP_TIMEOUT = 30
+
+
+def config_path(*, project: bool = False, cwd: Path | None = None) -> Path:
+    if project:
+        start = (cwd or Path.cwd()).resolve()
+        try:
+            completed = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=start,
+                text=True,
+                capture_output=True,
+                shell=False,
+                timeout=5,
+            )
+            if completed.returncode == 0 and completed.stdout.strip():
+                start = Path(completed.stdout.strip()).resolve()
+        except (OSError, subprocess.SubprocessError):
+            pass
+        return start / ".codex" / "config.toml"
+    return Path.home() / ".codex" / "config.toml"
+
+
+def read_config(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    import tomllib
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def get_server_entry(path: Path, name: str = SERVER_NAME) -> dict[str, Any] | None:
+    try:
+        item = read_config(path).get("mcp_servers", {}).get(name)
+    except Exception:
+        return None
+    return item if isinstance(item, dict) else None
+
+
+def launcher_argv(server_path: Path | None = None) -> list[str]:
+    return [sys.executable, str((server_path or Path(__file__).with_name("server.py")).resolve()), "mcp"]
+
+
+def _toml_quote(value: str) -> str:
+    return json.dumps(value)
+
+
+def _toml_array(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_quote(value) for value in values) + "]"
+
+
+def _render_server_entry(argv: list[str], name: str = SERVER_NAME) -> str:
+    quoted_name = _toml_quote(name)
+    command, *args = argv
+    return (
+        f"[mcp_servers.{quoted_name}]\n"
+        f"command = {_toml_quote(command)}\n"
+        f"args = {_toml_array(args)}\n"
+        f"startup_timeout_sec = {DEFAULT_STARTUP_TIMEOUT}\n\n"
+        f"[mcp_servers.{quoted_name}.env]\n"
+        f"{ENABLE_CODEX_ENV} = \"1\"\n"
+        f"{ENABLE_MCP_ENV} = \"1\"\n"
+    )
+
+
+def _is_hermes_entry(entry: dict[str, Any] | None) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    args = entry.get("args")
+    command = str(entry.get("command", "")).lower()
+    return isinstance(args, list) and "mcp" in args and ("hermes-gpt" in command or any("server.py" in str(arg).lower() for arg in args))
+
+
+def _is_named_table(line: str, name: str) -> bool:
+    quoted = re.escape(_toml_quote(name))
+    bare = re.escape(name)
+    return bool(re.match(rf"^\[mcp_servers\.(?:{quoted}|{bare})(?:\.env)?\]\s*$", line.strip()))
+
+
+def _drop_server_entry(text: str, name: str = SERVER_NAME) -> tuple[str, bool]:
+    """Remove only the named server and its env table, preserving other TOML."""
+    lines = text.splitlines(keepends=True)
+    kept: list[str] = []
+    removing = False
+    removed = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            if _is_named_table(line, name):
+                removing = True
+                removed = True
+                continue
+            removing = False
+        if not removing:
+            kept.append(line)
+    result = "".join(kept)
+    result = re.sub(r"\n{3,}", "\n\n", result).rstrip() + ("\n" if result.strip() else "")
+    return result, removed
+
+
+def _backup(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup = path.with_name(f"{path.name}.bak-{stamp}")
+    index = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.bak-{stamp}-{index}")
+        index += 1
+    shutil.copy2(path, backup)
+    return backup
+
+
+def _write_direct(path: Path, argv: list[str], name: str = SERVER_NAME) -> dict[str, Any]:
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    without_old, removed = _drop_server_entry(existing, name)
+    updated = without_old.rstrip()
+    if updated:
+        updated += "\n\n"
+    updated += _render_server_entry(argv, name)
+    if updated == existing:
+        return {"changed": False, "backup": None}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    backup = _backup(path)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(updated, encoding="utf-8", newline="\n")
+    try:
+        read_config(temporary)
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return {"changed": True, "backup": str(backup) if backup else None, "replaced_existing_entry": removed}
+
+
+def _run_codex_add(codex: str, name: str, argv: list[str]) -> subprocess.CompletedProcess[str]:
+    command = [codex, "mcp", "add", name, "--env", f"{ENABLE_CODEX_ENV}=1", "--env", f"{ENABLE_MCP_ENV}=1", "--", *argv]
+    return subprocess.run(command, text=True, capture_output=True, shell=False, timeout=30)
+
+
+def install(*, project: bool = False, cwd: Path | None = None, name: str = SERVER_NAME, server_path: Path | None = None, prefer_cli: bool = True) -> dict[str, Any]:
+    path = config_path(project=project, cwd=cwd)
+    argv = launcher_argv(server_path)
+    try:
+        read_config(path)
+    except Exception:
+        return {"ok": False, "changed": False, "code": "MALFORMED_CONFIG", "config_path": str(path), "message": "Codex config is not valid TOML; it was not modified."}
+    existing = get_server_entry(path, name)
+    if existing:
+        if _is_hermes_entry(existing):
+            return redact_value({"ok": True, "changed": False, "method": "existing", "config_path": str(path), "message": f"{name} is already configured.", "entry": existing})
+        return {"ok": False, "changed": False, "code": "NAME_CONFLICT", "config_path": str(path), "message": f"{name} is owned by a different MCP configuration; no changes were made."}
+
+    codex = shutil.which("codex") if prefer_cli and not project else None
+    if codex:
+        try:
+            completed = _run_codex_add(codex, name, argv)
+            if completed.returncode == 0:
+                return redact_value({"ok": True, "changed": True, "method": "codex-cli", "config_path": str(path), "command": [codex, "mcp", "add", name], "output": completed.stdout.strip()})
+            cli_error = op_policy.redact_output(completed.stderr.strip() or completed.stdout.strip())
+        except (OSError, subprocess.SubprocessError) as exc:
+            cli_error = op_policy.redact_output(str(exc))
+    else:
+        cli_error = "Codex CLI unavailable" if not project else "Project install uses safe TOML editing"
+
+    direct = _write_direct(path, argv, name)
+    return redact_value({"ok": True, "method": "toml-fallback", "config_path": str(path), "launcher": argv, "cli_note": cli_error, **direct})
+
+
+def uninstall(*, project: bool = False, cwd: Path | None = None, name: str = SERVER_NAME) -> dict[str, Any]:
+    path = config_path(project=project, cwd=cwd)
+    if not path.exists():
+        return {"ok": True, "changed": False, "config_path": str(path), "message": "No Codex config file exists."}
+    try:
+        read_config(path)
+    except Exception:
+        return {"ok": False, "changed": False, "code": "MALFORMED_CONFIG", "config_path": str(path), "message": "Codex config is not valid TOML; it was not modified."}
+    existing = path.read_text(encoding="utf-8")
+    entry = get_server_entry(path, name)
+    if entry is not None and not _is_hermes_entry(entry):
+        return {"ok": False, "changed": False, "code": "NAME_CONFLICT", "config_path": str(path), "message": f"{name} is not a Hermes GPT entry; no changes were made."}
+    updated, removed = _drop_server_entry(existing, name)
+    if not removed:
+        return {"ok": True, "changed": False, "config_path": str(path), "message": f"No {name} entry exists."}
+    backup = _backup(path)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(updated, encoding="utf-8", newline="\n")
+    try:
+        if updated.strip():
+            read_config(temporary)
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    return {"ok": True, "changed": True, "config_path": str(path), "backup": str(backup) if backup else None, "removed": name}
+
+
+def print_config(*, project: bool = False, cwd: Path | None = None, name: str = SERVER_NAME) -> dict[str, Any]:
+    path = config_path(project=project, cwd=cwd)
+    return redact_value({"ok": True, "config_path": str(path), "server_name": name, "entry": get_server_entry(path, name), "present": get_server_entry(path, name) is not None})
+
+
+def _readline_with_timeout(stream: Any, seconds: float = 8.0) -> str:
+    result: list[str] = []
+    worker = threading.Thread(target=lambda: result.append(stream.readline()), daemon=True)
+    worker.start()
+    worker.join(seconds)
+    if not result:
+        raise TimeoutError("No MCP stdio response arrived in time.")
+    return result[0]
+
+
+def _mcp_smoke(argv: list[str]) -> dict[str, Any]:
+    """Initialize a short-lived local stdio server and issue tools/list."""
+    proc = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=os.environ.copy(),
+    )
+
+    def send(payload: dict[str, Any]) -> None:
+        if proc.stdin is None:
+            raise RuntimeError("MCP stdin is unavailable.")
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+    try:
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "hermes-gpt-doctor", "version": "1"}}})
+        initialized = json.loads(_readline_with_timeout(proc.stdout))
+        if initialized.get("result", {}).get("serverInfo", {}).get("name") != "hermes-gpt":
+            return {"status": "FAIL", "detail": "The MCP launcher returned an unexpected server identity."}
+        send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+        send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        listed = json.loads(_readline_with_timeout(proc.stdout))
+        names = {item.get("name") for item in listed.get("result", {}).get("tools", [])}
+        expected = {"hermes_status", "hermes_capabilities", "hermes_plan", "hermes_gateway_diagnostics"}
+        return {"status": "PASS" if expected.issubset(names) else "FAIL", "tool_count": len(names), "missing": sorted(expected - names)}
+    except (OSError, ValueError, TimeoutError, subprocess.SubprocessError) as exc:
+        return {"status": "FAIL", "detail": op_policy.redact_output(str(exc))}
+    finally:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate(timeout=5)
+
+
+def doctor(*, project: bool = False, cwd: Path | None = None, list_tools: Callable[[], list[str]] | None = None, status: Callable[[], dict[str, Any]] | None = None) -> dict[str, Any]:
+    path = config_path(project=project, cwd=cwd)
+    codex = shutil.which("codex")
+    checks: dict[str, Any] = {
+        "codex_binary": {"status": "PASS" if codex else "WARN", "path": codex},
+        "codex_config": {"status": "PASS" if path.exists() else "WARN", "path": str(path)},
+        "hermes_gpt_entry": {"status": "PASS" if get_server_entry(path) else "WARN"},
+        "env_gates": {"status": "PASS" if os.environ.get(ENABLE_CODEX_ENV) == "1" and os.environ.get(ENABLE_MCP_ENV) == "1" else "WARN", "required": [ENABLE_CODEX_ENV, ENABLE_MCP_ENV]},
+    }
+    if codex:
+        try:
+            result = subprocess.run([codex, "--version"], text=True, capture_output=True, shell=False, timeout=10)
+            checks["codex_version"] = {"status": "PASS" if result.returncode == 0 else "WARN", "value": op_policy.redact_output(result.stdout.strip())}
+        except (OSError, subprocess.SubprocessError) as exc:
+            checks["codex_version"] = {"status": "WARN", "detail": op_policy.redact_output(str(exc))}
+    if list_tools:
+        try:
+            tools = list_tools()
+            expected = {"hermes_status", "hermes_capabilities", "hermes_plan", "hermes_gateway_diagnostics"}
+            checks["mcp_tool_registry"] = {"status": "PASS" if expected.issubset(set(tools)) else "FAIL", "tool_count": len(tools), "missing": sorted(expected - set(tools))}
+        except Exception:
+            checks["mcp_tool_registry"] = {"status": "FAIL", "detail": "Could not list the local MCP tool registry."}
+    checks["mcp_stdio_smoke"] = _mcp_smoke(launcher_argv())
+    redaction = op_policy.redact_output("token=secret-token-123456789")
+    checks["redaction_smoke"] = {"status": "PASS" if "secret-token" not in redaction else "FAIL"}
+    if status:
+        try:
+            snapshot = status()
+            checks["gateway"] = {"status": "PASS" if snapshot.get("ok") else "WARN", "gateway": snapshot.get("gateway")}
+        except Exception:
+            checks["gateway"] = {"status": "WARN", "detail": "Gateway status could not be checked."}
+    overall = "PASS" if all(item.get("status") == "PASS" for item in checks.values()) else "WARN"
+    return redact_value({"ok": overall == "PASS", "overall": overall, "checks": checks, "suggested_action": "Set the reported gates, run hermes-gpt codex install, then restart Codex." if overall != "PASS" else "Codex MCP integration is ready."})
+
+
+def main(argv: list[str], *, list_tools: Callable[[], list[str]] | None = None, status: Callable[[], dict[str, Any]] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="hermes-gpt codex", description="Install and diagnose the Hermes GPT Codex MCP connector.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("install", "uninstall", "doctor", "print-config"):
+        child = subparsers.add_parser(command)
+        child.add_argument("--project", action="store_true", help="Use .codex/config.toml in the current project.")
+        child.add_argument("--global", dest="project", action="store_false", help="Use ~/.codex/config.toml (default).")
+    subparsers.add_parser("mcp", help="Run the Codex-focused MCP stdio server.")
+    args = parser.parse_args(argv)
+    if args.command == "mcp":
+        raise RuntimeError("The mcp command is dispatched by server.py.")
+    operation = {"install": install, "uninstall": uninstall, "doctor": doctor, "print-config": print_config}[args.command]
+    kwargs: dict[str, Any] = {"project": args.project}
+    if operation is doctor:
+        kwargs.update({"list_tools": list_tools, "status": status})
+    print(json.dumps(operation(**kwargs), indent=2, default=str))

--- a/codex_core.py
+++ b/codex_core.py
@@ -1,0 +1,494 @@
+"""Transport-agnostic, Codex-focused Hermes GPT tool layer.
+
+The existing ``server`` module owns the mature Hermes Agent integrations.  This
+module deliberately owns only the Codex-specific contract: capability gates,
+safe local/URL inputs, compact repository context, and response sanitization.
+It accepts callbacks for Hermes operations so it can be tested without either
+an MCP transport or a local Hermes installation.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import mimetypes
+import os
+import re
+import socket
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+from urllib.parse import urlparse
+
+import operator_policy as op_policy
+
+
+ENABLE_CODEX_ENV = "HERMES_GPT_ENABLE_CODEX"
+ENABLE_MCP_ENV = "HERMES_GPT_ENABLE_MCP"
+ENABLE_VISION_ENV = "HERMES_GPT_ENABLE_VISION"
+ENABLE_WEB_ENV = "HERMES_GPT_ENABLE_WEB"
+ENABLE_CRON_ENV = "HERMES_GPT_ENABLE_CRON"
+ENABLE_DIAGNOSTICS_ENV = "HERMES_GPT_ENABLE_DIAGNOSTICS"
+ALLOW_WRITE_ENV = "HERMES_GPT_ALLOW_WRITE"
+ALLOW_CRON_WRITE_ENV = "HERMES_GPT_ALLOW_CRON_WRITE"
+ALLOW_SKILL_WRITE_ENV = "HERMES_GPT_ALLOW_SKILL_WRITE"
+ALLOWED_ROOTS_ENV = "HERMES_GPT_CODEX_ALLOWED_ROOTS"
+ALLOW_PRIVATE_NETWORK_ENV = "HERMES_GPT_ALLOW_PRIVATE_NETWORK"
+
+ALLOWED_IMAGE_SUFFIXES = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
+MAX_IMAGE_BYTES = 20 * 1024 * 1024
+MAX_EXTRACT_CHARS = 50_000
+MAX_PLAN_FILES = 200
+IGNORED_TREE_PARTS = {
+    ".git", ".venv", "venv", "node_modules", "__pycache__", ".pytest_cache",
+    ".mypy_cache", ".ruff_cache", "dist", "build", ".next",
+}
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name) == "1"
+
+
+def _error(code: str, message: str, suggested_action: str | None = None) -> dict[str, Any]:
+    result: dict[str, Any] = {"ok": False, "error": {"code": code, "message": _redact_text(message)}}
+    if suggested_action:
+        result["error"]["suggested_action"] = _redact_text(suggested_action)
+    return result
+
+
+def _redact_text(value: str) -> str:
+    text = op_policy.redact_output(str(value))
+    patterns = [
+        (r"(?i)\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b", "[REDACTED_GITHUB_TOKEN]"),
+        (r"(?i)\b(?:sk-ant|xai-|AIza)[A-Za-z0-9_-]{12,}\b", "[REDACTED_PROVIDER_KEY]"),
+        (r"(?i)(\b(?:cookie|session(?:_id)?|set-cookie)\s*[:=]\s*[\"']?)([^\s;\"']{8,})", r"\1[REDACTED]"),
+        (r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", "[REDACTED_PRIVATE_KEY]"),
+    ]
+    for pattern, replacement in patterns:
+        text = re.sub(pattern, replacement, text, flags=re.DOTALL)
+    return text
+
+
+def redact_value(value: Any) -> Any:
+    """Recursively redact all textual values before an MCP response leaves us."""
+    if isinstance(value, str):
+        return _redact_text(value)
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if re.search(r"(?i)(?:token|secret|password|passwd|api[_-]?key|cookie|session|authorization|private[_-]?key)", key_text):
+                result[key_text] = "[REDACTED]"
+            else:
+                result[key_text] = redact_value(item)
+        return result
+    if isinstance(value, (list, tuple, set)):
+        return [redact_value(item) for item in value]
+    return value
+
+
+def _decoded_json(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _parse_roots(raw: str | None) -> list[Path]:
+    if not raw:
+        return []
+    roots: list[Path] = []
+    for part in raw.split(os.pathsep):
+        if not part.strip():
+            continue
+        try:
+            candidate = Path(part).expanduser().resolve(strict=True)
+        except OSError:
+            continue
+        if candidate.is_dir() and not op_policy.is_denied_path(candidate):
+            roots.append(candidate)
+    return roots
+
+
+def _is_within(path: Path, roots: Iterable[Path]) -> bool:
+    for root in roots:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _image_mime(path: Path) -> str | None:
+    """Identify the allowed image formats from file signatures, not its name."""
+    try:
+        header = path.read_bytes()[:16]
+    except OSError:
+        return None
+    if header.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if header.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if header.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if header.startswith(b"BM"):
+        return "image/bmp"
+    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def resolve_project_root(project_root: str) -> Path:
+    if not project_root or not project_root.strip():
+        raise ValueError("project_root is required for local Codex operations.")
+    try:
+        root = Path(project_root).expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise ValueError("project_root must be an existing directory.") from exc
+    if not root.is_dir():
+        raise ValueError("project_root must be a directory.")
+    if op_policy.is_denied_path(root):
+        raise PermissionError("project_root is denied by the Hermes secret-path policy.")
+    return root
+
+
+def resolve_project_file(image_path: str, project_root: str | None) -> Path:
+    if not image_path or not image_path.strip():
+        raise ValueError("image_path is required.")
+    try:
+        image = Path(image_path).expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise ValueError("image_path must be an existing file.") from exc
+    if not image.is_file():
+        raise ValueError("image_path must be a file.")
+    if op_policy.is_denied_path(image):
+        raise PermissionError("image_path is denied by the Hermes secret-path policy.")
+
+    roots = [resolve_project_root(project_root)] if project_root else _parse_roots(os.environ.get(ALLOWED_ROOTS_ENV))
+    if not roots:
+        raise PermissionError(
+            "A project_root is required unless HERMES_GPT_CODEX_ALLOWED_ROOTS contains an approved root."
+        )
+    if not _is_within(image, roots):
+        raise PermissionError("image_path resolves outside the approved project root.")
+    if image.suffix.lower() not in ALLOWED_IMAGE_SUFFIXES:
+        raise ValueError("image_path must be a supported raster image (jpg, jpeg, png, gif, webp, or bmp).")
+    mime, _ = mimetypes.guess_type(str(image))
+    detected_mime = _image_mime(image)
+    if not mime or not detected_mime or mime != detected_mime:
+        raise ValueError("image_path extension and detected MIME type must be a supported matching image format.")
+    if image.stat().st_size > MAX_IMAGE_BYTES:
+        raise ValueError(f"image_path exceeds the {MAX_IMAGE_BYTES // (1024 * 1024)} MB safety limit.")
+    return image
+
+
+def validate_public_url(url: str) -> str:
+    """Reject local, private, metadata, credentialed, and non-HTTP URLs."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError("Only http and https URLs are allowed.")
+    if parsed.username or parsed.password:
+        raise ValueError("Credentialed URLs are not allowed.")
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("A hostname is required.")
+    host = hostname.rstrip(".").lower()
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+        raise PermissionError("Local network URLs are blocked.")
+
+    try:
+        addresses = {ipaddress.ip_address(host)}
+    except ValueError:
+        try:
+            addresses = {ipaddress.ip_address(item[4][0]) for item in socket.getaddrinfo(host, parsed.port or 443, type=socket.SOCK_STREAM)}
+        except socket.gaierror as exc:
+            raise ValueError("The URL hostname could not be resolved safely.") from exc
+
+    for address in addresses:
+        if not address.is_global:
+            if not _env_enabled(ALLOW_PRIVATE_NETWORK_ENV):
+                raise PermissionError("Private, loopback, link-local, and metadata network URLs are blocked.")
+    return url
+
+
+def _cron_expression(request: str) -> str | None:
+    normalized = " ".join(request.lower().split())
+    every_minutes = re.search(r"every\s+(\d{1,3})\s+minutes?", normalized)
+    if every_minutes:
+        minutes = int(every_minutes.group(1))
+        if 1 <= minutes <= 59:
+            return f"*/{minutes} * * * *"
+    match = re.search(r"(?:daily|every day)(?:\s+at)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?", normalized)
+    if match:
+        hour, minute, suffix = int(match.group(1)), int(match.group(2) or 0), match.group(3)
+        if suffix:
+            if not 1 <= hour <= 12:
+                return None
+            hour = (hour % 12) + (12 if suffix == "pm" else 0)
+        if 0 <= hour <= 23 and 0 <= minute <= 59:
+            return f"{minute} {hour} * * *"
+    weekdays = {"monday": 1, "tuesday": 2, "wednesday": 3, "thursday": 4, "friday": 5, "saturday": 6, "sunday": 0}
+    for name, dow in weekdays.items():
+        match = re.search(rf"(?:every\s+)?{name}(?:\s+at)?\s+(\d{{1,2}})(?::(\d{{2}}))?\s*(am|pm)?", normalized)
+        if match:
+            hour, minute, suffix = int(match.group(1)), int(match.group(2) or 0), match.group(3)
+            if suffix:
+                if not 1 <= hour <= 12:
+                    return None
+                hour = (hour % 12) + (12 if suffix == "pm" else 0)
+            if 0 <= hour <= 23 and 0 <= minute <= 59:
+                return f"{minute} {hour} * * {dow}"
+    return None
+
+
+@dataclass
+class CodexToolCore:
+    """A small, transport-independent facade over existing Hermes operations."""
+
+    version: str
+    imports_ready: Callable[[], bool]
+    gateway_snapshot: Callable[[], Any]
+    gateway_diagnostics_callback: Callable[[], Any]
+    vision_analyze: Callable[[str, str], Any]
+    web_search: Callable[[str, int], Any]
+    web_extract: Callable[[list[str], int], Any]
+    cron_create_callback: Callable[[str, str, bool], Any]
+    skill_create_callback: Callable[[str, str, bool], Any]
+
+    def _base_gate(self) -> dict[str, Any] | None:
+        missing = [name for name in (ENABLE_CODEX_ENV, ENABLE_MCP_ENV) if not _env_enabled(name)]
+        if missing:
+            return _error(
+                "CODEX_DISABLED",
+                "Codex MCP integration is disabled.",
+                "Set " + " and ".join(f"{name}=1" for name in missing) + " and restart the MCP server.",
+            )
+        return None
+
+    def _capability_gate(self, name: str, env_name: str) -> dict[str, Any] | None:
+        blocked = self._base_gate()
+        if blocked:
+            return blocked
+        if not _env_enabled(env_name):
+            return _error(
+                "CAPABILITY_DISABLED",
+                f"{name} is disabled.",
+                f"Set {env_name}=1 and restart the MCP server.",
+            )
+        return None
+
+    def status(self) -> dict[str, Any]:
+        blocked = self._base_gate()
+        if blocked:
+            return redact_value({**blocked, "version": self.version, "capabilities": self.capabilities()["capabilities"]})
+        try:
+            snapshot = _decoded_json(self.gateway_snapshot())
+            gateway = snapshot.get("gateway", {}) if isinstance(snapshot, dict) else {}
+            if isinstance(snapshot, dict) and not isinstance(gateway, dict):
+                gateway = {}
+            if isinstance(snapshot, dict) and not gateway:
+                gateway = {
+                    "running": snapshot.get("gateway_running", False),
+                    "pid": snapshot.get("gateway_pid"),
+                    "pid_source": snapshot.get("gateway_pid_source"),
+                    "state": snapshot.get("gateway_state"),
+                }
+            running = bool(gateway.get("running"))
+            return redact_value({
+                "ok": bool(self.imports_ready()),
+                "gateway": "running" if running else "not_running",
+                "agent": "reachable" if self.imports_ready() else "unavailable",
+                "version": self.version,
+                "capabilities": [name for name, item in self.capabilities()["capabilities"].items() if item["enabled"]],
+                "gateway_pid": gateway.get("pid"),
+                "gateway_pid_source": gateway.get("pid_source"),
+            })
+        except Exception as exc:
+            return _error("STATUS_UNAVAILABLE", "Hermes status could not be read.", _redact_text(str(exc)))
+
+    def capabilities(self) -> dict[str, Any]:
+        base_enabled = not bool(self._base_gate())
+        def state(env_name: str, reason: str) -> dict[str, Any]:
+            enabled = base_enabled and _env_enabled(env_name)
+            return {"enabled": enabled, **({} if enabled else {"reason": reason if base_enabled else "Codex MCP integration is disabled."})}
+        return redact_value({
+            "ok": True,
+            "capabilities": {
+                "status": {"enabled": base_enabled, **({} if base_enabled else {"reason": "Codex MCP integration is disabled."})},
+                "planning": {"enabled": base_enabled, **({} if base_enabled else {"reason": "Codex MCP integration is disabled."})},
+                "vision": state(ENABLE_VISION_ENV, f"Set {ENABLE_VISION_ENV}=1."),
+                "web_search": state(ENABLE_WEB_ENV, f"Set {ENABLE_WEB_ENV}=1."),
+                "web_extract": state(ENABLE_WEB_ENV, f"Set {ENABLE_WEB_ENV}=1."),
+                "cron": state(ENABLE_CRON_ENV, f"Set {ENABLE_CRON_ENV}=1."),
+                "diagnostics": state(ENABLE_DIAGNOSTICS_ENV, f"Set {ENABLE_DIAGNOSTICS_ENV}=1."),
+                "skill_authoring": {
+                    "enabled": base_enabled,
+                    "write_enabled": base_enabled and _env_enabled(ALLOW_WRITE_ENV) and _env_enabled(ALLOW_SKILL_WRITE_ENV),
+                    "reason": "Drafts are available in dry-run mode; direct writes need explicit write gates.",
+                },
+            },
+        })
+
+    def vision(self, image_path: str, prompt: str, project_root: str | None = None, detail: str = "medium") -> dict[str, Any]:
+        blocked = self._capability_gate("Vision analysis", ENABLE_VISION_ENV)
+        if blocked:
+            return blocked
+        if detail not in {"low", "medium", "high"}:
+            return _error("INVALID_DETAIL", "detail must be low, medium, or high.")
+        try:
+            image = resolve_project_file(image_path, project_root)
+            result = self.vision_analyze(str(image), f"Return {detail}-detail analysis. {prompt}".strip())
+            return redact_value({"ok": True, "image_path": str(image), "detail": detail, "analysis": _decoded_json(result)})
+        except (OSError, ValueError, PermissionError) as exc:
+            return _error("VISION_INPUT_BLOCKED", str(exc))
+        except Exception:
+            return _error("VISION_UNAVAILABLE", "Hermes vision analysis failed without exposing internal details.")
+
+    def search(self, query: str, max_results: int = 5) -> dict[str, Any]:
+        blocked = self._capability_gate("Web search", ENABLE_WEB_ENV)
+        if blocked:
+            return blocked
+        if not query or not query.strip():
+            return _error("INVALID_QUERY", "query is required.")
+        try:
+            limit = max(1, min(int(max_results), 10))
+            return redact_value({"ok": True, "query": query.strip(), "results": _decoded_json(self.web_search(query.strip(), limit))})
+        except Exception:
+            return _error("WEB_SEARCH_UNAVAILABLE", "Hermes web search failed without exposing internal details.")
+
+    def extract_page(self, url: str, max_chars: int = 12000) -> dict[str, Any]:
+        blocked = self._capability_gate("Web extraction", ENABLE_WEB_ENV)
+        if blocked:
+            return blocked
+        try:
+            safe_url = validate_public_url(url)
+            limit = max(500, min(int(max_chars), MAX_EXTRACT_CHARS))
+            return redact_value({"ok": True, "url": safe_url, "content": _decoded_json(self.web_extract([safe_url], limit))})
+        except (ValueError, PermissionError) as exc:
+            return _error("URL_BLOCKED", str(exc))
+        except Exception:
+            return _error("WEB_EXTRACT_UNAVAILABLE", "Hermes page extraction failed without exposing internal details.")
+
+    def plan(self, goal: str, project_root: str, include_git_diff: bool = False, include_tree: bool = True, max_files: int = 80) -> dict[str, Any]:
+        blocked = self._base_gate()
+        if blocked:
+            return blocked
+        if not goal or not goal.strip():
+            return _error("INVALID_GOAL", "goal is required.")
+        try:
+            root = resolve_project_root(project_root)
+            cap = max(1, min(int(max_files), MAX_PLAN_FILES))
+            files: list[str] = []
+            for item in root.rglob("*"):
+                if any(part in IGNORED_TREE_PARTS for part in item.parts):
+                    continue
+                if item.is_file() and not op_policy.is_denied_path(item):
+                    files.append(item.relative_to(root).as_posix())
+                    if len(files) >= cap:
+                        break
+            suggested = [name for name in files if Path(name).name.lower() in {"readme.md", "pyproject.toml", "package.json", "server.py", "main.py"}]
+            if not suggested:
+                suggested = files[: min(8, len(files))]
+            git: dict[str, Any] = {}
+            if (root / ".git").exists():
+                status = subprocess.run(["git", "status", "--short"], cwd=root, shell=False, text=True, capture_output=True, timeout=10)
+                git["status"] = _redact_text(status.stdout.strip())
+                if include_git_diff:
+                    diff = subprocess.run(["git", "diff", "--stat"], cwd=root, shell=False, text=True, capture_output=True, timeout=10)
+                    git["diff_stat"] = _redact_text(diff.stdout.strip())
+            return redact_value({
+                "ok": True,
+                "dry_run": True,
+                "goal": goal.strip(),
+                "project_root": str(root),
+                "suggested_files": suggested,
+                "repository_context": {"file_count_sampled": len(files), **({"tree": files} if include_tree else {}), **({"git": git} if git else {})},
+                "steps": [
+                    "Review the suggested files and existing tests before changing behavior.",
+                    "Implement the smallest change that satisfies the stated goal.",
+                    "Run focused tests first, then the full project test suite.",
+                    "Inspect the diff for secrets, unintended writes, and scope creep before committing.",
+                ],
+                "risks": ["This context pack is read-only and deterministic; it does not invoke an external planner.", "Ignored and secret-like paths are excluded from the repository sample."],
+            })
+        except (OSError, ValueError, PermissionError, subprocess.SubprocessError) as exc:
+            return _error("PLAN_INPUT_BLOCKED", str(exc))
+
+    def cron_plan(self, request: str, timezone: str | None = None, dry_run: bool = True) -> dict[str, Any]:
+        blocked = self._capability_gate("Cron planning", ENABLE_CRON_ENV)
+        if blocked:
+            return blocked
+        if not request or not request.strip():
+            return _error("INVALID_REQUEST", "request is required.")
+        schedule = _cron_expression(request)
+        result = {
+            "ok": True,
+            "dry_run": True,
+            "request": request.strip(),
+            "timezone": timezone or "local system timezone",
+            "proposed_schedule": schedule,
+            "command": "hermes-gpt codex mcp",
+            "required_env_vars": [ENABLE_CODEX_ENV, ENABLE_MCP_ENV, ENABLE_CRON_ENV],
+            "risks": ["Cron creation remains blocked until confirm=true and both cron write gates are enabled.", "Review timezone and schedule before creating a job."],
+        }
+        if not schedule:
+            result["needs_clarification"] = "Use an explicit schedule such as 'daily at 9am', 'Monday at 14:30', or 'every 15 minutes'."
+        return redact_value(result)
+
+    def cron_create(self, request: str, timezone: str | None = None, confirm: bool = False, dry_run: bool = True) -> dict[str, Any]:
+        plan = self.cron_plan(request=request, timezone=timezone, dry_run=True)
+        if not plan.get("ok"):
+            return plan
+        if not confirm:
+            return _error("CONFIRMATION_REQUIRED", "Cron creation requires confirm=true. Review hermes_cron_plan first.")
+        if not _env_enabled(ALLOW_WRITE_ENV) or not _env_enabled(ALLOW_CRON_WRITE_ENV):
+            return _error("CRON_WRITE_DISABLED", "Cron creation is write-gated.", f"Set {ALLOW_WRITE_ENV}=1 and {ALLOW_CRON_WRITE_ENV}=1; existing operator direct-mode gates also apply.")
+        schedule = plan.get("proposed_schedule")
+        if not schedule:
+            return _error("SCHEDULE_UNRESOLVED", "The request could not be converted to a safe cron schedule.")
+        try:
+            result = self.cron_create_callback(str(schedule), request.strip(), bool(dry_run))
+            return redact_value({"ok": True, "result": _decoded_json(result)})
+        except Exception:
+            return _error("CRON_CREATE_UNAVAILABLE", "Cron creation failed without exposing internal details.")
+
+    def author_skill(self, skill_name: str, goal: str, project_root: str | None = None, dry_run: bool = True) -> dict[str, Any]:
+        blocked = self._base_gate()
+        if blocked:
+            return blocked
+        name = (skill_name or "").strip().lower()
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,62}", name):
+            return _error("INVALID_SKILL_NAME", "skill_name must be lowercase letters, numbers, and hyphens.")
+        if not goal or not goal.strip():
+            return _error("INVALID_GOAL", "goal is required.")
+        if project_root:
+            try:
+                resolve_project_root(project_root)
+            except (ValueError, PermissionError) as exc:
+                return _error("SKILL_INPUT_BLOCKED", str(exc))
+        draft = f"---\nname: {name}\ndescription: {goal.strip()[:180]}\n---\n\n# {name}\n\n{goal.strip()}\n"
+        if dry_run:
+            return redact_value({"ok": True, "dry_run": True, "skill_name": name, "diff_preview": draft, "write_blocked_by_default": True})
+        if not _env_enabled(ALLOW_WRITE_ENV) or not _env_enabled(ALLOW_SKILL_WRITE_ENV):
+            return _error("SKILL_WRITE_DISABLED", "Skill writing is write-gated.", f"Set {ALLOW_WRITE_ENV}=1 and {ALLOW_SKILL_WRITE_ENV}=1; existing operator direct-mode gates also apply.")
+        try:
+            result = self.skill_create_callback(name, draft, False)
+            return redact_value({"ok": True, "dry_run": False, "result": _decoded_json(result)})
+        except Exception:
+            return _error("SKILL_WRITE_UNAVAILABLE", "Skill creation failed without exposing internal details.")
+
+    def gateway_diagnostics(self, verbose: bool = False) -> dict[str, Any]:
+        blocked = self._capability_gate("Gateway diagnostics", ENABLE_DIAGNOSTICS_ENV)
+        if blocked:
+            return blocked
+        try:
+            data = _decoded_json(self.gateway_diagnostics_callback())
+            if isinstance(data, dict) and not verbose:
+                data = {key: data.get(key) for key in ("success", "profile", "checks", "failed_checks", "warnings", "recommended_action", "trace_id") if key in data}
+            return redact_value({"ok": True, "diagnostics": data})
+        except Exception:
+            return _error("DIAGNOSTICS_UNAVAILABLE", "Gateway diagnostics failed without exposing internal details.")

--- a/codex_mcp.py
+++ b/codex_mcp.py
@@ -1,0 +1,73 @@
+"""MCP stdio surface for the safe Codex-focused Hermes GPT tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from codex_core import CodexToolCore
+
+
+NOAUTH_META = {"securitySchemes": [{"type": "noauth"}]}
+
+
+def build_codex_server(core: CodexToolCore, *, host: str = "127.0.0.1", port: int = 7677, http: bool = False) -> FastMCP:
+    server = FastMCP(
+        "hermes-gpt",
+        host=host,
+        port=port,
+        streamable_http_path="/mcp",
+        sse_path="/sse",
+        message_path="/messages/",
+        stateless_http=http,
+        json_response=http,
+    )
+
+    def hermes_status() -> dict[str, Any]:
+        """Check the local Hermes GPT and Hermes Agent gateway state."""
+        return core.status()
+
+    def hermes_capabilities() -> dict[str, Any]:
+        """Return enabled Codex capabilities and the gates required for disabled ones."""
+        return core.capabilities()
+
+    def hermes_vision_analyze(image_path: str, prompt: str, project_root: str | None = None, detail: str = "medium") -> dict[str, Any]:
+        """Analyze an approved local raster image through Hermes Agent vision."""
+        return core.vision(image_path, prompt, project_root, detail)
+
+    def hermes_web_search(query: str, max_results: int = 5) -> dict[str, Any]:
+        """Search the web with the configured Hermes provider. No pages are fetched here."""
+        return core.search(query, max_results)
+
+    def hermes_extract_page(url: str, max_chars: int = 12000) -> dict[str, Any]:
+        """Extract readable public web content after local/private-network safety checks."""
+        return core.extract_page(url, max_chars)
+
+    def hermes_plan(goal: str, project_root: str, include_git_diff: bool = False, include_tree: bool = True, max_files: int = 80) -> dict[str, Any]:
+        """Create a compact, read-only repository context pack and implementation plan."""
+        return core.plan(goal, project_root, include_git_diff, include_tree, max_files)
+
+    def hermes_author_skill(skill_name: str, goal: str, project_root: str | None = None, dry_run: bool = True) -> dict[str, Any]:
+        """Draft a Hermes skill; writes stay dry-run unless every write gate is enabled."""
+        return core.author_skill(skill_name, goal, project_root, dry_run)
+
+    def hermes_cron_plan(request: str, timezone: str | None = None, dry_run: bool = True) -> dict[str, Any]:
+        """Convert a simple natural-language schedule request into a dry-run cron plan."""
+        return core.cron_plan(request, timezone, dry_run)
+
+    def hermes_cron_create(request: str, timezone: str | None = None, confirm: bool = False, dry_run: bool = True) -> dict[str, Any]:
+        """Create a cron job only after explicit confirmation and strict write gates."""
+        return core.cron_create(request, timezone, confirm, dry_run)
+
+    def hermes_gateway_diagnostics(verbose: bool = False) -> dict[str, Any]:
+        """Run read-only Hermes gateway diagnostics, including PID-state checks."""
+        return core.gateway_diagnostics(verbose)
+
+    for tool in (
+        hermes_status, hermes_capabilities, hermes_vision_analyze, hermes_web_search,
+        hermes_extract_page, hermes_plan, hermes_author_skill, hermes_cron_plan,
+        hermes_cron_create, hermes_gateway_diagnostics,
+    ):
+        server.add_tool(tool, meta=NOAUTH_META)
+    return server

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,0 +1,85 @@
+# Hermes GPT for Codex
+
+Hermes GPT can expose selected local Hermes Agent capabilities to the Codex app, Codex CLI, and Codex IDE integration through a local MCP server. It is a local bridge; it does not patch Codex, store OpenAI credentials, bypass approvals, or enable writes by default.
+
+## Install
+
+Set the base gates in the environment that will launch Codex, then install the MCP entry:
+
+```powershell
+$env:HERMES_GPT_ENABLE_CODEX="1"
+$env:HERMES_GPT_ENABLE_MCP="1"
+hermes-gpt codex install
+hermes-gpt codex doctor
+```
+
+`install` uses `codex mcp add hermes-gpt -- ...` when the Codex CLI is available. If it must edit TOML directly, it first validates the config, creates a timestamped backup, preserves unrelated configuration, and adds only `[mcp_servers."hermes-gpt"]` plus its environment table. It is idempotent.
+
+For a repository-local entry, run the command from inside that repository:
+
+```powershell
+hermes-gpt codex install --project
+```
+
+This creates or updates `<git-root>/.codex/config.toml`; Codex CLI currently has no project-scope switch for `mcp add`.
+
+## Verify and remove
+
+```powershell
+hermes-gpt codex print-config
+hermes-gpt codex doctor
+hermes-gpt codex uninstall
+```
+
+`doctor` is read-only. It checks the Codex binary/version, target config, MCP registry, base gates, gateway status, and redaction smoke path. `uninstall` removes only the Hermes GPT MCP tables and makes a backup first.
+
+## Available Codex tools
+
+| Tool | Behavior |
+| --- | --- |
+| `hermes_status` | Local Hermes GPT/gateway status, including state-file PID fallback. |
+| `hermes_capabilities` | Enabled features and the gate required for disabled ones. |
+| `hermes_plan` | Compact, read-only repository context and implementation plan. |
+| `hermes_vision_analyze` | Approved local raster image analysis. |
+| `hermes_web_search` | Search only; no pages are fetched. |
+| `hermes_extract_page` | Public HTTP(S) content extraction. |
+| `hermes_cron_plan` | Dry-run cron proposal from a simple schedule request. |
+| `hermes_cron_create` | Explicitly confirmed, tightly gated creation. |
+| `hermes_author_skill` | Skill draft by default; write requires explicit gates. |
+| `hermes_gateway_diagnostics` | Read-only gateway and PID diagnostics. |
+
+## Safety model
+
+The server launches even when gates are absent, so Codex can list the tool schemas and receive an actionable blocked response. The base gates are:
+
+```text
+HERMES_GPT_ENABLE_CODEX=1
+HERMES_GPT_ENABLE_MCP=1
+```
+
+Individual feature gates are `HERMES_GPT_ENABLE_VISION=1`, `HERMES_GPT_ENABLE_WEB=1`, `HERMES_GPT_ENABLE_CRON=1`, and `HERMES_GPT_ENABLE_DIAGNOSTICS=1`.
+
+Every persistent action is dry-run by default. Direct skill or cron writes require the base/feature gates plus `HERMES_GPT_ALLOW_WRITE=1` and the relevant `HERMES_GPT_ALLOW_SKILL_WRITE=1` or `HERMES_GPT_ALLOW_CRON_WRITE=1`; existing Hermes Operator Mode policy and direct-apply gates remain in force too.
+
+Local image paths resolve symlinks, must remain under an explicit `project_root` (or `HERMES_GPT_CODEX_ALLOWED_ROOTS`), and reject secret paths and unsupported types. Web extraction accepts only public HTTP(S) URLs; it blocks file URLs, localhost, private/loopback/link-local/reserved IPs, and metadata targets unless the explicit private-network override is set. Returned text is redacted for common API keys, provider/GitHub tokens, bearer/cookie/session values, and private keys.
+
+## Example Codex prompts
+
+```text
+Use hermes_plan to inspect this repository and produce a dry-run build plan. Do not edit files.
+```
+
+```text
+Use hermes_cron_plan to turn “every Monday at 9am summarize project alerts” into a safe proposal. Do not create it.
+```
+
+```text
+Use hermes_vision_analyze with this project image and keep the answer concise.
+```
+
+## Troubleshooting
+
+- If every tool says `CODEX_DISABLED`, set both base gates in the process that starts Codex and restart Codex.
+- If `doctor` reports no MCP entry, rerun `hermes-gpt codex install`; use `--project` when you intend the current repository only.
+- If vision rejects a path, provide `project_root` and keep the image beneath it; secret files and symlink escapes are intentionally blocked.
+- If page extraction rejects a URL, use a public `http` or `https` URL. Local/private address access is intentionally not the default.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-gpt"
-version = "0.4.0"
+version = "0.5.0b1"
 description = "Local-dev MCP sidecar for exposing selected Hermes Agent capabilities."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -35,6 +35,9 @@ py-modules = [
   "operator_config",
   "operator_workspace",
   "operator_diagnostics",
+  "codex_core",
+  "codex_mcp",
+  "codex_config",
 ]
 
 [tool.setuptools.data-files]
@@ -47,6 +50,7 @@ py-modules = [
   "docs/operator-mode.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",
+  "docs/codex.md",
 ]
 "share/hermes-gpt/examples" = [
   "examples/start-hermes-gpt.example.ps1",

--- a/server.py
+++ b/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib.metadata
 import inspect
 import json
@@ -27,6 +28,7 @@ ENABLE_SESSION_SEARCH_ENV = "HERMES_GPT_ENABLE_SESSION_SEARCH"
 ENABLE_TERMINAL_ENV = "HERMES_GPT_ENABLE_TERMINAL"
 ENABLE_VISION_ENV = "HERMES_GPT_ENABLE_VISION"
 ENABLE_WEB_ENV = "HERMES_GPT_ENABLE_WEB"
+CODEX_BATCH_VERSION = "0.5.0b1"
 NOAUTH_META = {"securitySchemes": [{"type": "noauth"}]}
 
 HERMES_ROOT: Path | None = None
@@ -1116,10 +1118,75 @@ def register_tools(server: FastMCP) -> None:
     server.add_tool(hermes_owner_write_file, meta=tool_meta())
 
 
+def _codex_gateway_diagnostics() -> dict[str, Any]:
+    """Combine the general doctor with the state-file-aware gateway status."""
+    def decoded(value: Any) -> Any:
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+        return value
+
+    return {
+        "operator_doctor": decoded(hermes_operator_doctor()),
+        # operator_workspace has the gateway_state.json fallback required for
+        # macOS installs when gateway.pid is stale or absent.
+        "gateway_status": decoded(hermes_gateway_status()),
+    }
+
+
+def build_codex_mcp_server(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 7677,
+    http: bool = False,
+) -> FastMCP:
+    """Build the deliberately compact Codex-facing MCP registry.
+
+    The existing ``build_server`` remains the backwards-compatible legacy
+    surface.  Codex gets only the high-leverage tools defined in codex_mcp.
+    """
+    from codex_core import CodexToolCore
+    from codex_mcp import build_codex_server
+
+    def imports_ready() -> bool:
+        return IMPORT_ERROR is None and HERMES_ROOT is not None
+
+    core = CodexToolCore(
+        version=CODEX_BATCH_VERSION,
+        imports_ready=imports_ready,
+        gateway_snapshot=lambda: hermes_gateway_status(),
+        gateway_diagnostics_callback=_codex_gateway_diagnostics,
+        vision_analyze=lambda image_path, prompt: hermes_vision_analyze(image_url=image_path, question=prompt),
+        web_search=lambda query, limit: hermes_web_search(query=query, limit=limit),
+        web_extract=lambda urls, limit: hermes_web_extract(urls=urls, char_limit=limit),
+        cron_create_callback=lambda schedule, prompt, dry_run: hermes_cron_create(schedule=schedule, prompt=prompt, dry_run=dry_run),
+        skill_create_callback=lambda name, content, dry_run: hermes_skill_create(name=name, content=content, dry_run=dry_run),
+    )
+    return build_codex_server(core, host=host, port=port, http=http)
+
+
 mcp = build_server()
 
 
-def main() -> None:
+def _run_codex_mcp(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(prog="hermes-gpt mcp", description="Run the Hermes GPT Codex MCP server.")
+    parser.add_argument("--http", action="store_true", help="Run streamable HTTP instead of stdio.")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7677)
+    args = parser.parse_args(argv)
+    server = build_codex_mcp_server(host=args.host, port=args.port, http=args.http)
+    if not args.http:
+        eprint("hermes-gpt Codex MCP server starting in stdio mode.")
+        server.run(transport="stdio")
+        return
+    eprint(f"hermes-gpt Codex MCP server running at http://{args.host}:{args.port}/mcp")
+    import uvicorn
+    uvicorn.run(server.streamable_http_app(), host=args.host, port=args.port, proxy_headers=True, forwarded_allow_ips="*")
+
+
+def _run_legacy_server(argv: list[str]) -> None:
     parser = argparse.ArgumentParser(description="Hermes Agent MCP sidecar.")
     parser.add_argument("--http", action="store_true", help="Run streamable HTTP transport instead of stdio.")
     parser.add_argument("--sse", action="store_true", help="Run legacy SSE transport instead of stdio.")
@@ -1139,7 +1206,7 @@ def main() -> None:
         dest="unsafe_remote_ack",
         help="Allow remote profile without auth. For experiments only; not release-safe.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     if args.http and args.sse:
         raise SystemExit("Choose only one of --http or --sse.")
@@ -1179,6 +1246,37 @@ def main() -> None:
             proxy_headers=True,
             forwarded_allow_ips="*",
         )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run legacy MCP, the Codex MCP alias, or the Codex installer helpers."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == "mcp":
+        _run_codex_mcp(args[1:])
+        return
+    if args and args[0] == "codex":
+        if len(args) > 1 and args[1] == "mcp":
+            _run_codex_mcp(args[2:])
+            return
+        import codex_config
+
+        def list_tools() -> list[str]:
+            return [tool.name for tool in asyncio.run(build_codex_mcp_server().list_tools())]
+
+        def status() -> dict[str, Any]:
+            try:
+                data = json.loads(hermes_gateway_status())
+                return {
+                    "ok": bool(data.get("success")),
+                    "gateway": "running" if data.get("gateway_running") else "not_running",
+                    "gateway_pid_source": data.get("gateway_pid_source"),
+                }
+            except Exception:
+                return {"ok": False, "gateway": "unknown"}
+
+        codex_config.main(args[1:], list_tools=list_tools, status=status)
+        return
+    _run_legacy_server(args)
 
 
 if __name__ == "__main__":

--- a/test_codex_config.py
+++ b/test_codex_config.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import codex_config
+
+
+def test_direct_project_install_is_idempotent_and_preserves_other_servers(tmp_path):
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    config = config_dir / "config.toml"
+    config.write_text(
+        "# existing user comment\n[mcp_servers.other]\ncommand = \"other.exe\"\nargs = []\n",
+        encoding="utf-8",
+    )
+    first = codex_config.install(project=True, cwd=tmp_path, server_path=tmp_path / "server.py", prefer_cli=False)
+    assert first["ok"] is True
+    assert first["changed"] is True
+    assert first["backup"]
+    text = config.read_text(encoding="utf-8")
+    assert "# existing user comment" in text
+    assert "[mcp_servers.other]" in text
+    assert codex_config.get_server_entry(config)["args"][-1] == "mcp"
+
+    second = codex_config.install(project=True, cwd=tmp_path, server_path=tmp_path / "server.py", prefer_cli=False)
+    assert second["ok"] is True
+    assert second["changed"] is False
+
+    removed = codex_config.uninstall(project=True, cwd=tmp_path)
+    assert removed["ok"] is True
+    assert removed["changed"] is True
+    after = config.read_text(encoding="utf-8")
+    assert "[mcp_servers.other]" in after
+    assert "hermes-gpt" not in after
+
+
+def test_install_refuses_conflicting_server_name(tmp_path):
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    config.write_text("[mcp_servers.\"hermes-gpt\"]\ncommand = \"not-hermes.exe\"\nargs = [\"x\"]\n", encoding="utf-8")
+    result = codex_config.install(project=True, cwd=tmp_path, prefer_cli=False)
+    assert result["ok"] is False
+    assert result["code"] == "NAME_CONFLICT"
+    assert "not-hermes.exe" in config.read_text(encoding="utf-8")
+
+
+def test_malformed_config_is_never_changed(tmp_path):
+    config = tmp_path / ".codex" / "config.toml"
+    config.parent.mkdir()
+    original = "[mcp_servers\nthis is invalid"
+    config.write_text(original, encoding="utf-8")
+    result = codex_config.install(project=True, cwd=tmp_path, prefer_cli=False)
+    assert result["ok"] is False
+    assert result["code"] == "MALFORMED_CONFIG"
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_doctor_reports_registry_and_redaction_checks(tmp_path):
+    result = codex_config.doctor(
+        project=True,
+        cwd=tmp_path,
+        list_tools=lambda: ["hermes_status", "hermes_capabilities", "hermes_plan", "hermes_gateway_diagnostics"],
+        status=lambda: {"ok": True, "gateway": "running"},
+    )
+    assert result["checks"]["mcp_tool_registry"]["status"] == "PASS"
+    assert result["checks"]["redaction_smoke"]["status"] == "PASS"
+    assert result["checks"]["gateway"]["status"] == "PASS"

--- a/test_codex_core.py
+++ b/test_codex_core.py
@@ -1,0 +1,185 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import codex_core as core_module
+
+
+ALL_GATES = [
+    core_module.ENABLE_CODEX_ENV, core_module.ENABLE_MCP_ENV,
+    core_module.ENABLE_VISION_ENV, core_module.ENABLE_WEB_ENV,
+    core_module.ENABLE_CRON_ENV, core_module.ENABLE_DIAGNOSTICS_ENV,
+    core_module.ALLOW_WRITE_ENV, core_module.ALLOW_CRON_WRITE_ENV,
+    core_module.ALLOW_SKILL_WRITE_ENV, core_module.ALLOWED_ROOTS_ENV,
+    core_module.ALLOW_PRIVATE_NETWORK_ENV,
+]
+
+
+@pytest.fixture
+def tool_core(monkeypatch):
+    for name in ALL_GATES:
+        monkeypatch.delenv(name, raising=False)
+    calls = {}
+
+    def remember(name, value):
+        calls[name] = value
+        return value
+
+    tool = core_module.CodexToolCore(
+        version="0.5.0b1",
+        imports_ready=lambda: True,
+        gateway_snapshot=lambda: {"gateway": {"running": True, "pid": 42}},
+        gateway_diagnostics_callback=lambda: {"success": True, "warnings": []},
+        vision_analyze=lambda path, prompt: remember("vision", {"path": path, "prompt": prompt, "api_key": "not-a-real-secret-but-long-enough"}),
+        web_search=lambda query, limit: remember("search", {"title": "Result", "url": "https://example.com", "snippet": f"token=very-secret-token-123456789 for {query}"}),
+        web_extract=lambda urls, limit: remember("extract", {"url": urls[0], "content": "Authorization: Bearer abcdefghi.jklmnopqr.stuvwx"}),
+        cron_create_callback=lambda schedule, prompt, dry_run: remember("cron", {"schedule": schedule, "prompt": prompt, "dry_run": dry_run}),
+        skill_create_callback=lambda name, content, dry_run: remember("skill", {"name": name, "content": content, "dry_run": dry_run}),
+    )
+    return tool, calls
+
+
+def enable_base(monkeypatch):
+    monkeypatch.setenv(core_module.ENABLE_CODEX_ENV, "1")
+    monkeypatch.setenv(core_module.ENABLE_MCP_ENV, "1")
+
+
+def test_missing_base_gates_report_a_clean_block(tool_core):
+    tool, _ = tool_core
+    result = tool.plan("inspect repository", str(Path.cwd()))
+    assert result["ok"] is False
+    assert result["error"]["code"] == "CODEX_DISABLED"
+    assert "HERMES_GPT_ENABLE_CODEX=1" in result["error"]["suggested_action"]
+
+
+def test_capabilities_list_disabled_reasons_without_leaking_environment(tool_core):
+    tool, _ = tool_core
+    result = tool.capabilities()
+    assert result["ok"] is True
+    assert result["capabilities"]["vision"]["enabled"] is False
+    assert "reason" in result["capabilities"]["vision"]
+
+
+def test_vision_validates_roots_and_symlink_escape(tmp_path, monkeypatch, tool_core):
+    tool, calls = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_VISION_ENV, "1")
+    root = tmp_path / "project"
+    root.mkdir()
+    image = root / "sample.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"image payload")
+
+    allowed = tool.vision(str(image), "describe it", str(root))
+    assert allowed["ok"] is True
+    assert calls["vision"]["path"] == str(image.resolve())
+    assert "not-a-real-secret" not in str(allowed)
+
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(b"\x89PNG\r\n\x1a\n" + b"image payload")
+    blocked = tool.vision(str(outside), "describe it", str(root))
+    assert blocked["error"]["code"] == "VISION_INPUT_BLOCKED"
+    assert "outside the approved project root" in blocked["error"]["message"]
+
+
+def test_vision_denies_secret_paths_before_extension_checks(tmp_path, monkeypatch, tool_core):
+    tool, _ = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_VISION_ENV, "1")
+    secret = tmp_path / ".env"
+    secret.write_text("OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz_1234567890")
+    result = tool.vision(str(secret), "read", str(tmp_path))
+    assert result["ok"] is False
+    assert result["error"]["code"] == "VISION_INPUT_BLOCKED"
+    assert "OPENAI_API_KEY" not in str(result)
+
+
+def test_vision_rejects_a_mismatched_extension_and_file_signature(tmp_path, monkeypatch, tool_core):
+    tool, _ = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_VISION_ENV, "1")
+    image = tmp_path / "not-really-jpeg.jpg"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"image payload")
+    result = tool.vision(str(image), "describe it", str(tmp_path))
+    assert result["ok"] is False
+    assert result["error"]["code"] == "VISION_INPUT_BLOCKED"
+    assert "detected MIME type" in result["error"]["message"]
+
+
+@pytest.mark.parametrize("url", [
+    "file:///etc/passwd",
+    "http://localhost:8080/",
+    "http://127.0.0.1/",
+    "http://10.0.0.8/",
+    "http://169.254.169.254/latest/meta-data/",
+])
+def test_extract_rejects_nonpublic_urls(url, monkeypatch, tool_core):
+    tool, calls = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_WEB_ENV, "1")
+    result = tool.extract_page(url)
+    assert result["ok"] is False
+    assert result["error"]["code"] == "URL_BLOCKED"
+    assert "extract" not in calls
+
+
+def test_web_responses_are_recursively_redacted(monkeypatch, tool_core):
+    tool, _ = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_WEB_ENV, "1")
+    result = tool.search("test")
+    assert result["ok"] is True
+    assert "very-secret-token" not in str(result)
+    assert "[REDACTED]" in str(result)
+
+
+def test_plan_is_read_only_and_excludes_secret_files(tmp_path, monkeypatch, tool_core):
+    tool, _ = tool_core
+    enable_base(monkeypatch)
+    (tmp_path / "README.md").write_text("hello")
+    (tmp_path / ".env").write_text("secret")
+    result = tool.plan("document repository", str(tmp_path), include_tree=True)
+    assert result["ok"] is True
+    assert result["dry_run"] is True
+    assert "README.md" in result["repository_context"]["tree"]
+    assert ".env" not in result["repository_context"]["tree"]
+
+
+def test_cron_write_requires_confirmation_and_all_gates(monkeypatch, tool_core):
+    tool, calls = tool_core
+    enable_base(monkeypatch)
+    monkeypatch.setenv(core_module.ENABLE_CRON_ENV, "1")
+    request = "daily at 9am summarize the logs"
+    assert tool.cron_plan(request)["proposed_schedule"] == "0 9 * * *"
+    assert tool.cron_create(request, confirm=False)["error"]["code"] == "CONFIRMATION_REQUIRED"
+    assert tool.cron_create(request, confirm=True)["error"]["code"] == "CRON_WRITE_DISABLED"
+    monkeypatch.setenv(core_module.ALLOW_WRITE_ENV, "1")
+    monkeypatch.setenv(core_module.ALLOW_CRON_WRITE_ENV, "1")
+    created = tool.cron_create(request, confirm=True, dry_run=True)
+    assert created["ok"] is True
+    assert calls["cron"]["dry_run"] is True
+
+
+def test_skill_authoring_is_a_draft_by_default_and_write_gated(monkeypatch, tool_core):
+    tool, calls = tool_core
+    enable_base(monkeypatch)
+    draft = tool.author_skill("release-helper", "Draft reliable release steps")
+    assert draft["ok"] is True
+    assert draft["dry_run"] is True
+    assert "skill" not in calls
+    blocked = tool.author_skill("release-helper", "Draft reliable release steps", dry_run=False)
+    assert blocked["error"]["code"] == "SKILL_WRITE_DISABLED"
+    monkeypatch.setenv(core_module.ALLOW_WRITE_ENV, "1")
+    monkeypatch.setenv(core_module.ALLOW_SKILL_WRITE_ENV, "1")
+    applied = tool.author_skill("release-helper", "Draft reliable release steps", dry_run=False)
+    assert applied["ok"] is True
+    assert calls["skill"]["dry_run"] is False
+
+
+def test_redaction_covers_provider_github_cookie_and_private_key_text():
+    text = "github_pat_abcdefghijklmnopqrstuvwxyz123456 Cookie: session-abcdefghijklm xai-abcdefghijklmnopqrst\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----"
+    result = core_module.redact_value({"nested": [text]})
+    rendered = str(result)
+    assert "github_pat_" not in rendered
+    assert "session-abcdefgh" not in rendered
+    assert "BEGIN PRIVATE KEY" not in rendered

--- a/test_codex_mcp.py
+++ b/test_codex_mcp.py
@@ -1,0 +1,87 @@
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import codex_core
+import codex_mcp
+
+
+def test_codex_mcp_registry_is_curated_and_complete():
+    core = codex_core.CodexToolCore(
+        version="test",
+        imports_ready=lambda: True,
+        gateway_snapshot=lambda: {"gateway": {"running": False}},
+        gateway_diagnostics_callback=lambda: {},
+        vision_analyze=lambda path, prompt: {},
+        web_search=lambda query, limit: {},
+        web_extract=lambda urls, limit: {},
+        cron_create_callback=lambda schedule, prompt, dry_run: {},
+        skill_create_callback=lambda name, content, dry_run: {},
+    )
+    server = codex_mcp.build_codex_server(core)
+    names = {tool.name for tool in asyncio.run(server.list_tools())}
+    assert names == {
+        "hermes_status", "hermes_capabilities", "hermes_vision_analyze",
+        "hermes_web_search", "hermes_extract_page", "hermes_plan",
+        "hermes_author_skill", "hermes_cron_plan", "hermes_cron_create",
+        "hermes_gateway_diagnostics",
+    }
+    for tool in asyncio.run(server.list_tools()):
+        assert tool.meta == {"securitySchemes": [{"type": "noauth"}]}
+
+
+def _readline_with_timeout(stream, seconds: float = 8.0) -> str:
+    result: list[str] = []
+    worker = threading.Thread(target=lambda: result.append(stream.readline()), daemon=True)
+    worker.start()
+    worker.join(seconds)
+    if not result:
+        raise TimeoutError("No MCP stdio response arrived in time.")
+    return result[0]
+
+
+def test_codex_stdio_initialize_list_and_safe_tool_call():
+    root = Path(__file__).resolve().parent
+    proc = subprocess.Popen(
+        [sys.executable, "server.py", "mcp"],
+        cwd=root,
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env={**os.environ, "HERMES_GPT_ENABLE_CODEX": "1", "HERMES_GPT_ENABLE_MCP": "1"},
+    )
+
+    def send(payload):
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(payload) + "\n")
+        proc.stdin.flush()
+
+    try:
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "pytest", "version": "1"}}})
+        initialized = json.loads(_readline_with_timeout(proc.stdout))
+        assert initialized["result"]["serverInfo"]["name"] == "hermes-gpt"
+        send({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+        send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        listed = json.loads(_readline_with_timeout(proc.stdout))
+        names = {tool["name"] for tool in listed["result"]["tools"]}
+        assert {"hermes_status", "hermes_capabilities", "hermes_plan"}.issubset(names)
+        send({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {"name": "hermes_capabilities", "arguments": {}}})
+        called = json.loads(_readline_with_timeout(proc.stdout))
+        assert called["result"]["isError"] is False
+        assert called["result"]["structuredContent"]["ok"] is True
+        send({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {"name": "hermes_status", "arguments": {}}})
+        status = json.loads(_readline_with_timeout(proc.stdout))
+        assert status["result"]["isError"] is False
+        assert "gateway" in status["result"]["structuredContent"]
+    finally:
+        proc.terminate()
+        try:
+            proc.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate(timeout=5)


### PR DESCRIPTION
## Summary

Adds the first v0.5.0 Codex integration batch for Hermes GPT.

- Adds a curated `hermes-gpt mcp` tool surface and `hermes-gpt codex mcp` alias.
- Adds safe Codex install, uninstall, doctor, and print-config commands.
- Adds strict capability/write gates, response redaction, local image-path safety, and public-URL SSRF protections.
- Documents setup, verification, safety defaults, and example Codex prompts.

## Validation

- `python -m pytest -q`
- `python -m build --sdist --wheel`
- MCP stdio initialize, `tools/list`, and safe tool-call smoke tests

## Notes

This is the first v0.5.0 batch (`0.5.0b1`), not a full release.