### PR TITLE
Add a safe Hermes GPT update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.0b2 - Unreleased
+
+- Added `hermes-gpt update`: check-first, safe fast-forward updates for clean Git checkouts and explicit pip upgrades for installed packages.
+- Added update documentation and aligned the README, Codex guide, release notes, package data, and release checklist.
+
 ## 0.5.0b1 - 2026-07-09
 
 - Added the first Codex integration batch: a curated MCP stdio server at `hermes-gpt mcp` (also available as `hermes-gpt codex mcp`).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Or clone from [GitHub](https://github.com/asimons81/hermes-gpt).
 
 This is a **local-dev release**.
 
+## v0.5.0 beta updates
+
+The v0.5.0 beta adds a curated Codex MCP connector and a safe, check-first updater. See [Codex setup](docs/codex.md), [updating](docs/updating.md), and the existing [Operator Mode guide](docs/operator-mode.md) for the focused workflows.
+
+### Updating Hermes GPT
+
+```powershell
+hermes-gpt update
+hermes-gpt update --apply
+```
+
+The first command only checks. `--apply` fast-forwards a clean checkout on its default branch, or upgrades an installed PyPI package. It never creates merge commits, rebases, downgrades packages, or overwrites tracked local changes.
+
 ## Codex App / Codex CLI Support
 
 The first v0.5.0 batch adds a local Codex connector built on MCP. It is a curated tool surface for planning, local vision analysis, web search/extraction, cron planning, skill drafts, and gateway diagnostics; it does not modify Codex itself or bypass its permissions.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -4,6 +4,7 @@ Use this checklist before publishing any release artifact.
 
 - `python -m py_compile server.py test_server.py`
 - `python -m pytest`
+- `hermes-gpt update --help` and the check-only `hermes-gpt update` path work without modifying the checkout.
 - Run `hermes_release_doctor(full_tests=true)` and confirm status is `PASS` or only `WARN` (no `BLOCKED`).
 - Confirm default tools exclude write, patch, terminal, and session search.
 - Confirm `--profile remote` refuses to start without the explicit unsafe bypass.
@@ -17,3 +18,4 @@ Use this checklist before publishing any release artifact.
 - Confirm README still states that unauthenticated public exposure is not release-safe.
 - Confirm CHANGELOG.md mentions the new version.
 - Confirm docs/operator-mode.md documents the new diagnostic/recovery tools.
+- Confirm README.md, docs/codex.md, and docs/updating.md describe any changed install, update, or safety behavior.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -33,6 +33,8 @@ hermes-gpt codex uninstall
 
 `doctor` is read-only. It checks the Codex binary/version, target config, MCP registry, base gates, gateway status, and redaction smoke path. `uninstall` removes only the Hermes GPT MCP tables and makes a backup first.
 
+Before reinstalling a connector after a release, run `hermes-gpt update` to check safely; use `hermes-gpt update --apply` only when you are ready to update the checkout or installed package. See [updating](updating.md) for the exact safety behavior.
+
 ## Available Codex tools
 
 | Tool | Behavior |

--- a/docs/release-notes-v0.5.0b1.md
+++ b/docs/release-notes-v0.5.0b1.md
@@ -1,0 +1,10 @@
+# Hermes GPT v0.5.0b1
+
+The first v0.5.0 beta batch adds Codex integration through a local, curated MCP server.
+
+- `hermes-gpt mcp` and `hermes-gpt codex mcp` expose planning, vision, web, cron planning, skill drafting, and gateway diagnostics to Codex.
+- `hermes-gpt codex install`, `uninstall`, `doctor`, and `print-config` manage the local MCP entry safely.
+- The Codex facade adds capability gates, strict write gates, recursive secret redaction, local image path validation, and public URL SSRF protections.
+- New setup and safety documentation is available in [codex.md](codex.md).
+
+This is a beta batch, not the complete v0.5.0 release.

--- a/docs/release-notes-v0.5.0b2.md
+++ b/docs/release-notes-v0.5.0b2.md
@@ -1,0 +1,10 @@
+# Hermes GPT v0.5.0b2
+
+This maintenance beta adds safe, easy Hermes GPT updates and aligns the project documentation.
+
+- `hermes-gpt update` checks for updates without changing anything.
+- `hermes-gpt update --apply` fast-forwards a clean default-branch checkout or upgrades an installed package only when a newer version exists.
+- The updater refuses tracked local changes, non-default branches, divergent Git history, and package downgrades.
+- Documentation now links the Codex, Operator Mode, and update workflows consistently.
+
+See [updating.md](updating.md) for details.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,44 @@
+# Updating Hermes GPT
+
+`hermes-gpt update` is deliberately check-first. It reports the current and available revision or package version without changing files, environments, or Git history.
+
+```powershell
+hermes-gpt update
+```
+
+When the report shows an update is available, apply it explicitly:
+
+```powershell
+hermes-gpt update --apply
+```
+
+## Git checkout updates
+
+When Hermes GPT runs from a Git checkout, the updater:
+
+1. Refuses to act if tracked files have local changes.
+2. Refuses to update from a feature branch; it operates only on the remote default branch.
+3. Checks the remote branch without modifying the checkout.
+4. On `--apply`, fetches the default branch and runs `git merge --ff-only`.
+
+It never creates a merge commit, rebases, stashes changes, force-resets, or deletes untracked files. Untracked files are left alone. If a checkout has diverged, the command stops and tells you to resolve it manually.
+
+## Installed-package updates
+
+When Hermes GPT is installed from PyPI rather than a Git checkout, the updater checks the latest package version through pip. `--apply` runs the current Python environment's pip with `install --upgrade hermes-gpt` only if the available version is newer.
+
+It never downgrades a package. Add `--pre` only when you want pip to consider prerelease packages:
+
+```powershell
+hermes-gpt update --pre
+hermes-gpt update --pre --apply
+```
+
+Restart any running Hermes GPT server or Codex MCP process after a successful installed-package update.
+
+## Troubleshooting
+
+- `WORKTREE_DIRTY`: commit, stash, or otherwise resolve tracked changes first. The updater intentionally ignores untracked files but will not update over tracked edits.
+- `NOT_ON_DEFAULT_BRANCH`: switch to the default branch before applying an update.
+- `FAST_FORWARD_REQUIRED`: the checkout has diverged. Resolve the history manually; the updater will not merge or rebase it.
+- `UPDATE_CHECK_FAILED`: verify network/PyPI access and retry. No update was applied.

--- a/operator_diagnostics.py
+++ b/operator_diagnostics.py
@@ -34,7 +34,23 @@ import operator_workspace as op_workspace
 # Release version
 # ---------------------------------------------------------------------------
 
-VERSION = "0.4.0"
+def _source_version() -> str:
+    """Read the checked-out package version without depending on install state."""
+    try:
+        pyproject = Path(__file__).with_name("pyproject.toml")
+        match = re.search(
+            r'^version\s*=\s*["\']([^"\']+)["\']',
+            pyproject.read_text(encoding="utf-8"),
+            re.MULTILINE,
+        )
+        if match:
+            return match.group(1)
+    except OSError:
+        pass
+    return "unknown"
+
+
+VERSION = _source_version()
 
 # ---------------------------------------------------------------------------
 # Check statuses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-gpt"
-version = "0.5.0b1"
+version = "0.5.0b2"
 description = "Local-dev MCP sidecar for exposing selected Hermes Agent capabilities."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -14,6 +14,7 @@ authors = [
 ]
 dependencies = [
   "mcp[cli]",
+  "packaging>=23",
   "uvicorn",
 ]
 
@@ -38,6 +39,7 @@ py-modules = [
   "codex_core",
   "codex_mcp",
   "codex_config",
+  "updater",
 ]
 
 [tool.setuptools.data-files]
@@ -50,7 +52,11 @@ py-modules = [
   "docs/operator-mode.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",
+  "docs/release-notes-v0.4.0.md",
   "docs/codex.md",
+  "docs/updating.md",
+  "docs/release-notes-v0.5.0b1.md",
+  "docs/release-notes-v0.5.0b2.md",
 ]
 "share/hermes-gpt/examples" = [
   "examples/start-hermes-gpt.example.ps1",

--- a/server.py
+++ b/server.py
@@ -28,7 +28,7 @@ ENABLE_SESSION_SEARCH_ENV = "HERMES_GPT_ENABLE_SESSION_SEARCH"
 ENABLE_TERMINAL_ENV = "HERMES_GPT_ENABLE_TERMINAL"
 ENABLE_VISION_ENV = "HERMES_GPT_ENABLE_VISION"
 ENABLE_WEB_ENV = "HERMES_GPT_ENABLE_WEB"
-CODEX_BATCH_VERSION = "0.5.0b1"
+CODEX_BATCH_VERSION = "0.5.0b2"
 NOAUTH_META = {"securitySchemes": [{"type": "noauth"}]}
 
 HERMES_ROOT: Path | None = None
@@ -1253,6 +1253,11 @@ def main(argv: list[str] | None = None) -> None:
     args = list(sys.argv[1:] if argv is None else argv)
     if args and args[0] == "mcp":
         _run_codex_mcp(args[1:])
+        return
+    if args and args[0] == "update":
+        import updater
+
+        updater.main(args[1:])
         return
     if args and args[0] == "codex":
         if len(args) > 1 and args[1] == "mcp":

--- a/test_codex_core.py
+++ b/test_codex_core.py
@@ -27,7 +27,7 @@ def tool_core(monkeypatch):
         return value
 
     tool = core_module.CodexToolCore(
-        version="0.5.0b1",
+        version="0.5.0b2",
         imports_ready=lambda: True,
         gateway_snapshot=lambda: {"gateway": {"running": True, "pid": 42}},
         gateway_diagnostics_callback=lambda: {"success": True, "warnings": []},

--- a/test_updater.py
+++ b/test_updater.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+
+import updater
+
+
+def completed(argv, stdout="", stderr="", returncode=0):
+    return subprocess.CompletedProcess(argv, returncode, stdout, stderr)
+
+
+class GitRunner:
+    def __init__(self, *, dirty: str = "", updated: bool = False):
+        self.dirty = dirty
+        self.updated = updated
+        self.calls: list[list[str]] = []
+        self.rev_calls = 0
+
+    def __call__(self, argv, cwd, timeout):
+        self.calls.append(argv)
+        if argv[:3] == ["git", "status", "--porcelain"]:
+            return completed(argv, self.dirty)
+        if argv == ["git", "branch", "--show-current"]:
+            return completed(argv, "master\n")
+        if argv[:3] == ["git", "symbolic-ref", "--quiet"]:
+            return completed(argv, "origin/master\n")
+        if argv == ["git", "rev-parse", "HEAD"]:
+            self.rev_calls += 1
+            return completed(argv, ("b" * 40 if self.updated and self.rev_calls > 1 else "a" * 40) + "\n")
+        if argv[:3] == ["git", "ls-remote", "--heads"]:
+            return completed(argv, "b" * 40 + "\trefs/heads/master\n")
+        if argv[:3] == ["git", "fetch", "--prune"]:
+            return completed(argv)
+        if argv[:3] == ["git", "merge", "--ff-only"]:
+            return completed(argv)
+        raise AssertionError(f"Unexpected command: {argv}")
+
+
+def test_git_update_checks_only_by_default(tmp_path):
+    runner = GitRunner()
+    result = updater._source_update(root=tmp_path, apply=False, runner=runner)
+    assert result["ok"] is True
+    assert result["update_available"] is True
+    assert result["applied"] is False
+    assert result["next_command"] == "hermes-gpt update --apply"
+    assert not any(call[1] in {"fetch", "merge"} for call in runner.calls)
+
+
+def test_git_update_refuses_tracked_changes(tmp_path):
+    runner = GitRunner(dirty=" M server.py\n")
+    result = updater._source_update(root=tmp_path, apply=True, runner=runner)
+    assert result["ok"] is False
+    assert result["code"] == "WORKTREE_DIRTY"
+    assert len(runner.calls) == 1
+
+
+def test_git_check_still_reports_an_update_when_tracked_changes_exist(tmp_path):
+    runner = GitRunner(dirty=" M server.py\n")
+    result = updater._source_update(root=tmp_path, apply=False, runner=runner)
+    assert result["ok"] is True
+    assert result["update_available"] is True
+    assert result["tracked_changes_present"] is True
+    assert "apply_blocked_by" in result
+
+
+def test_git_update_applies_only_a_fast_forward(tmp_path):
+    runner = GitRunner(updated=True)
+    result = updater._source_update(root=tmp_path, apply=True, runner=runner)
+    assert result["ok"] is True
+    assert result["applied"] is True
+    assert result["current_revision"] == "b" * 40
+    assert ["git", "fetch", "--prune", "origin", "master"] in runner.calls
+    assert ["git", "merge", "--ff-only", "origin/master"] in runner.calls
+
+
+def test_pip_update_checks_only_until_apply(monkeypatch):
+    calls = []
+
+    def runner(argv, cwd, timeout):
+        calls.append(argv)
+        if argv[2:4] == ["pip", "index"]:
+            return completed(argv, "hermes-gpt (0.5.0)\nAvailable versions: 0.5.0, 0.4.0\n")
+        if argv[2:4] == ["pip", "install"]:
+            return completed(argv, "Successfully installed hermes-gpt-0.5.0\n")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(updater, "_current_version", lambda source_root: "0.4.0")
+    checked = updater._pip_update(apply=False, include_prereleases=False, runner=runner)
+    assert checked["ok"] is True
+    assert checked["update_available"] is True
+    assert checked["applied"] is False
+    assert not any(command[3] == "install" for command in calls)
+
+    applied = updater._pip_update(apply=True, include_prereleases=False, runner=runner)
+    assert applied["ok"] is True
+    assert applied["applied"] is True
+    assert applied["restart_required"] is True
+    assert any(command[3] == "install" for command in calls)
+
+
+def test_pip_updater_never_downgrades(monkeypatch):
+    def runner(argv, cwd, timeout):
+        assert argv[2:4] == ["pip", "index"]
+        return completed(argv, "hermes-gpt (0.4.0)\nAvailable versions: 0.4.0\n")
+
+    monkeypatch.setattr(updater, "_current_version", lambda source_root: "0.5.0b2")
+    result = updater._pip_update(apply=True, include_prereleases=False, runner=runner)
+    assert result["ok"] is True
+    assert result["update_available"] is False
+    assert result["applied"] is False
+
+
+def test_update_cli_emits_check_result(monkeypatch, capsys):
+    monkeypatch.setattr(updater, "check_for_update", lambda **kwargs: {"ok": True, **kwargs})
+    updater.main(["--pre"])
+    result = json.loads(capsys.readouterr().out)
+    assert result == {"ok": True, "apply": False, "include_prereleases": True}

--- a/updater.py
+++ b/updater.py
@@ -1,0 +1,216 @@
+"""Check-first, non-destructive update support for Hermes GPT."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from packaging.version import InvalidVersion, Version
+
+import operator_policy as op_policy
+
+
+PACKAGE_NAME = "hermes-gpt"
+DEFAULT_BRANCH = "master"
+Runner = Callable[[list[str], Path | None, int], subprocess.CompletedProcess[str]]
+
+
+def _run(argv: list[str], cwd: Path | None = None, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, cwd=cwd, text=True, capture_output=True, shell=False, timeout=timeout)
+
+
+def _safe_text(value: str) -> str:
+    return op_policy.redact_output(value.strip())
+
+
+def _error(code: str, message: str, **extra: Any) -> dict[str, Any]:
+    return {"ok": False, "code": code, "message": _safe_text(message), **extra}
+
+
+def _current_version(source_root: Path | None) -> str:
+    if source_root:
+        pyproject = source_root / "pyproject.toml"
+        if pyproject.exists():
+            match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', pyproject.read_text(encoding="utf-8"), re.MULTILINE)
+            if match:
+                return match.group(1)
+    try:
+        return importlib.metadata.version(PACKAGE_NAME)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def _find_git_root(start: Path, runner: Runner) -> Path | None:
+    try:
+        result = runner(["git", "rev-parse", "--show-toplevel"], start, 10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        return Path(result.stdout.strip()).resolve()
+    except OSError:
+        return None
+
+
+def _git_output(argv: list[str], root: Path, runner: Runner, timeout: int = 30) -> tuple[str | None, dict[str, Any] | None]:
+    try:
+        result = runner(argv, root, timeout)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, _error("GIT_UNAVAILABLE", str(exc))
+    if result.returncode != 0:
+        return None, _error("GIT_COMMAND_FAILED", result.stderr or result.stdout or "Git command failed.")
+    return result.stdout.strip(), None
+
+
+def _source_update(*, root: Path, apply: bool, runner: Runner) -> dict[str, Any]:
+    tracked_changes, error = _git_output(["git", "status", "--porcelain", "--untracked-files=no"], root, runner)
+    if error:
+        return error
+    worktree_dirty = bool(tracked_changes)
+    if worktree_dirty and apply:
+        return _error(
+            "WORKTREE_DIRTY",
+            "Tracked changes are present, so no update was attempted.",
+            suggested_action="Commit, stash, or discard the tracked changes before running hermes-gpt update --apply.",
+        )
+
+    branch, error = _git_output(["git", "branch", "--show-current"], root, runner)
+    if error:
+        return error
+    default_ref, error = _git_output(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], root, runner)
+    if error:
+        default_ref = f"origin/{DEFAULT_BRANCH}"
+    default_branch = default_ref.removeprefix("origin/") if default_ref else DEFAULT_BRANCH
+    if branch != default_branch:
+        return _error(
+            "NOT_ON_DEFAULT_BRANCH",
+            f"Updates are allowed only from the default branch {default_branch!r}; current branch is {branch!r}.",
+            branch=branch,
+            default_branch=default_branch,
+            suggested_action=f"Switch to {default_branch!r}, then run hermes-gpt update again.",
+        )
+
+    current_sha, error = _git_output(["git", "rev-parse", "HEAD"], root, runner)
+    if error:
+        return error
+    remote_head, error = _git_output(["git", "ls-remote", "--heads", "origin", default_branch], root, runner)
+    if error:
+        return error
+    fields = (remote_head or "").split()
+    if not fields:
+        return _error("REMOTE_BRANCH_MISSING", f"origin/{default_branch} could not be found.")
+    available_sha = fields[0]
+    update_available = current_sha != available_sha
+    result: dict[str, Any] = {
+        "ok": True,
+        "mode": "git",
+        "current_version": _current_version(root),
+        "branch": branch,
+        "current_revision": current_sha,
+        "available_revision": available_sha,
+        "update_available": update_available,
+        "applied": False,
+        "tracked_changes_present": worktree_dirty,
+        "untracked_files_ignored": True,
+    }
+    if not update_available:
+        result["message"] = "Hermes GPT checkout is already up to date."
+        return result
+    if not apply:
+        result["message"] = "An update is available. No changes were made; rerun with --apply to fast-forward."
+        result["next_command"] = "hermes-gpt update --apply"
+        if worktree_dirty:
+            result["apply_blocked_by"] = "Tracked changes must be resolved before --apply can fast-forward the checkout."
+        return result
+
+    fetched, error = _git_output(["git", "fetch", "--prune", "origin", default_branch], root, runner, timeout=60)
+    if error:
+        return error
+    _, error = _git_output(["git", "merge", "--ff-only", f"origin/{default_branch}"], root, runner, timeout=60)
+    if error:
+        return _error(
+            "FAST_FORWARD_REQUIRED",
+            "The checkout was not fast-forwardable, so it was not merged.",
+            suggested_action="Resolve the branch divergence manually; hermes-gpt update never creates merge commits or rebases.",
+        )
+    new_sha, error = _git_output(["git", "rev-parse", "HEAD"], root, runner)
+    if error:
+        return error
+    result.update({"applied": True, "current_revision": new_sha, "message": "Hermes GPT checkout was fast-forwarded safely."})
+    return result
+
+
+def _pip_latest_version(*, include_prereleases: bool, runner: Runner) -> tuple[str | None, dict[str, Any] | None]:
+    command = [sys.executable, "-m", "pip", "index", "versions", PACKAGE_NAME, "--disable-pip-version-check"]
+    if include_prereleases:
+        command.append("--pre")
+    try:
+        result = runner(command, None, 45)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, _error("PIP_UNAVAILABLE", str(exc))
+    if result.returncode != 0:
+        return None, _error("UPDATE_CHECK_FAILED", result.stderr or result.stdout or "pip could not check for releases.")
+    match = re.search(rf"^{re.escape(PACKAGE_NAME)}\s*\(([^)]+)\)", result.stdout, re.MULTILINE | re.IGNORECASE)
+    if not match:
+        return None, _error("UPDATE_CHECK_FAILED", "pip did not report a latest Hermes GPT version.")
+    return match.group(1), None
+
+
+def _pip_update(*, apply: bool, include_prereleases: bool, runner: Runner) -> dict[str, Any]:
+    current = _current_version(None)
+    latest, error = _pip_latest_version(include_prereleases=include_prereleases, runner=runner)
+    if error:
+        return error
+    try:
+        update_available = Version(latest) > Version(current)
+    except InvalidVersion:
+        return _error("INVALID_VERSION", f"Could not safely compare installed version {current!r} and available version {latest!r}.")
+    result: dict[str, Any] = {
+        "ok": True,
+        "mode": "pip",
+        "current_version": current,
+        "available_version": latest,
+        "update_available": update_available,
+        "applied": False,
+    }
+    if not update_available:
+        result["message"] = "Installed Hermes GPT is already up to date; no downgrade was attempted."
+        return result
+    if not apply:
+        result["message"] = "An update is available. No packages were changed; rerun with --apply to install it."
+        result["next_command"] = "hermes-gpt update --apply"
+        return result
+    command = [sys.executable, "-m", "pip", "install", "--upgrade", "--disable-pip-version-check", PACKAGE_NAME]
+    if include_prereleases:
+        command.append("--pre")
+    try:
+        completed = runner(command, None, 180)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return _error("UPDATE_INSTALL_FAILED", str(exc))
+    if completed.returncode != 0:
+        return _error("UPDATE_INSTALL_FAILED", completed.stderr or completed.stdout or "pip failed to install the update.")
+    result.update({"applied": True, "restart_required": True, "message": "Hermes GPT was updated. Restart any running Hermes GPT or Codex MCP process."})
+    return result
+
+
+def check_for_update(*, apply: bool = False, include_prereleases: bool = False, start: Path | None = None, runner: Runner = _run) -> dict[str, Any]:
+    """Check for an update, or apply only a safe, explicit update path."""
+    source_root = _find_git_root((start or Path(__file__).resolve().parent), runner)
+    if source_root:
+        return _source_update(root=source_root, apply=apply, runner=runner)
+    return _pip_update(apply=apply, include_prereleases=include_prereleases, runner=runner)
+
+
+def main(argv: list[str]) -> None:
+    parser = argparse.ArgumentParser(prog="hermes-gpt update", description="Check for a Hermes GPT update; use --apply to perform a safe update.")
+    parser.add_argument("--apply", action="store_true", help="Apply the available update. The default is check-only.")
+    parser.add_argument("--pre", action="store_true", help="Include prerelease package versions for installed-package updates.")
+    args = parser.parse_args(argv)
+    print(json.dumps(check_for_update(apply=args.apply, include_prereleases=args.pre), indent=2, default=str))


### PR DESCRIPTION
## Summary

Adds the v0.5.0b2 safe-update and documentation maintenance batch.

- Adds `hermes-gpt update` as a check-first update command.
- Requires `--apply` before a clean Git checkout is fast-forwarded or an installed package is upgraded.
- Refuses tracked edits, non-default branches, divergent Git history, and package downgrades.
- Aligns README, Codex docs, release notes, package data, release checklist, and diagnostics version reporting.

## Validation

- `python -m pytest -q`
- `python -m build --sdist --wheel`
- `python server.py update`
- `python server.py codex doctor`
- Markdown link audit

## Safety

The default command only checks. Git updates use `git merge --ff-only`; no merge commit, rebase, reset, stash, or untracked-file deletion is performed.