### PR TITLE
docs: make v0.6 documentation current and agent-friendly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,118 @@
+# AGENTS.md
+
+These instructions apply to the entire `hermes-gpt` repository.
+
+## Start here
+
+Before changing code or documentation:
+
+1. Read `docs/README.md` for the documentation authority map.
+2. Read `pyproject.toml` for the checked-out package version and shipped modules/docs.
+3. Read the current operational document for the subsystem you are touching.
+4. Inspect the implementation module and its tests before changing behavioral claims.
+
+Do not treat `docs/design/*`, `docs/releases/*`, or `FEASIBILITY.md` as current runtime instructions. They preserve design and release history.
+
+## Source-of-truth precedence
+
+When sources disagree:
+
+1. current implementation and tests;
+2. current operational docs;
+3. current release notes / CHANGELOG;
+4. historical design, risk, counsel, release-plan, and feasibility artifacts.
+
+Never change runtime behavior solely to make it match a historical plan. First determine whether the implementation or the documentation is the intended current contract.
+
+## Product invariants
+
+Preserve these unless the task explicitly changes the security model and includes corresponding tests/docs:
+
+- local loopback is the default network boundary;
+- public unauthenticated Operator hosting is unsupported;
+- default behavior is read-only;
+- mutating Operator actions are opt-in and dry-run-first;
+- direct mutation requires server direct mode plus per-call gates;
+- Owner Mode is break-glass and does not bypass secret-path protections;
+- `.env`, auth/token stores, SSH/AWS secrets, vault secrets, and secret-looking files remain denied;
+- protected subprocess paths use fixed argv and `shell=False`;
+- raw prompts are not persisted in Operator audit records;
+- Mission Control excludes raw messages, memory bodies, transcripts, request dumps, credentials, and profile-secret bodies;
+- Work Contract completion is validated from observed state and fails closed when evidence is missing;
+- Swarm orchestration has bounded concurrency/rework and a final human approval gate;
+- Codex may review Swarm work but is never an implementation owner.
+
+## Mission Control allowlist
+
+`HERMES_GPT_MISSION_ALLOWED_SURFACES` behaves as follows:
+
+- unset: all read-only Mission Control surfaces are available;
+- comma-separated list: only valid listed surfaces are available;
+- empty: all Mission Control surfaces are denied.
+
+Do not call the unset state "deny by default".
+
+## Codex terminology
+
+Keep these two relationships separate:
+
+- **Codex as MCP client:** configured with `hermes-gpt codex install`; documented in `docs/codex.md`.
+- **Codex CLI as delegated worker/reviewer:** invoked through `hermes_codex_*` from the normal Operator server.
+
+Tool names can differ by surface. In particular:
+
+- main server extraction: `hermes_web_extract`
+- curated Codex MCP extraction: `hermes_extract_page`
+
+Verify the active tool registration before writing docs, examples, or agent prompts.
+
+## Documentation rules
+
+For every documentation change:
+
+- put current behavior before historical context;
+- use exact tool/env names from code;
+- state defaults and required gates explicitly;
+- distinguish read-only, dry-run, direct, and Owner authority;
+- prefer links to canonical docs over copying large blocks;
+- mark historical artifacts as historical when they could be mistaken for current instructions;
+- do not imply GitHub releases and PyPI are synchronized;
+- do not expose machine-specific secrets, tokens, raw prompts, transcripts, or private operational data.
+
+If behavior changes, review at minimum:
+
+- `README.md`
+- `docs/README.md`
+- the subsystem guide (`docs/operator-mode.md`, `docs/codex.md`, etc.)
+- `CHANGELOG.md` when user-visible
+- release notes when preparing a release
+
+## Verification
+
+Run the smallest relevant tests first, then the full suite for cross-cutting changes.
+
+Common commands:
+
+```bash
+python -m pytest test_operator_mission.py
+python -m pytest test_operator_contract.py
+python -m pytest test_operator_swarm.py
+python -m pytest test_operator_codex.py
+python -m pytest
+```
+
+For release/package work also run:
+
+```bash
+python -m build
+python -m twine check dist/*
+python tools/check_package_hygiene.py dist/*
+```
+
+Do not weaken or skip a failing safety test just to make a change pass.
+
+## Release discipline
+
+`RELEASE_CHECKLIST.md` is the maintainer checklist. A historical release plan does not authorize a new tag, PyPI upload, connector mutation, or public deployment.
+
+Before claiming a version is available through a distribution channel, verify that channel directly.

--- a/FEASIBILITY.md
+++ b/FEASIBILITY.md
@@ -1,10 +1,12 @@
 # hermes-gpt feasibility
 
+> **Historical probe, not current setup authority.** This file records the environment inspected on 2026-06-18 before the initial sidecar implementation. Machine-specific paths, Hermes Agent versions, signatures, and capability observations below may no longer match a current installation. For current docs and source-of-truth rules, see [`docs/README.md`](docs/README.md).
+
 Date: 2026-06-18
 
 ## Decision
 
-Feasibility passed. The required capabilities are available in this environment, so the sidecar implementation was built.
+Feasibility passed. The required capabilities were available in the probed environment, so the sidecar implementation was built.
 
 ## Probe scope
 
@@ -64,7 +66,7 @@ The Hermes source root and bundled venv site-packages were added to `sys.path` f
 
 ## Build decision
 
-All required capabilities passed:
+All required capabilities passed in the probed environment:
 
 - Hermes root detection
 - FastMCP import
@@ -78,4 +80,4 @@ Optional capabilities also passed:
 - session DB import
 - session search via `SessionDB.search_messages`
 
-The server was built under `~/hermes-gpt/`.
+The server was then built under `~/hermes-gpt/`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include pyproject.toml
 include CHANGELOG.md
 # Public-safe docs only. Internal counsel/design/release-planning packets
 # (docs/design/*, docs/releases/*) are intentionally NOT distributed.
+include docs/README.md
 include docs/codex.md
 include docs/operator-mode.md
 include docs/release-notes-v0.2.0.md

--- a/README.md
+++ b/README.md
@@ -3,249 +3,69 @@
 [![PyPI version](https://img.shields.io/pypi/v/hermes-gpt.svg)](https://pypi.org/project/hermes-gpt/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/hermes-gpt.svg)](https://pypi.org/project/hermes-gpt/)
 
-![Hermes GPT v0.6.0 — ChatGPT for Hermes Agent](assets/hermes-gpt-v0.6.0-readme-hero.jpg)
+![Hermes GPT v0.6.0 - ChatGPT for Hermes Agent](assets/hermes-gpt-v0.6.0-readme-hero.jpg)
 
-`hermes-gpt` is a standalone MCP sidecar for Hermes Agent. It imports selected local Hermes Agent internals at runtime and exposes them to MCP clients without modifying Hermes Agent source files.
+`hermes-gpt` is a local-first MCP sidecar for Hermes Agent. It exposes selected Hermes capabilities to trusted MCP clients without modifying Hermes Agent source files.
 
-```bash
-pip install hermes-gpt
-```
+## Current status
 
-Or clone from [GitHub](https://github.com/asimons81/hermes-gpt).
+- **Repository / GitHub release:** v0.6.0
+- **Python requirement:** 3.10+
+- **Deployment posture:** local-dev / trusted-machine only
+- **Remote public hosting:** unsupported without a real authenticated private boundary
 
-This is a **local-dev release**.
+> [!IMPORTANT]
+> GitHub releases and PyPI can temporarily be on different versions. The PyPI badge above is the source of truth for what `pip install hermes-gpt` installs. At the v0.6.0 GitHub release, PyPI still served v0.5.0. Do not assume a PyPI install contains v0.6 features unless the badge reports v0.6.0 or newer.
 
-## v0.5.0 Two-Way Codex Bridge
+For the current documentation map and source-of-truth rules, start with [docs/README.md](docs/README.md). Agents working in this repository should also read [AGENTS.md](AGENTS.md).
 
-v0.5.0 adds a two-way bridge: Codex can opt into Hermes Operator tools, and trusted Hermes GPT clients can delegate asynchronous tasks and reviews to Codex. Updates remain check-first and mutations remain gated and dry-run-first. See [Codex setup](docs/codex.md), [Operator Mode](docs/operator-mode.md), [updating](docs/updating.md), and the [v0.5.0 release notes](docs/release-notes-v0.5.0.md).
+## What v0.6.0 adds
 
-## v0.6.0 Mission Control, Work Contracts, and Swarms
+v0.6.0 adds three coordinated control-plane layers on top of the existing Operator and Codex integrations:
 
-v0.6.0 adds **Mission Control**, a read-only operational view of the whole
-Hermes fleet exposed as the `hermes_mission_*` tool family; **Work Contracts**
-(`hermes_contract_*`) that validate completion from observed state rather than a
-worker's self-report; and bounded **Swarm Orchestration** (`hermes_swarm_*`) on
-top of those contracts. See the [release notes](docs/release-notes-v0.6.0.md)
-and [retention policy](docs/retention-policy.md).
+1. **Mission Control** - bounded, audited, read-only operational views through `hermes_mission_*`.
+2. **Work Contracts** - declarative `hermes_contract_*` work orders whose completion is validated from observed state rather than worker self-report.
+3. **Swarm Orchestration** - bounded `hermes_swarm_*` DAG workflows with explicit ownership, capped concurrency, fail-closed validation, review gates, and final human approval.
 
-Mission Control is structurally read-only — all SQLite is opened `mode=ro`, no
-write/dry-run/apply arguments exist, and no mutating shell calls are made. It
-never returns raw message, memory, transcript, request-dump, or profile-secret
-bodies; prompts surface as `{prompt_len, prompt_sha256}` only, and every call is
-audited. Per-client authorization uses the `HERMES_GPT_MISSION_ALLOWED_SURFACES`
-allowlist (deny-by-default). See [Operator Mode](docs/operator-mode.md) for the
-full surface, allowlist, and redaction contract.
+See the [v0.6.0 release notes](docs/release-notes-v0.6.0.md) and [retention policy](docs/retention-policy.md).
 
-### Updating Hermes GPT
+## Choose the path you need
 
-```powershell
-hermes-gpt update
-hermes-gpt update --apply
-```
+| Goal | Start here |
+| --- | --- |
+| Understand the repository and current docs | [Documentation map](docs/README.md) |
+| Run Hermes GPT locally | [Local quickstart](#local-quickstart) |
+| Use Codex as an MCP client | [Codex guide](docs/codex.md) |
+| Use ChatGPT or another trusted client to operate Hermes | [Operator Mode](docs/operator-mode.md) |
+| Let ChatGPT dispatch bounded work to the Codex CLI on Windows | [Windows ChatGPT -> Codex guide](docs/windows-chatgpt-codex.md) |
+| Update an install safely | [Updating](docs/updating.md) |
+| Review v0.6 data cleanup rules | [Retention policy](docs/retention-policy.md) |
+| Understand historical implementation decisions | [Design and release artifacts](docs/README.md#historical-and-internal-artifacts) |
 
-The first command only checks. `--apply` fast-forwards a clean checkout on its default branch, or upgrades an installed PyPI package. It never creates merge commits, rebases, downgrades packages, or overwrites tracked local changes.
+## Local quickstart
 
-## Codex App / Codex CLI Support
-
-The v0.5.0 core connector is a curated tool surface for planning, local vision analysis, web search/extraction, cron planning, skill drafts, and gateway diagnostics; it does not modify Codex itself or bypass its permissions.
-
-```powershell
-$env:HERMES_GPT_ENABLE_CODEX="1"
-$env:HERMES_GPT_ENABLE_MCP="1"
-hermes-gpt codex install --toolset core
-hermes-gpt codex doctor
-```
-
-Use `hermes-gpt codex install --toolset operator --refresh` for the opt-in Operator control plane. The installer creates a backup before refreshing only the Hermes GPT entry. Use `--project` for `<repo>/.codex/config.toml`, and `uninstall` to remove only that entry. Full setup, runner gates, and troubleshooting live in [docs/codex.md](docs/codex.md). For a Windows deployment where ChatGPT dispatches approved jobs to the standalone Codex CLI, see [docs/windows-chatgpt-codex.md](docs/windows-chatgpt-codex.md).
-
-## What's New in v0.4.0
-
-v0.4.0 is the Tool Surface Expansion release. It adds env-gated Hermes tool wrappers, a cron creation operator tool, and ships the first external contribution.
-
-- **New env-gated MCP tools:**
-  - `hermes_vision_analyze` — analyze images through Hermes Agent (`HERMES_GPT_ENABLE_VISION=1`)
-  - `hermes_web_search` — search the web (`HERMES_GPT_ENABLE_WEB=1`)
-  - `hermes_web_extract` — extract page content (same env gate)
-- **New operator tool:**
-  - `hermes_cron_create` — create cron jobs from scratch with full field support: schedule, prompt, script, skills, deliver, repeat, workdir, no_agent, model, context_from, enabled_toolsets
-- **First external contribution:** Gateway PID fallback from `gateway_state.json` when `gateway.pid` is missing (fixes macOS detection)
-- **Expanded gateway diagnostics:** New fields — `gateway_state`, `gateway_kind`, `gateway_pid_source`, `gateway_updated_at`, `gateway_exit_reason`, `gateway_active_agents`
-- **Infrastructure:** Vercel static site deploys correctly, HTTP smoke test no longer fails CI
-- **Published on PyPI:** `pip install hermes-gpt`
-
-## What’s New in v0.3.0
-
-v0.3.0 is the Operator Reliability Release. It makes Hermes GPT self-diagnosing, safely recoverable, and release-checkable.
-
-- New operator diagnostics tools:
-  - `hermes_operator_doctor` — read-only deep health check across operator, gateway, config, env, cron, skills, policy, audit, and connector surfaces.
-  - `hermes_operator_snapshot` — single current-state summary.
-  - `hermes_release_doctor` — release readiness checks with PASS / WARN / BLOCKED classification.
-  - `hermes_operator_recover` — conservative dry-run-first recovery sequence.
-- All operator-facing failures now return a structured error envelope:
-  `{success, ok, error, layer, code, safe_message, suggested_action, trace_id}`.
-- Diagnostic and recovery statuses use PASS / WARN / FAIL / UNSUPPORTED.
-- Connector re-registration is explicitly reported as unsupported unless a real supported command/API exists.
-- `hermes_operator_recover` is dry-run by default and requires `apply=true` for mutations.
-
-## What’s New in v0.2.0
-
-v0.2.0 adds tiered Operator / Owner Mode so trusted MCP clients can see the full Hermes GPT surface while the default posture stays safe.
-
-- Default mode remains read-only.
-- Recommended always-on connector/tunnel mode is `dry_run`.
-- Direct mutation requires both:
-  - `HERMES_GPT_OPERATOR_APPLY_MODE=direct`
-  - the mutating tool call sets `dry_run=false`
-- Owner Mode requires the exact break-glass acknowledgement:
-  - `HERMES_GPT_OWNER_ACK=I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE`
-- Operator Mode is not a sandbox.
-- Do not expose publicly without real auth, VPN, Tailscale, or an equivalent private boundary.
-
-What v0.2.0 adds:
-
-- operator policy, status, and audit tools
-- cron tools
-- skill tools
-- config and env tools
-- gateway tools
-- workspace tools
-- owner tools behind explicit acknowledgement
-- audit logging with hashes and lengths instead of raw prompt/content
-- Hermes data-root normalization for operator profile operations
-- packaging fixes so operator modules ship in the release
-
-| Mode | Env posture | What happens |
-| --- | --- | --- |
-| Read-only | no operator env vars | read/list/status tools only; mutations refuse |
-| Dry-run Operator | operator enabled + apply_mode=dry_run | mutation tools return plans/previews only |
-| Direct Operator | operator enabled + apply_mode=direct | writes allowed only when tool call also sets `dry_run=false` |
-| Owner Mode | level=owner + exact owner ack | break-glass local owner tools; still denies secret paths |
-
-For the full Operator Mode guide, new-user quickstart, and tunnel safety model, see `docs/operator-mode.md`.
-
-## Fleet routing through one connector
-
-When the local Hermes install already has authenticated named peers in its A2A
-registry, one Hermes GPT connector can route bounded tasks to those peers:
-
-- `hermes_fleet_list()` lists registered peers without exposing bearer tokens.
-- `hermes_fleet_status(agent)` runs a metadata-only A2A compatibility check.
-- `hermes_fleet_dispatch(agent, message, confirm, dry_run)` submits a task only
-  to a registered peer. A real dispatch requires workspace-level Operator Mode,
-  direct apply mode, `dry_run=false`, and `confirm=true`.
-- `hermes_fleet_task(agent, task_id)` returns a safe status summary without
-  returning task prompts or histories.
-- `hermes_fleet_dispatch_work_order(...)` validates and submits a canonical,
-  profile-aware work order.
-- `hermes_fleet_result(agent, task_id)` returns only a safe completion bundle.
-- `hermes_fleet_authority_drift()` reports registry, manifest, profile, role,
-  and Agent Card drift.
-
-This is deliberately not a generic remote shell: callers cannot provide a peer
-URL or token, and dispatch is constrained to the local authenticated A2A
-registry. Use `hermes_fleet_list` before selecting a target. Keep the connector
-behind an authenticated private boundary; A2A peer authentication does not make
-an unauthenticated public MCP endpoint safe.
-
-Structured dispatch reads `HERMES_GPT_FLEET_AUTHORITY_MANIFEST`, defaulting to
-`<Hermes data root>/config/fleet-authority.json`. The server-controlled path is
-absolute, non-symlinked, size-bounded, and checked by the secret-path policy.
-Copy `examples/fleet-authority.example.json`, set expected roles and identities,
-install it with service-account-only permissions, and run the drift tool before
-enabling direct mode. Confirmed structured dispatch rechecks the live peer
-identity and host role against that manifest immediately before sending. Never
-place URLs, credentials, or tokens in the manifest.
-
-## Security posture
-
-By default, `hermes-gpt` is designed for a trusted local machine:
-
-- HTTP binds to `127.0.0.1` by default.
-- Tools advertise `noauth` only for local-dev MCP clients.
-- Write, patch, terminal execution, memory writes, and session search are disabled or hidden by default.
-- Remote/public release is not supported until real OAuth or another ChatGPT-compatible authentication layer is added.
-
-Do not expose this server publicly without authentication. A temporary tunnel is acceptable only for short local testing when you understand that any enabled tool is reachable through that URL.
-
-## Prerequisites
-
-- Python 3.10+
-- A local Hermes Agent install
-- MCP Python SDK and Uvicorn
-
-Install dependencies:
+### Install from PyPI
 
 ```bash
-cd ~/hermes-gpt
-python -m pip install -r requirements.txt
+python -m pip install hermes-gpt
 ```
 
-## Local MCP clients
+Check the PyPI badge before relying on version-specific features.
 
-Stdio mode is for local MCP clients that support subprocess MCP servers:
+### Run the current source checkout
 
 ```bash
-cd ~/hermes-gpt
-python server.py
+git clone https://github.com/asimons81/hermes-gpt.git
+cd hermes-gpt
+python -m pip install .
+hermes-gpt
 ```
 
-Example client command:
+The final v0.6.0 wheel and sdist are also attached to the [GitHub v0.6.0 release](https://github.com/asimons81/hermes-gpt/releases/tag/v0.6.0).
 
-```json
-{
-  "command": "python",
-  "args": ["C:\\Users\\<YOU>\\hermes-gpt\\server.py"]
-}
-```
+## Default local MCP surface
 
-## Local HTTP
-
-HTTP mode uses FastMCP streamable HTTP:
-
-```bash
-cd ~/hermes-gpt
-python server.py --http --host 127.0.0.1 --port 7677
-```
-
-Local endpoint:
-
-```text
-http://127.0.0.1:7677/mcp
-```
-
-If you bind to anything other than loopback in the default `local-dev` profile, the server prints a warning. This warning means the configuration is not release-safe.
-
-## ChatGPT local testing
-
-ChatGPT developer mode expects a remote MCP endpoint. Do not enter a localhost URL such as `http://127.0.0.1:4750`; ChatGPT fetches the MCP configuration through its connector path, where `127.0.0.1` is not your machine.
-
-For short local testing only:
-
-```powershell
-cd C:\Users\<YOU>\hermes-gpt
-python server.py --http --host 127.0.0.1 --port 4750
-```
-
-In another terminal:
-
-```powershell
-& "C:\Program Files (x86)\cloudflared\cloudflared.exe" tunnel --url http://127.0.0.1:4750 --http-host-header 127.0.0.1:4750
-```
-
-In ChatGPT, configure:
-
-- Protocol: Streaming HTTP
-- MCP server URL: `https://<your-trycloudflare-host>/mcp`
-- Authentication: No Authentication
-
-If ChatGPT only shows the old 5-tool surface, reconnect or recreate the connector and follow the workflow in `docs/operator-mode.md`.
-
-Example scripts for local setup live under `examples/`.
-
-## Tool gates
-
-Default visible tools:
+With no optional feature gates enabled, the server exposes a small read-oriented surface:
 
 - `hermes_read_file(path, offset=1, limit=500)`
 - `hermes_search_files(pattern, target="content", path=".", file_glob=None, limit=50)`
@@ -253,209 +73,207 @@ Default visible tools:
 - `hermes_skill_list()`
 - `hermes_skill_view(name)`
 
-Opt-in tools and actions:
+Optional legacy feature gates remain available for compatibility:
 
-| Capability | Env var | Default |
+| Capability | Gate | Default |
 | --- | --- | --- |
-| Write file and patch tools | `HERMES_GPT_ENABLE_WRITE=1` | Hidden |
-| Memory `add`, `replace`, `remove` | `HERMES_GPT_ENABLE_MEMORY_WRITE=1` | Disabled |
-| Session search | `HERMES_GPT_ENABLE_SESSION_SEARCH=1` | Hidden |
-| Terminal command execution | `HERMES_GPT_ENABLE_TERMINAL=1` | Hidden |
+| File write / patch | `HERMES_GPT_ENABLE_WRITE=1` | hidden |
+| Memory mutation | `HERMES_GPT_ENABLE_MEMORY_WRITE=1` | disabled |
+| Session search | `HERMES_GPT_ENABLE_SESSION_SEARCH=1` | hidden |
+| Terminal execution | `HERMES_GPT_ENABLE_TERMINAL=1` | hidden |
+| Vision | `HERMES_GPT_ENABLE_VISION=1` | hidden |
+| Web search / extraction | `HERMES_GPT_ENABLE_WEB=1` | hidden |
 
-Terminal timeout is capped at 120 seconds even when enabled.
+For new automation and maintenance work, prefer Operator Mode instead of enabling broad legacy write gates.
 
-The broad `HERMES_GPT_ENABLE_*` flags still work for backward compatibility,
-but for tiered, safe operation prefer the **Operator / Owner Mode** tools
-documented below.
+## Run modes
 
-## Hermes GPT Operator Mode
+### Stdio
 
-Operator / Owner Mode is a tiered control plane that lets trusted MCP
-clients (like ChatGPT) operate Hermes safely: cron jobs, skills, profile
-config wiring, safe non-secret env keys, gateway/runtime status and restart,
-scoped workspace edits, and (with explicit acknowledgement) owner-level
-command and file access.
+For a local MCP client that can launch a subprocess:
 
-### Safety model
+```bash
+hermes-gpt
+```
 
-- **Default behavior is read-only.** Mutating operator tools refuse unless
-  operator mode is explicitly enabled.
-- **Dry-run is the default.** Even when operator mode is enabled, every
-  mutating tool defaults to `dry_run=True` and returns a plan instead of
-  mutating. To actually mutate, you must set
-  `HERMES_GPT_OPERATOR_APPLY_MODE=direct` AND pass `dry_run=False` to the
-  tool call.
-- **Direct mutation requires explicit opt-in.** `HERMES_GPT_OPERATOR_APPLY_MODE=direct`
-  is required for any write to happen.
-- **Owner Mode requires an explicit break-glass activation and acknowledgement.**
-  Setting `HERMES_GPT_OPERATOR_LEVEL=owner` alone is clamped to effective
-  `workspace` operation. Owner tools require both `HERMES_GPT_OWNER_ACTIVE=1`
-  and `HERMES_GPT_OWNER_ACK=I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE`.
-- **No secrets exposed.** Config `get` redacts secret-looking keys; `env`
-  tools never return values; skill/cron prompts are logged and surfaced
-  only as `prompt_len` + `prompt_sha256`.
-- **No `.env` raw read/write.** The denied-path policy refuses `.env`,
-  `auth.json`, `mcp-tokens/`, `.ssh/`, `.aws/`, `vault/`, and any
-  secret-looking filename.
-- **No `shell=True` anywhere.** Every subprocess invocation uses
-  `shell=False` with a fixed argv.
-- **No `git add -A`, no `git push`, no destructive filesystem operations.**
-  Workspace `run_test` only allows a conservative allowlist (pytest, ruff,
-  mypy, npm test/lint, git status/diff). Owner `run_command` blocks
-  catastrophic patterns (`rm -rf /`, `del /s`, `format`, `curl | bash`,
-  `git push --force`, `git add -A`, `git add .`, anything touching
-  `.env`/`vault`/`token`/`.ssh`).
-- **Operator Mode is not a sandbox.** Use OS-level isolation (container,
-  VM, or a tool like OpenShell) for untrusted input. The operator gates
-  are defense-in-depth, not a security boundary — same stance as Hermes
-  Agent's own SECURITY.md.
-- **Do not expose remote without real auth.** Operator Mode does not add
-  any authentication. Bind to loopback only, or put a real auth layer
-  (VPN, Tailscale, OAuth) in front before exposing on a network.
+or from a checkout:
 
-### Operator levels
+```bash
+python server.py
+```
 
-Levels are ordered; each level includes all capabilities of the levels
-above it in this list.
+### Local streamable HTTP
 
-| Level | Capabilities |
+```bash
+python server.py --http --host 127.0.0.1 --port 7677
+```
+
+Endpoint:
+
+```text
+http://127.0.0.1:7677/mcp
+```
+
+Keep the server on loopback. A remote client such as ChatGPT cannot use your machine's `127.0.0.1` directly, so remote access requires a deliberately configured private/authenticated boundary. Do not publish an unauthenticated Operator endpoint to the internet.
+
+## Operator Mode
+
+Operator Mode is the policy-gated control plane for trusted clients. Tool visibility does not grant mutation authority.
+
+| Level | Adds |
 | --- | --- |
-| `read_only` | status, policy, audit tail, cron list/status, skill diff/list/view, config get, env status, gateway status, git status/diff |
-| `cron` | + cron run, cron pause, cron copy, cron move |
-| `skills` | + skill create, edit, patch, write_file, copy, sync_to_default, delete |
-| `skills_config` | + config set/patch, env set/copy (non-secret keys only) |
-| `workspace` | + scoped workspace patch/write, test/lint allowlist, gateway restart |
-| `owner` | + raw command, raw file patch/write — still gated by explicit owner ack and still denies secret paths |
+| `read_only` | status, policy, audit, list/view/diff, Mission Control |
+| `cron` | cron run/pause/copy/move |
+| `skills` | skill create/edit/patch/write/copy/sync/delete |
+| `skills_config` | non-secret config and environment writes |
+| `workspace` | scoped workspace writes/tests, gateway restart, Codex jobs, contract/swarm dispatch |
+| `owner` | break-glass raw command/file operations and final swarm approval; secret paths remain denied |
 
-### Env flags
+Mutation requires both the server and the individual call to opt in:
 
-| Env var | Default | Purpose |
-| --- | --- | --- |
-| `HERMES_GPT_OPERATOR_ENABLED` | unset (false) | Enable operator mode |
-| `HERMES_GPT_OPERATOR_LEVEL` | `read_only` | Operator level (see table above) |
-| `HERMES_GPT_OPERATOR_APPLY_MODE` | `dry_run` | `dry_run` returns plans; `direct` allows mutation |
-| `HERMES_GPT_OPERATOR_ALLOWED_PROFILES` | `default` | Comma-separated profile names, or `*` for all existing |
-| `HERMES_GPT_OPERATOR_ALLOWED_PATHS` | empty | Comma-separated workspace root paths; empty disables workspace writes |
-| `HERMES_GPT_OPERATOR_DENIED_PATHS` | built-in defaults | Extra denied paths (additions only; cannot weaken defaults) |
-| `HERMES_GPT_OWNER_ACTIVE` | unset | Must be truthy to activate break-glass Owner Mode; otherwise configured `owner` is clamped to `workspace` |
-| `HERMES_GPT_OWNER_ACK` | unset | Must equal `I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE` for owner tools |
-
-### Examples
-
-Read-only default (no env vars needed):
-
-```powershell
-hermes-gpt
+```text
+HERMES_GPT_OPERATOR_ENABLED=1
+HERMES_GPT_OPERATOR_APPLY_MODE=direct
 ```
 
-Cron dry-run:
+and the mutating call must use `dry_run=false`. Tools that require explicit confirmation also require `confirm=true`.
 
-```powershell
-$env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="cron"
-$env:HERMES_GPT_OPERATOR_APPLY_MODE="dry_run"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default,hermes-researcher"
-hermes-gpt
+Owner Mode additionally requires:
+
+```text
+HERMES_GPT_OWNER_ACTIVE=1
+HERMES_GPT_OWNER_ACK=I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE
 ```
 
-Skills/config dry-run:
+See [docs/operator-mode.md](docs/operator-mode.md) for the complete policy model and exact gates.
 
-```powershell
-$env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="skills_config"
-$env:HERMES_GPT_OPERATOR_APPLY_MODE="dry_run"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default,hermes-researcher,hermes-trt-manager,hermes-nexus-wiki"
-hermes-gpt
+## Mission Control
+
+Mission Control is structurally read-only. It exposes bounded operational summaries for:
+
+`overview`, `health`, `profiles`, `fleet`, `codex`, `cron`, `delegations`, `failures`, `approvals`, `vault`, `usage`, and `audit`.
+
+Important authorization semantics for `HERMES_GPT_MISSION_ALLOWED_SURFACES`:
+
+- **unset:** all read-only Mission Control surfaces are available;
+- **set to a comma-separated list:** only listed valid surfaces are available;
+- **set to an empty value:** all Mission Control surfaces are denied.
+
+Mission Control excludes raw message, memory, transcript, request-dump, credential, token, and profile-secret bodies. Prompt-like content is surfaced only as bounded metadata such as length and SHA-256. Free-text operational fields receive conservative redaction / PII stripping before they leave the host.
+
+## Work Contracts
+
+The `hermes_contract_*` family makes completion verifiable instead of trusting a worker's `done` claim.
+
+- `hermes_contract_define` validates and canonicalizes a contract.
+- `hermes_contract_dispatch` is workspace-level and dry-run-first.
+- `hermes_contract_validate` checks observed runs, artifacts, audit evidence, tests, and review evidence.
+- `hermes_contract_status` links a contract to bounded observed state.
+
+Validation is fail-closed. Missing evidence cannot become `SATISFIED`. v0.6.0 does not ship a production review-accept writer, so required review evidence must already exist through an authorized external review path or human approval reference.
+
+## Swarm Orchestration
+
+The `hermes_swarm_*` family runs bounded DAG workflows on top of Work Contracts.
+
+Typical shape:
+
+```text
+research -> architecture -> implementation/tests/docs
+         -> integration review -> Codex review
+         -> acceptance validation -> HUMAN APPROVAL
 ```
 
-Workspace direct with allowed path:
+Key properties:
 
-```powershell
-$env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="workspace"
-$env:HERMES_GPT_OPERATOR_APPLY_MODE="direct"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PATHS="C:\Users\<YOU>\hermes-gpt,C:\Users\<YOU>\AppData\Local\hermes\hermes-agent"
-hermes-gpt
-```
+- explicit stage ownership;
+- validated dependencies and cycle rejection;
+- default caps of 3 concurrent stages per workflow, 4 per board, and 12 stages per workflow;
+- one bounded rework retry before blocking for human attention;
+- Codex can review but is never an implementation owner;
+- final approval is an Owner-level human gate.
 
-Owner Mode (WARNING: can mutate your machine):
+## Codex integration
 
-```powershell
-$env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="owner"
-$env:HERMES_GPT_OPERATOR_APPLY_MODE="direct"
-$env:HERMES_GPT_OWNER_ACTIVE="1"
-$env:HERMES_GPT_OWNER_ACK="I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE"
-hermes-gpt
-```
+Hermes GPT supports two different Codex relationships. Keep them conceptually separate:
 
-### Audit log
+1. **Codex as MCP client** - install the curated Hermes GPT MCP toolset into Codex. See [docs/codex.md](docs/codex.md).
+2. **Codex CLI as delegated worker/reviewer** - a trusted Hermes GPT client can start bounded async Codex jobs through `hermes_codex_*`. This requires Operator `workspace` level, an approved work directory, `HERMES_GPT_ENABLE_CODEX_RUNNER=1`, direct mode for execution, `confirm=true`, and `dry_run=false`.
 
-Every mutating tool call appends a JSONL record to:
+`HERMES_GPT_ALLOW_CODEX_WRITE=1` is required only for `workspace-write` jobs.
 
-- `%USERPROFILE%\AppData\Local\hermes\logs\hermes_gpt_operator_audit.jsonl` (preferred), or
-- `<hermes-gpt>\logs\hermes_gpt_operator_audit.jsonl` (fallback)
+### Tool-name note
 
-Each record contains: `timestamp`, `tool`, `level`, `apply_mode`, `dry_run`,
-`success`, `changed`, `summary`, `error`, profile(s), path summary, job_id /
-skill_name / key (when relevant), and `prompt_len` + `prompt_sha256` /
-`content_len` + `content_sha256` for skill/cron content. The audit log
-**never** records full prompts, full config values, raw `.env` contents,
-vault contents, or command output likely to contain secrets. Read it with
-the `hermes_operator_audit_tail` tool.
+The main Hermes GPT server and the curated Codex MCP server have one intentional naming difference:
 
-### Owner Mode warning
+- main server web extraction: `hermes_web_extract`
+- Codex-focused MCP extraction: `hermes_extract_page`
 
-Owner Mode can mutate your machine. Use it only on a trusted local
-machine. It is **not a sandbox** — it is the explicit break-glass path
-for the local owner. Even in Owner Mode, secret paths (`.env`, `auth.json`,
-`.ssh/`, `mcp-tokens/`, etc.) remain denied; no secret override is
-shipped in this release.
+Do not silently substitute one name for the other when generating tool calls.
 
-## Remote profile
+## Fleet routing
 
-`--profile remote` is intentionally blocked because authentication is not implemented:
+When Hermes already has authenticated peers in its local A2A registry, Hermes GPT can route bounded work to named peers through `hermes_fleet_*`.
+
+Callers cannot provide arbitrary peer URLs or bearer tokens. Real dispatch remains constrained by Operator level, direct mode, confirmation, the local registry, and the server-controlled fleet authority manifest. See [Operator Mode](docs/operator-mode.md#fleet-routing-through-the-local-a2a-registry).
+
+## Security invariants
+
+These rules are part of the product contract, not optional recommendations:
+
+- loopback is the default network boundary;
+- public unauthenticated hosting is unsupported;
+- Operator Mode is not a sandbox;
+- mutations are off by default and dry-run-first when enabled;
+- secret-looking paths such as `.env`, `auth.json`, token stores, `.ssh`, `.aws`, and vault secrets remain denied;
+- subprocesses use fixed argv and `shell=False` on protected execution paths;
+- raw prompts are not written into Operator audit records;
+- Mission Control never exposes raw messages, memory bodies, transcripts, request dumps, or credentials;
+- Owner Mode does not disable secret-path protections.
+
+Use OS-level isolation for untrusted input.
+
+## Updating
+
+Updates are check-first:
 
 ```bash
-python server.py --http --profile remote
+hermes-gpt update
 ```
 
-For temporary experiments only, you can bypass this block with both:
+Apply only after reviewing the result:
 
 ```bash
-HERMES_GPT_UNSAFE_REMOTE_NOAUTH=1
-python server.py --http --profile remote --i-understand-this-is-unsafe
+hermes-gpt update --apply
 ```
 
-Do not use this bypass for release.
+Git checkout updates require a clean checkout on the default branch and use fast-forward-only behavior. Installed-package updates use pip only when a newer package version is available. See [docs/updating.md](docs/updating.md).
 
-## Release checklist
+## Documentation
 
-Before publishing:
+Current operational documentation:
 
-- No `*.pem` files.
-- No `*.log` or `*.err.log` files.
-- No `__pycache__/` or `*.pyc`.
-- `python -m py_compile server.py` passes.
-- `pytest` passes.
-- Server binds to loopback by default.
-- Terminal, write tools, memory writes, and session search are disabled by default.
+- [Documentation map and source-of-truth rules](docs/README.md)
+- [Operator Mode](docs/operator-mode.md)
+- [Codex integration](docs/codex.md)
+- [Windows ChatGPT -> Codex deployment](docs/windows-chatgpt-codex.md)
+- [Updating](docs/updating.md)
+- [Retention policy](docs/retention-policy.md)
+- [v0.6.0 release notes](docs/release-notes-v0.6.0.md)
+- [Changelog](CHANGELOG.md)
 
-## Current capability notes
+Historical release notes and pre-release design / risk / planning artifacts remain in the repository for provenance. They are not authoritative instructions for current runtime behavior. See [docs/README.md](docs/README.md) before using them as implementation guidance.
 
-The feasibility probe passed in this environment:
+## Development and verification
 
-- Hermes source root: `C:\Users\<YOU>\AppData\Local\hermes\hermes-agent`
-- File tools: available
-- Terminal tool: available, gated by `HERMES_GPT_ENABLE_TERMINAL=1`
-- Memory tool: available
-- Skill discovery: available through local and bundled skill directories
-- Session search: available through `SessionDB.search_messages`
-- FastMCP stdio: available
-- FastMCP streamable HTTP: available
+```bash
+python -m pip install -r requirements-dev.txt
+python -m pytest
+python tools/check_package_hygiene.py dist/*
+```
 
-See `FEASIBILITY.md` for probe details and exact signatures.
+Release-specific checks are listed in [RELEASE_CHECKLIST.md](RELEASE_CHECKLIST.md).
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,29 +1,116 @@
 # Release Checklist
 
-Use this checklist before publishing any release artifact.
+Use this checklist before publishing a Hermes GPT release artifact.
+
+## 1. Establish release state
+
+- Confirm the intended version in `pyproject.toml`.
+- Confirm `CHANGELOG.md` contains that version.
+- Confirm the release notes describe a final release rather than a candidate once publication is approved.
+- Read `docs/README.md` and confirm current operational docs are the documents being updated, not historical files under `docs/design/` or `docs/releases/`.
+- Verify each distribution channel separately. A GitHub release does not prove the same version is already available from PyPI.
+
+## 2. Core verification
 
 - `python -m py_compile server.py test_server.py`
 - `python -m pytest`
-- `python -m pytest test_operator_mission.py` — Mission Control redaction, no-raw-body, read-only, audit, and allowlist tests must be green (risk review R1: mandatory redaction test is a release blocker).
-- `python -m pytest test_operator_contract.py` — Work Contracts schema, false-"done" rejection (S2 exit criterion), D6 test gating, redaction, read-only, and audit tests must be green.
-- `python -m pytest test_operator_swarm.py` — Swarm Orchestration DAG validation, scheduler bounds, contract dispatch, verifiable completion (S2), bounded rework, worktree plans (NG5), Codex review posture, approval gate, mutation gates, audit, and redaction tests must be green.
-- `hermes-gpt update --help` and the check-only `hermes-gpt update` path work without modifying the checkout.
-- Run `hermes_release_doctor(full_tests=true)` and confirm status is `PASS` or only `WARN` (no `BLOCKED`).
-- Run the Windows/Linux Python 3.10-3.12 CI matrix before publishing.
-- Confirm `python -m build` and `python -m twine check dist/*` pass and artifacts include the runner, version helper, public docs, the final release notes, and retention policy.
-- Run `python tools/check_package_hygiene.py dist/*` and confirm it exits `0` with `CLEAN` (no absolute `/home` paths, RFC1918/Tailscale IPs, machine hostnames, or live operational metrics in wheel or sdist).
-- Confirm `docs/retention-policy.md` is present and its request-dump, Codex-artifact, worktree, and workflow-record cleanup windows are actionable.
-- Confirm runner metadata and audit records contain no raw prompts and no danger/bypass argv can be constructed.
-- Confirm default tools exclude write, patch, terminal, and session search.
+- `python -m pytest test_operator_mission.py`
+  - Mission Control redaction, no-raw-body, read-only, audit, bounds, and allowlist behavior must be green.
+- `python -m pytest test_operator_contract.py`
+  - Work Contract schema, observed-state validation, false-done rejection, test gating, redaction, read-only behavior, and audit must be green.
+- `python -m pytest test_operator_swarm.py`
+  - DAG validation, scheduler caps, contract dispatch, observed completion, bounded rework, worktree plans, Codex review posture, approval gate, mutation gates, audit, and redaction must be green.
+- `python -m pytest test_operator_codex.py`
+  - Codex executable resolution, runner gates, bounded argv, redaction, and retention behavior must be green.
+- Run the Windows/Linux Python 3.10-3.12 CI matrix.
+
+## 3. Release doctor
+
+- Run `hermes_release_doctor(full_tests=true)`.
+- Require `PASS` or understood non-blocking `WARN` results.
+- Do not publish with `BLOCKED`.
+- Confirm the server is not accidentally left in direct/Owner posture as part of release preparation.
+
+## 4. Package build and hygiene
+
+- `python -m build`
+- `python -m twine check dist/*`
+- Confirm wheel and sdist contain the current public docs expected by `pyproject.toml` / `MANIFEST.in`, including:
+  - `README.md`
+  - `docs/README.md`
+  - `docs/operator-mode.md`
+  - `docs/codex.md`
+  - `docs/windows-chatgpt-codex.md`
+  - `docs/updating.md`
+  - `docs/retention-policy.md`
+  - current release notes
+- Run `python tools/check_package_hygiene.py dist/*` and require exit `0` / `CLEAN`.
+- Confirm package artifacts contain no absolute private machine paths, RFC1918/Tailscale addresses, machine hostnames, live operational metrics, or private release-planning packets.
+
+## 5. Security invariants
+
+- Confirm default tools exclude write, patch, terminal, and session search unless their explicit gates are enabled.
+- Confirm Mission Control never returns raw messages, memory bodies, transcripts, request dumps, credentials, tokens, or profile-secret bodies.
+- Confirm Mission Control allowlist semantics match implementation:
+  - unset = all read-only Mission surfaces;
+  - explicit list = listed valid surfaces only;
+  - empty = none.
+- Confirm runner metadata and Operator audit records contain no raw prompts.
+- Confirm danger/bypass argv cannot be constructed through protected execution paths.
+- Confirm Owner Mode still denies secret paths.
 - Confirm `--profile remote` refuses to start without the explicit unsafe bypass.
-- Confirm no private files are present:
-  - `*.pem`
-  - `*.log`
-  - `*.err.log`
-  - `.env`
-  - `__pycache__/`
-  - `.pytest_cache/`
-- Confirm README still states that unauthenticated public exposure is not release-safe.
-- Confirm CHANGELOG.md mentions the new version.
-- Confirm docs/operator-mode.md documents the new diagnostic/recovery tools.
-- Confirm README.md, docs/codex.md, and docs/updating.md describe any changed install, update, or safety behavior.
+- Confirm README still states public unauthenticated Operator exposure is unsupported.
+
+## 6. Retention
+
+- Confirm `docs/retention-policy.md` matches current implementation.
+- Confirm Codex artifact cleanup still uses the implemented 30-day reconciliation window.
+- Confirm request-dump and Swarm cleanup windows are actionable and are not falsely described as a global automatic deletion daemon.
+
+## 7. Update behavior
+
+- `hermes-gpt update --help`
+- Run the check-only `hermes-gpt update` path and confirm it does not modify the checkout/package.
+- Confirm Git checkout updates remain clean-tree, default-branch, fast-forward-only.
+- Confirm installed-package updates check PyPI independently of GitHub release state.
+
+## 8. Private-file scan
+
+Confirm release artifacts do not contain:
+
+- `*.pem`
+- `*.key`
+- `*.log`
+- `*.err.log`
+- `.env` / `.env.*`
+- auth/token/cookie files
+- `__pycache__/`
+- `.pytest_cache/`
+- internal `docs/design/*`
+- internal `docs/releases/*`
+
+## 9. Documentation consistency
+
+Before publication, inspect at minimum:
+
+- `README.md`
+- `docs/README.md`
+- `docs/operator-mode.md`
+- `docs/codex.md`
+- `docs/windows-chatgpt-codex.md`
+- `docs/updating.md`
+- `docs/retention-policy.md`
+- current release notes
+- `CHANGELOG.md`
+
+Check exact tool names and environment variables against the implementation. In particular, do not confuse main-server `hermes_web_extract` with Codex-focused MCP `hermes_extract_page`.
+
+## 10. Publication
+
+Only after the checks above pass:
+
+- create/push the intended tag;
+- publish the GitHub release artifacts;
+- publish to PyPI as a separate explicit action when intended;
+- verify the public version on each published channel;
+- restart/reconnect any live MCP deployments whose tool schema changed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,126 @@
+# Hermes GPT documentation map
+
+This file tells humans and agents which documents are current, which are historical, and where to verify behavior before making changes.
+
+## Source-of-truth order
+
+When documents disagree, use this precedence:
+
+1. **Runtime code and tests** for the checked-out version.
+2. **Current operational docs** listed below.
+3. **Current release notes and CHANGELOG** for version history and known limitations.
+4. **Design, risk, counsel, and release-planning artifacts** for historical intent and provenance only.
+5. **FEASIBILITY.md** for the original machine-specific feasibility probe only.
+
+A design document describes intended architecture. It does not override implemented code or tests.
+
+## Current version context
+
+Repository version: **0.6.0**.
+
+The final GitHub release is `v0.6.0`. PyPI is an independent distribution channel and can lag the repository release. Check the PyPI badge in the root README before assuming `pip install hermes-gpt` contains a particular feature set.
+
+## Current operational docs
+
+| Document | Authority | Use it for |
+| --- | --- | --- |
+| [`../README.md`](../README.md) | current | project overview, current release, quickstart, safety invariants, entry-point selection |
+| [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration |
+| [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
+| [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |
+| [`updating.md`](updating.md) | current | check-first Git and PyPI update behavior |
+| [`retention-policy.md`](retention-policy.md) | current | local diagnostic artifact retention and cleanup |
+| [`release-notes-v0.6.0.md`](release-notes-v0.6.0.md) | current release record | shipped v0.6 behavior and known limitations |
+| [`../RELEASE_CHECKLIST.md`](../RELEASE_CHECKLIST.md) | maintainer | release verification and publication gates |
+| [`../CHANGELOG.md`](../CHANGELOG.md) | historical/current | concise version history |
+
+## Tool-name namespaces
+
+Do not infer tool names from a different MCP surface.
+
+The main Hermes GPT server and the curated Codex MCP server overlap but are not identical.
+
+Important example:
+
+- main server page extraction: `hermes_web_extract`
+- Codex-focused MCP page extraction: `hermes_extract_page`
+
+Before generating a tool call, verify the active server/toolset and exact registered name.
+
+## Current safety invariants
+
+These should remain true across documentation and implementation:
+
+- local loopback is the default network boundary;
+- public unauthenticated Operator hosting is unsupported;
+- default behavior is read-only;
+- mutating Operator tools are opt-in and dry-run-first;
+- direct mutation requires server direct mode plus the individual call's mutation/confirmation gates;
+- Owner Mode is break-glass and does not bypass secret-path restrictions;
+- protected execution paths use fixed argv and `shell=False`;
+- raw prompts are not persisted in Operator audit records;
+- Mission Control excludes raw messages, memory bodies, transcripts, request dumps, credentials, and profile-secret bodies;
+- Work Contract validation is observed-state and fail-closed;
+- Swarm final approval is a human Owner-level gate;
+- Codex is never a Swarm implementation owner.
+
+## Mission Control allowlist semantics
+
+`HERMES_GPT_MISSION_ALLOWED_SURFACES` is restrictive when configured:
+
+- unset: all read-only Mission Control surfaces are available;
+- comma-separated list: only listed valid surfaces are available;
+- empty value: no Mission Control surfaces are available.
+
+Do not describe the unset state as "deny by default". The implementation defaults to all read-only Mission Control surfaces when the variable is absent.
+
+## Historical release notes
+
+These are version records, not current setup instructions:
+
+- [`release-notes-v0.5.0.md`](release-notes-v0.5.0.md)
+- [`release-notes-v0.5.0b2.md`](release-notes-v0.5.0b2.md)
+- [`release-notes-v0.5.0b1.md`](release-notes-v0.5.0b1.md)
+- [`release-notes-v0.4.0.md`](release-notes-v0.4.0.md)
+- [`release-notes-v0.3.0.md`](release-notes-v0.3.0.md)
+- [`release-notes-v0.2.0.md`](release-notes-v0.2.0.md)
+
+## Historical and internal artifacts
+
+The following directories contain valuable provenance, but they are not operational source-of-truth documents:
+
+- `design/` - v0.6 technical design documents written before or during implementation.
+- `releases/` - release brief, integrated plan, risk reviews, counsel packet, and surface manifest created during pre-release work.
+
+Some of these files intentionally preserve phrases such as "candidate", "gate", or "before release" because they record the state at the time they were written. Agents must not treat those historical status statements as the current release state.
+
+When using an internal artifact:
+
+1. read it for rationale or constraints;
+2. verify every implementation claim against current code/tests;
+3. verify every release-status claim against the current GitHub release and current operational docs;
+4. do not copy machine-specific paths, identities, metrics, or approval history into new public docs unless required and still accurate.
+
+## Agent reading protocol
+
+For repository work, use this sequence:
+
+1. Read `AGENTS.md`.
+2. Read this file.
+3. Read `pyproject.toml` to establish the checked-out version and package surface.
+4. Read the relevant current operational doc.
+5. Inspect the implementation module and its tests before changing behavioral documentation.
+6. If working from a design/release artifact, treat it as a hypothesis until code/tests confirm it.
+7. After a behavior change, update the smallest canonical doc set that prevents drift.
+
+## Documentation maintenance rules
+
+- Put current instructions before historical context.
+- Prefer exact environment variable and tool names over prose aliases.
+- State defaults explicitly.
+- Distinguish read-only, dry-run, direct, and Owner authority.
+- Separate "Codex as MCP client" from "Codex CLI as delegated worker".
+- Keep examples minimal and copyable.
+- Link to one canonical explanation instead of duplicating large sections across files.
+- Mark time-sensitive distribution state clearly. Do not imply PyPI and GitHub releases are automatically synchronized.
+- Never document secrets, live credentials, bearer tokens, private keys, or raw prompt/transcript content.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,38 +1,58 @@
-# Hermes GPT for Codex
+# Hermes GPT and Codex
 
-Hermes GPT can expose selected local Hermes Agent capabilities to the Codex app, Codex CLI, and Codex IDE integration through a local MCP server. It is a local bridge; it does not patch Codex, store OpenAI credentials, bypass approvals, or enable writes by default.
+Hermes GPT supports **two different Codex workflows**. Keep them separate when configuring systems or generating tool calls.
 
-## Install
+1. **Codex as an MCP client**: Codex loads a curated Hermes GPT MCP server and calls Hermes tools.
+2. **Codex CLI as a delegated worker/reviewer**: ChatGPT or another trusted client calls the normal Hermes GPT Operator server, which launches bounded async Codex CLI jobs through `hermes_codex_*`.
 
-Set the base gates in the environment that will launch Codex, then install the MCP entry:
+The first workflow uses the Codex/MCP feature gates. The second uses Operator `workspace` authority plus the Codex runner gate.
+
+For documentation authority rules, see [docs/README.md](README.md).
+
+## Workflow A: Codex as an MCP client
+
+### Install the MCP entry
+
+Set the base gates in the environment that launches Codex:
 
 ```powershell
 $env:HERMES_GPT_ENABLE_CODEX="1"
 $env:HERMES_GPT_ENABLE_MCP="1"
+```
+
+Install the core toolset:
+
+```powershell
 hermes-gpt codex install --toolset core
 hermes-gpt codex doctor
 ```
 
-`install` uses `codex mcp add hermes-gpt -- ...` when the Codex CLI is available. If it must edit TOML directly, it first validates the config, creates a timestamped backup, preserves unrelated configuration, and adds only `[mcp_servers."hermes-gpt"]` plus its environment table. It is idempotent.
+`install` prefers `codex mcp add hermes-gpt -- ...` when the Codex CLI supports it. If Hermes GPT must edit TOML directly, it validates the config, creates a timestamped backup, preserves unrelated settings, and changes only the Hermes GPT MCP entry. The operation is idempotent.
 
-`core` is the backward-compatible default. For the opt-in Operator control plane:
+For the opt-in Operator alias toolset:
 
 ```powershell
 hermes-gpt codex install --toolset operator --refresh
 hermes-gpt codex doctor
 ```
 
-Different requested settings require `--refresh`, which backs up and replaces only the Hermes GPT entry. Existing entries without a toolset are treated as `core`.
+Changing an existing toolset requires `--refresh`, which backs up and replaces only the Hermes GPT entry. Existing entries with no toolset metadata are treated as `core`.
 
-For a repository-local entry, run the command from inside that repository:
+### Repository-local configuration
+
+Run from the target Git repository:
 
 ```powershell
 hermes-gpt codex install --project
 ```
 
-This creates or updates `<git-root>/.codex/config.toml`; Codex CLI currently has no project-scope switch for `mcp add`.
+This creates or updates:
 
-## Verify and remove
+```text
+<git-root>/.codex/config.toml
+```
+
+### Verify or remove
 
 ```powershell
 hermes-gpt codex print-config
@@ -40,60 +60,180 @@ hermes-gpt codex doctor
 hermes-gpt codex uninstall
 ```
 
-`doctor` is read-only. It checks the Codex binary/version, target config, MCP registry, base gates, gateway status, and redaction smoke path. `uninstall` removes only the Hermes GPT MCP tables and makes a backup first.
+`doctor` is read-only. `uninstall` removes only Hermes GPT MCP configuration and creates a backup first.
 
-Before reinstalling a connector after a release, run `hermes-gpt update` to check safely; use `hermes-gpt update --apply` only when you are ready to update the checkout or installed package. See [updating](updating.md) for the exact safety behavior.
+### Core Codex MCP tools
 
-## Available Codex tools
+The curated Codex MCP server registers these names:
 
 | Tool | Behavior |
 | --- | --- |
-| `hermes_status` | Local Hermes GPT/gateway status, including state-file PID fallback. |
-| `hermes_capabilities` | Enabled features and the gate required for disabled ones. |
-| `hermes_plan` | Compact, read-only repository context and implementation plan. |
-| `hermes_vision_analyze` | Approved local raster image analysis. |
-| `hermes_web_search` | Search only; no pages are fetched. |
-| `hermes_extract_page` | Public HTTP(S) content extraction. |
-| `hermes_cron_plan` | Dry-run cron proposal from a simple schedule request. |
-| `hermes_cron_create` | Explicitly confirmed, tightly gated creation. |
-| `hermes_author_skill` | Skill draft by default; write requires explicit gates. |
-| `hermes_gateway_diagnostics` | Read-only gateway and PID diagnostics. |
+| `hermes_status` | Local Hermes GPT / gateway status. |
+| `hermes_capabilities` | Enabled features and missing gates. |
+| `hermes_plan` | Compact read-only repository context and implementation plan. |
+| `hermes_vision_analyze` | Analyze an approved local raster image. |
+| `hermes_web_search` | Search the web without fetching result pages. |
+| `hermes_extract_page` | Extract readable public HTTP(S) content with network safety checks. |
+| `hermes_cron_plan` | Produce a dry-run cron proposal. |
+| `hermes_cron_create` | Create a cron job only through explicit write/confirmation gates. |
+| `hermes_author_skill` | Draft a skill; writes require explicit gates. |
+| `hermes_gateway_diagnostics` | Read-only gateway diagnostics. |
 
-The `operator` toolset adds namespaced aliases for Operator diagnostics, audit, cron, skills, non-secret config/environment, and gateway operations. It excludes workspace, git, raw command, Owner patch, and Owner write tools. Existing Operator gates remain authoritative.
+The `operator` toolset adds curated namespaced aliases for Operator diagnostics, audit, cron, skills, non-secret config/environment, and gateway operations. It intentionally excludes broad workspace, raw git/command, and Owner file-write surfaces.
 
-## Codex jobs through Hermes GPT
+### Tool-name namespace warning
 
-The normal Operator server exposes `hermes_codex_status`, `hermes_codex_plan`, `hermes_codex_start`, `hermes_codex_review_start`, `hermes_codex_jobs`, `hermes_codex_job_status`, `hermes_codex_job_result`, and `hermes_codex_cancel`.
+The curated Codex MCP server is not identical to the main Hermes GPT server.
 
-Execution requires Operator Mode at `workspace` or acknowledged `owner` level, direct apply mode, an approved work directory, `HERMES_GPT_ENABLE_CODEX_RUNNER=1`, `confirm=true`, and `dry_run=false`. Add `HERMES_GPT_ALLOW_CODEX_WRITE=1` only for `workspace-write`; read-only jobs do not need it.
+Important example:
 
-The Codex CLI executable is resolved at status and launch time. Set `HERMES_GPT_CODEX_EXE` to an absolute path when you want to pin a specific standalone CLI — for example when a Windows desktop app install puts a protected `WindowsApps` shim earlier in `PATH` that fails with `WinError 5`. The resolver validates that the path exists, is a regular file, is not under `WindowsApps`, and answers `codex --version` before it is used; otherwise it walks `PATH` and skips protected or unlaunchable candidates. `hermes_codex_status` reports the chosen `codex_path` and `codex_source` (`env`, `path`, or `none`) so availability is never reported for an executable that cannot actually launch.
+```text
+main Hermes GPT server:  hermes_web_extract
+Codex-focused MCP:       hermes_extract_page
+```
 
-The work directory must be a trusted Git repository for the Codex CLI. If a job fails with `Not inside a trusted directory and --skip-git-repo-check was not specified`, run `codex trust` (or `git init`) in the work directory and retry.
+Agents must verify which MCP server/toolset is active before generating calls. Do not substitute a familiar tool name from another surface.
 
-Jobs use fixed arguments, `shell=False`, bounded timeouts, prompt hashes instead of raw prompt persistence, and redacted bounded results. Danger-full-access, bypass flags, arbitrary commands/config, executable paths, and extra directories are unsupported. Operator Mode is not a sandbox, and these tools do not bypass Codex permissions.
+### Feature gates for the core toolset
 
-For a Windows setup where ChatGPT connects through a private tunnel and Hermes dispatches approved jobs to the standalone Codex CLI, see [ChatGPT to Codex through Hermes GPT on Windows](windows-chatgpt-codex.md).
-
-## Safety model
-
-The server launches even when gates are absent, so Codex can list the tool schemas and receive an actionable blocked response. The base gates are:
+Base gates:
 
 ```text
 HERMES_GPT_ENABLE_CODEX=1
 HERMES_GPT_ENABLE_MCP=1
 ```
 
-Individual feature gates are `HERMES_GPT_ENABLE_VISION=1`, `HERMES_GPT_ENABLE_WEB=1`, `HERMES_GPT_ENABLE_CRON=1`, and `HERMES_GPT_ENABLE_DIAGNOSTICS=1`.
-
-Every persistent action is dry-run by default. Direct skill or cron writes require the base/feature gates plus `HERMES_GPT_ALLOW_WRITE=1` and the relevant `HERMES_GPT_ALLOW_SKILL_WRITE=1` or `HERMES_GPT_ALLOW_CRON_WRITE=1`; existing Hermes Operator Mode policy and direct-apply gates remain in force too.
-
-Local image paths resolve symlinks, must remain under an explicit `project_root` (or `HERMES_GPT_CODEX_ALLOWED_ROOTS`), and reject secret paths and unsupported types. Web extraction accepts only public HTTP(S) URLs; it blocks file URLs, localhost, private/loopback/link-local/reserved IPs, and metadata targets unless the explicit private-network override is set. Returned text is redacted for common API keys, provider/GitHub tokens, bearer/cookie/session values, and private keys.
-
-## Example Codex prompts
+Optional capabilities use gates such as:
 
 ```text
-Use hermes_plan to inspect this repository and produce a dry-run build plan. Do not edit files.
+HERMES_GPT_ENABLE_VISION=1
+HERMES_GPT_ENABLE_WEB=1
+HERMES_GPT_ENABLE_CRON=1
+HERMES_GPT_ENABLE_DIAGNOSTICS=1
+```
+
+Persistent core-tool writes are dry-run-first. Skill or cron writes require the appropriate write gates in addition to the feature gates and any applicable Operator policy.
+
+### Core-tool safety behavior
+
+- Local image paths resolve symlinks and must stay within an approved project root / allowed root.
+- Secret-looking paths are rejected.
+- Web extraction accepts public HTTP(S) URLs by default and rejects file URLs, localhost, private/loopback/link-local/reserved addresses, and metadata targets unless a specific private-network override is deliberately enabled.
+- Returned structured text is recursively redacted for common secret/token/cookie/private-key patterns.
+- The MCP server launches even when optional gates are absent so tools can return an actionable blocked response rather than disappearing silently.
+
+## Workflow B: Codex CLI as a delegated worker or reviewer
+
+This workflow uses the **normal Hermes GPT Operator server**, not the curated Codex-as-client MCP server.
+
+Tools:
+
+- `hermes_codex_status`
+- `hermes_codex_plan`
+- `hermes_codex_start`
+- `hermes_codex_review_start`
+- `hermes_codex_jobs`
+- `hermes_codex_job_status`
+- `hermes_codex_job_result`
+- `hermes_codex_cancel`
+
+### Required authority for real execution
+
+A real job requires:
+
+- Operator Mode enabled;
+- Operator level `workspace` or acknowledged `owner`;
+- the work directory allowed by Operator policy;
+- `HERMES_GPT_ENABLE_CODEX_RUNNER=1`;
+- `HERMES_GPT_OPERATOR_APPLY_MODE=direct`;
+- `confirm=true`;
+- `dry_run=false`.
+
+For `sandbox=workspace-write`, also set:
+
+```text
+HERMES_GPT_ALLOW_CODEX_WRITE=1
+```
+
+Read-only jobs do not need the write gate.
+
+**The runner path does not require `HERMES_GPT_ENABLE_CODEX` or `HERMES_GPT_ENABLE_MCP`.** Those two gates belong to Workflow A, where Codex itself is the MCP client.
+
+### Codex executable resolution
+
+Hermes GPT resolves a launchable standalone Codex CLI at status and launch time.
+
+To pin a specific executable:
+
+```powershell
+$env:HERMES_GPT_CODEX_EXE="C:\path\to\codex.exe"
+```
+
+The override must resolve to an existing regular file, must not be under a protected `WindowsApps` path, and must pass a `codex --version` probe.
+
+Without an override, Hermes GPT searches `PATH`, skips protected or unlaunchable candidates, and reports the selected path/source through `hermes_codex_status`.
+
+Important status fields include:
+
+- `codex_available`
+- `codex_path`
+- `codex_source`
+- `codex_version` when available
+- `codex_reason` when unavailable
+
+### Work-directory requirements
+
+The work directory must be both:
+
+1. allowed by Hermes GPT Operator policy; and
+2. acceptable to the Codex CLI as a trusted Git workspace.
+
+If Codex reports that the directory is not trusted, use a dedicated intended repository and establish trust there. Do not weaken Hermes GPT's path gates or initialize Git in a broad personal directory merely to satisfy the CLI.
+
+### Runner safety model
+
+Delegated jobs use:
+
+- fixed argument construction;
+- `shell=False`;
+- bounded timeouts;
+- supported sandboxes only (`read-only`, `workspace-write`);
+- bounded/redacted result material;
+- prompt hashes rather than raw prompt persistence in Operator metadata/audit;
+- approved work directories only.
+
+Danger-full-access, approval bypasses, arbitrary command injection, arbitrary executable arguments, and arbitrary extra-directory grants are unsupported.
+
+Codex review jobs are also bounded. In Swarm Orchestration, Codex can be a reviewer but never an implementation owner.
+
+## Windows ChatGPT -> Codex deployment
+
+For a Windows setup where ChatGPT connects to the normal Hermes GPT Operator server through a private boundary and Hermes GPT dispatches explicitly approved jobs to the standalone Codex CLI, use:
+
+[ChatGPT to Codex through Hermes GPT on Windows](windows-chatgpt-codex.md)
+
+That guide uses Workflow B. Do not add the Workflow A MCP-client gates unless you are also installing Hermes GPT into Codex as an MCP server.
+
+## Updating before connector changes
+
+Check first:
+
+```powershell
+hermes-gpt update
+```
+
+Apply explicitly:
+
+```powershell
+hermes-gpt update --apply
+```
+
+Installed-package updates check PyPI. GitHub and PyPI releases can temporarily differ, so a newer GitHub tag does not guarantee that the installed-package updater will offer that version. See [updating](updating.md).
+
+## Example prompts for Workflow A
+
+```text
+Use hermes_plan to inspect this repository and produce a dry-run implementation plan. Do not edit files.
 ```
 
 ```text
@@ -106,9 +246,42 @@ Use hermes_vision_analyze with this project image and keep the answer concise.
 
 ## Troubleshooting
 
-- If every tool says `CODEX_DISABLED`, set both base gates in the process that starts Codex and restart Codex.
-- If `doctor` reports no MCP entry, rerun `hermes-gpt codex install`; use `--project` when you intend the current repository only.
-- If a Codex job fails with `[WinError 5] Access is denied` on Windows, the runner selected a protected `WindowsApps` shim from the desktop app install. Set `HERMES_GPT_CODEX_EXE` to the standalone CLI's absolute path (e.g. `C:\Users\<YOU>\AppData\Roaming\npm\codex.exe`), or reorder `PATH` so the standalone CLI comes before `%LOCALAPPDATA%\Microsoft\WindowsApps`.
-- If a Codex job fails with `Not inside a trusted directory`, the work directory is not trusted by the Codex CLI; run `codex trust` (or `git init`) there first.
-- If vision rejects a path, provide `project_root` and keep the image beneath it; secret files and symlink escapes are intentionally blocked.
-- If page extraction rejects a URL, use a public `http` or `https` URL. Local/private address access is intentionally not the default.
+### Every curated MCP tool says `CODEX_DISABLED`
+
+Set both Workflow A base gates in the process that starts Codex and restart Codex:
+
+```text
+HERMES_GPT_ENABLE_CODEX=1
+HERMES_GPT_ENABLE_MCP=1
+```
+
+### `codex doctor` reports no MCP entry
+
+Re-run `hermes-gpt codex install`. Use `--project` only when you want repository-local configuration.
+
+### Runner reports no launchable Codex CLI
+
+Run `hermes_codex_status` and inspect `codex_path`, `codex_source`, and `codex_reason`. Install the standalone CLI or set `HERMES_GPT_CODEX_EXE` to a validated absolute path.
+
+### Windows access-denied errors mention WindowsApps
+
+A protected desktop-app shim is being selected by an old process/configuration or outside Hermes GPT's validated resolver path. Update/restart Hermes GPT, then verify `hermes_codex_status` selects the standalone CLI outside `WindowsApps`.
+
+### Runner says the work directory is not trusted
+
+Use a dedicated Git repository intended for the job and establish Codex trust there. Keep Hermes GPT's allowed-path policy narrow.
+
+### Vision rejects a path
+
+Provide the correct project root and keep the image beneath it. Secret paths and symlink escapes are intentionally blocked.
+
+### Page extraction rejects a URL
+
+Use a public `http` or `https` URL unless a deliberate private-network override is part of your trusted deployment.
+
+## Related docs
+
+- [Documentation map](README.md)
+- [Operator Mode](operator-mode.md)
+- [Windows ChatGPT -> Codex](windows-chatgpt-codex.md)
+- [Updating](updating.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,26 @@
+# v0.6 design artifacts
+
+Files in this directory preserve technical design work produced before or during the v0.6.0 implementation.
+
+They are **historical design authority, not current runtime authority**.
+
+When a design statement differs from the current implementation or tests, use the implementation/tests as the source of truth and update current operational documentation if needed.
+
+Agents should read [../README.md](../README.md) before using these files.
+
+Use these documents for:
+
+- architecture rationale;
+- intended invariants;
+- threat/risk assumptions that informed implementation;
+- understanding why a current behavior exists.
+
+Do not use them alone to determine:
+
+- current release status;
+- current distribution-channel availability;
+- exact current tool schemas;
+- exact current environment defaults;
+- whether a pre-release gate is still pending.
+
+Before turning design text into a code or documentation change, verify the relevant implementation module and tests.

--- a/docs/operator-mode.md
+++ b/docs/operator-mode.md
@@ -1,119 +1,98 @@
-# Operator Mode for hermes-gpt
+# Operator Mode for Hermes GPT
 
-## Codex bridge posture (v0.5.0)
+Operator Mode is the policy-gated control plane for trusted MCP clients such as ChatGPT. This document describes the current v0.6.0 behavior.
 
-Codex can opt into the control plane with `hermes-gpt codex install --toolset operator --refresh`. Registration does not grant authority; the same level, profile, apply, path, redaction, and audit policy applies.
+For documentation authority and historical-artifact rules, see [docs/README.md](README.md).
 
-Trusted clients can delegate asynchronous Codex jobs through the eight `hermes_codex_*` tools. Set `HERMES_GPT_ENABLE_CODEX_RUNNER=1`; direct execution also requires workspace-or-higher level, direct mode, an allowed directory, `confirm=true`, and `dry_run=false`. `HERMES_GPT_ALLOW_CODEX_WRITE=1` is needed only for `workspace-write`. Normal jobs do not require Owner Mode, and raw prompts are not persisted.
+## Core rule
 
-`hermes-gpt` is a local MCP bridge for exposing selected Hermes Agent capabilities to trusted MCP clients like ChatGPT. It is meant to run on your machine, bound to loopback, with a tunnel in front of it only when you deliberately want remote access.
+**Tool visibility is not authority.** A tool can be present in the MCP schema and still refuse to mutate because the required policy gates are not satisfied.
 
-Operator Mode is the safer control plane inside `hermes-gpt`. It exposes operator tools, but tool visibility does not mean mutation is allowed. Whether a call can change anything depends on:
+Hermes GPT is designed to run on the user's machine, bound to loopback. Remote clients require a deliberately configured private or authenticated boundary in front of that loopback service. Public unauthenticated Operator hosting is unsupported.
 
-- the operator level
-- the server apply mode
-- the tool’s own `dry_run` argument
-- and, for owner tools, the exact break-glass acknowledgement
+Operator Mode is defense-in-depth, not an OS sandbox. Use OS-level isolation for untrusted input.
 
-Default posture should stay `dry_run` for always-on tunnel use.
+## Authority model
 
-## New user quickstart
+Operator authority is determined by four things:
 
-1. Install and run `hermes-gpt`.
-2. Start it in dry-run Operator Mode.
-3. Connect ChatGPT or another MCP client to the tunnel URL.
-4. Call:
-   - `hermes_operator_policy`
-   - `hermes_operator_status`
-   - `hermes_cron_list`
-5. Only switch to direct mode when you are doing a deliberate maintenance session.
+1. `HERMES_GPT_OPERATOR_ENABLED`
+2. `HERMES_GPT_OPERATOR_LEVEL`
+3. `HERMES_GPT_OPERATOR_APPLY_MODE`
+4. the individual tool call's mutation gates, normally `dry_run` and sometimes `confirm`
 
-## Four safety postures
+Owner operations add two more gates:
 
-### A. Read-only default
+```text
+HERMES_GPT_OWNER_ACTIVE=1
+HERMES_GPT_OWNER_ACK=I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE
+```
 
-No environment variables are needed.
+### Operator levels
 
-Behavior:
+Higher levels include the capabilities of lower levels.
 
-- status, read, list, and diff tools work
-- mutating tools refuse because Operator Mode is disabled
+| Level | What it unlocks |
+| --- | --- |
+| `read_only` | status, policy, audit, list/view/diff operations, Mission Control |
+| `cron` | cron run, pause, copy, move |
+| `skills` | skill create, edit, patch, write, copy, sync, delete |
+| `skills_config` | non-secret config and environment writes |
+| `workspace` | scoped workspace read/write/test, gateway restart, Codex jobs, contract/swarm dispatch |
+| `owner` | break-glass raw command/file operations and final swarm approval; secret paths remain denied |
 
-Example:
+`skills_config` is a reasonable ceiling for routine configuration work. Use `workspace` only when a task requires scoped workspace operations or delegated execution. Treat `owner` as break-glass.
+
+## Four operating postures
+
+### 1. Read-only default
+
+No Operator environment variables are required.
 
 ```powershell
 hermes-gpt
 ```
 
-This is the safest starting point if you only want inspection.
+Expected behavior:
 
-### B. Dry-run Operator Mode
+- read/status/list tools work where enabled;
+- mutating Operator tools refuse;
+- Mission Control remains read-only.
 
-This is the recommended always-on tunnel posture.
+### 2. Dry-run Operator Mode
 
-Behavior:
-
-- operator tools are available
-- mutating tools return plans or previews
-- nothing actually changes
-- safe default for ChatGPT connector use
-
-Example:
+Recommended for an always-on trusted connector.
 
 ```powershell
 $env:HERMES_HOME="C:\Users\<YOU>\AppData\Local\hermes"
 $env:HERMES_GPT_OPERATOR_ENABLED="1"
 $env:HERMES_GPT_OPERATOR_LEVEL="skills_config"
 $env:HERMES_GPT_OPERATOR_APPLY_MODE="dry_run"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default,hermes-researcher,hermes-trt-manager,hermes-nexus-wiki"
+$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default"
 
 python server.py --http --host 127.0.0.1 --port 4750
 ```
 
-### C. Direct Operator Mode
+Mutating tools return plans or previews but do not apply changes.
 
-Use this only when you intentionally want writes.
+### 3. Direct Operator Mode
 
-Behavior:
-
-- the server policy allows direct mutation
-- individual tool calls still must pass `dry_run=false`
-- mutation requires two gates:
-  1. server apply mode must be `direct`
-  2. the individual call must ask for `dry_run=false`
-
-Example:
+Use only for a deliberate maintenance session.
 
 ```powershell
 $env:HERMES_HOME="C:\Users\<YOU>\AppData\Local\hermes"
 $env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="skills_config"
+$env:HERMES_GPT_OPERATOR_LEVEL="workspace"
 $env:HERMES_GPT_OPERATOR_APPLY_MODE="direct"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default,hermes-researcher,hermes-trt-manager,hermes-nexus-wiki"
-
-python server.py --http --host 127.0.0.1 --port 4750
+$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default"
+$env:HERMES_GPT_OPERATOR_ALLOWED_PATHS="C:\path\to\approved-workspace"
 ```
 
-A mutating tool still needs:
+Direct mode only permits mutation. It does not force mutation. A mutating call still needs `dry_run=false`, and tools with an explicit confirmation gate also need `confirm=true`.
 
-```json
-{
-  "dry_run": false
-}
-```
-
-### D. Owner Mode
+### 4. Owner Mode
 
 Break-glass only.
-
-Behavior:
-
-- configured `owner` is clamped to effective `workspace` unless break-glass activation is explicitly enabled
-- owner tools require both the activation flag and exact owner acknowledgement
-- owner mode is not recommended for always-on tunnels
-- owner mode still denies secret paths
-
-Example:
 
 ```powershell
 $env:HERMES_GPT_OPERATOR_ENABLED="1"
@@ -123,448 +102,329 @@ $env:HERMES_GPT_OWNER_ACTIVE="1"
 $env:HERMES_GPT_OWNER_ACK="I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE"
 ```
 
-Do not use Owner Mode for public, shared, or always-on connectors.
+Configured `owner` authority is clamped unless the Owner activation and exact acknowledgement are present. Owner Mode still cannot access denied secret paths.
 
-## Operator levels
+Do not use Owner Mode for a public, shared, or always-on connector.
 
-Higher levels include the lower levels before them.
+## Dry-run and confirmation semantics
 
-| Level | What it unlocks |
-| --- | --- |
-| `read_only` | status, policy, audit tail, cron list/status, skill list/view/diff, config get, env status, gateway status, git status/diff |
-| `cron` | plus cron run, pause, copy, move |
-| `skills` | plus skill create, edit, patch, write_file, copy, sync_to_default, delete |
-| `skills_config` | plus config set/patch and non-secret env set/copy |
-| `workspace` | plus scoped workspace read/patch/write/test and gateway restart under allowed paths |
-| `owner` | break-glass raw command and raw file patch/write; still denies secret paths and requires exact owner acknowledgement |
+For a normal mutating Operator tool, actual mutation requires:
 
-`skills_config` is a good normal operator level for trusted dry-run usage.
-`workspace` is for scoped workspace file operations only under allowed paths.
-`owner` is break-glass.
-
-## Fleet routing through the local A2A registry
-
-The full Hermes GPT MCP surface includes seven fleet tools for an existing
-authenticated Hermes A2A mesh:
-
-| Tool | Access | Behavior |
-| --- | --- | --- |
-| `hermes_fleet_list` | read-only | Lists named local-registry peers; tokens and peer URLs never leave the host. |
-| `hermes_fleet_status` | read-only | Returns a bounded metadata-only compatibility summary for one named peer. |
-| `hermes_fleet_dispatch` | workspace + direct + confirmation | Submits a bounded task to one named peer. |
-| `hermes_fleet_task` | read-only | Returns task id, state, timestamp, and artifact count only. |
-| `hermes_fleet_dispatch_work_order` | workspace + direct + confirmation | Validates and submits a canonical profile-aware work order. |
-| `hermes_fleet_result` | read-only | Returns only a validated safe completion bundle. |
-| `hermes_fleet_authority_drift` | read-only | Reports registry/manifest/profile/role/Agent Card drift. |
-
-Fleet routing is intentionally narrow. All fleet tools require enabled
-read-only Operator Mode or higher. MCP callers cannot provide an endpoint,
-bearer token, SSH command, or arbitrary executable. A real dispatch requires
-all of: Operator Mode enabled at `workspace` or higher, server `direct` apply
-mode, `dry_run=false`, and `confirm=true`. The dispatch message is recorded in
-the audit log only as a length and SHA-256 digest; it is not returned in the
-tool response.
-
-`hermes_fleet_dispatch` creates remote work. Do not use it for casual probes,
-and do not leave an internet-exposed connector unauthenticated merely because
-the A2A peer mesh itself uses bearer authentication.
-
-### Fleet authority manifest and deployment
-
-Set `HERMES_GPT_FLEET_AUTHORITY_MANIFEST` to an absolute JSON file, or install
-it at `<Hermes data root>/config/fleet-authority.json`. Start from
-`examples/fleet-authority.example.json`. Version 1 has a `peers` array; each
-peer contains `name`, `expected_host_role`, `expected_card_identity`,
-`allowed_profiles`, `max_authorization`, and `allow_public_actions`. Valid
-authorization classes are `none`, `read_only`, `reversible_write`, and
-`high_impact`. Do not include URLs, credentials, or tokens.
-
-1. Install the manifest for the service account (`0600` on POSIX).
-2. Match names to the authenticated registry and set expected card identities
-   and host roles. Keep Nous Girl limited to `default`.
-3. Restart Hermes GPT, enable read-only Operator Mode, and run
-   `hermes_fleet_authority_drift`.
-4. Resolve findings before enabling workspace/direct mode. Dispatch still
-   requires `dry_run=false` and `confirm=true`. Immediately before a confirmed
-   structured dispatch, Hermes GPT runs a bounded live Agent Card check and
-   requires its identity and host role to exactly match the manifest; failure
-   stops the dispatch before the work order is sent. Dry runs remain network-free
-   apart from the local registry lookup and do not contact the peer.
-
-High-impact work additionally requires `approved=true` plus bounded
-`approved_by` and `approval_reference` metadata. Public actions on Nous Girl,
-Vault-policy edits, raw-secret requests, and work above role authority are
-rejected locally. Public-action detection examines affirmative command intent
-in the objective, so supporting filenames, review language, negated constraints,
-and acceptance checks do not become public-action requests.
-
-## Mission Control (v0.6 M0, read-only)
-
-Mission Control is a read-only operational view of the whole Hermes fleet —
-profiles, fleet agents, Codex jobs, cron activity, delegated work, failures,
-pending approvals, vault, usage, and the operator audit trail — exposed to
-trusted clients (ChatGPT first) as the `hermes_mission_*` tool family
-(`operator_mission.py`).
-
-It is structurally read-only:
-
-- every SQLite store is opened `file:...?mode=ro`; no write / dry-run / apply
-  arguments exist; no mutating shell calls are made.
-- no message, memory, transcript, request-dump, or profile-secret body ever
-  crosses the surface — prompts appear as `{prompt_len, prompt_sha256}` only,
-  delegation/kanban bodies are stripped, Codex transcripts and Vault
-  credentials are never returned, and `.env`/`auth.json`/tokens are excluded.
-- every mission call is written to the operator audit log (`dry_run=true`,
-  `changed=false`).
-
-Each surface reports `available:false + reason` when its source is absent
-(e.g. no Codex store on the host) rather than failing. Output is bounded per
-design §8.4 (overview 64 KB / hard 128 KB; surface 256 KB / hard 512 KB), with
-lists truncated via `truncated:true, count_total:N`.
-
-Per-client authorization uses the `HERMES_GPT_MISSION_ALLOWED_SURFACES`
-allowlist (deny-by-default): a comma-separated list of surface names
-(`health`, `profiles`, `fleet`, `codex`, `cron`, `delegations`, `failures`,
-`approvals`, `vault`, `usage`, `audit`, `overview`). When unset, all read-only
-surfaces are allowed; an empty value denies everything; a listed-only value
-restricts a client to that subset. This is the seam a future OAuth scope maps
-onto (design D12). Denied surfaces return `AUTHZ_DENIED`, not a data error.
-
-Mission Control requires only operator level `read_only` (the default) — it
-never needs `direct` apply mode.
-
-## Work Contracts (v0.6 M1)
-
-Work Contracts (`operator_contract.py`) add a structured work-order layer on top
-of Mission Control: declarative `hermes.work-contract/v1` documents whose
-completion is verified against **observed** state, not a worker's claim (see the
-v0.6 Work Contracts design document).
-
-Tools:
-
-- `hermes_contract_define(contract_json)` — read-only, pure. Validates and
-  canonicalizes a contract (schema, scope, forbidden actions, artifacts, tests,
-  review, criteria, authorization) and returns the canonical document
-  (redacted: objective appears only as `{prompt_len, prompt_sha256}`) plus
-  `contract_sha256`.
-- `hermes_contract_dispatch(contract_json, confirm, dry_run)` — workspace
-  level, dry-run-first. Submits the contract as a fleet work order reusing the
-  existing authority manifest, live peer verification, dry-run/confirm gates,
-  and audit. Requires a unique `task_id` and `confirm=true` + direct mode to
-  actually dispatch.
-- `hermes_contract_validate(contract_json)` — read-only by default. Returns a
-  deterministic verdict (`SATISFIED` / `NOT_SATISFIED` / `INCONCLUSIVE` /
-  `INVALID_CONTRACT`) with per-check detail and `false_done_detected`. Evidence
-  is observed-only (kanban runs, async delegations, artifacts on disk, audit
-  trail); a worker-supplied result is never proof. A valid contract with no
-  observed run returns `INCONCLUSIVE` (fail-closed), never `SATISFIED`. For
-  retries, the latest observed run is selected deterministically. Forbidden-action
-  audit evidence is scoped to the contract `task_id`, so concurrent work cannot
-  contaminate another contract's verdict. Review also remains fail-closed: a
-  distinct reviewer audit acceptance or human approval reference is required;
-  v0.6 ships no production review-accept writer, so unavailable evidence yields
-  `NOT_SATISFIED`.
-  Test checks run only through the workspace allowlist
-  (`hermes_workspace_run_test`, `shell=False`) and are individually gated at
-  workspace + direct apply mode (design D6) — at `read_only` a required test is
-  `UNVERIFIED` and the verdict is `NOT_SATISFIED`.
-- `hermes_contract_status(contract_json)` — read-only. Links a contract to its
-  observed run/delegation state (redacted summary).
-
-Every call is audited with `contract_sha256` + `task_id`; no objective text is
-ever written to the audit log or the surface.
-
-## Swarm Orchestration (v0.6 M2)
-
-Swarm Orchestration (`operator_swarm.py` + `operator_swarm_workflows.py`) is a
-workflow engine on top of Mission Control (M0) and Work Contracts (M1): a
-declarative, validated DAG of stages (see the v0.6 Swarm Orchestration design
-document). The canonical shape is
-
-```
-research → architecture → (implementation / tests / docs in parallel)
-→ integration review → Codex review → acceptance validation → HUMAN APPROVAL
+```text
+HERMES_GPT_OPERATOR_APPLY_MODE=direct
 ```
 
-Every stage is dispatched as an M1 **contract**; completion is validated by the
-M1 validator against **observed** Mission Control state, so a false "done"
-claim returns the stage for rework (bounded to one retry, then blocked for a
-human). Implementation stages run in upstream kanban **worktrees** (separate
-branch per stage; the engine never manages git itself). Codex review drives the
-existing runner unchanged (fixed argv, `shell=False`, bounded timeout, approved
-workdir) and reads only a bounded verdict JSON — never a raw transcript.
-
-Tools:
-
-- `hermes_swarm_workflow_validate(workflow_json)` — read-only, pure. Validates
-  the DAG (schema, cycles, owners, caps, per-stage contracts) and returns the
-  stage plan.
-- `hermes_swarm_workflow_create(workflow_json, confirm, dry_run)` — workspace,
-  dry-run-first. Registers a workflow instance; returns `workflow_id` + stage
-  plan. Direct requires `confirm=true`.
-- `hermes_swarm_workflow_list()` — read-only. Instances + status (running /
-  blocked / done / awaiting_approval).
-- `hermes_swarm_workflow_status(workflow_id)` — read-only. One workflow's stage
-  map, owners, verdicts, handoffs, observed runs, approval record.
-- `hermes_swarm_stage_dispatch(workflow_id, stage_id, confirm, dry_run)` —
-  workspace, dry-run-first. Dispatches one ready stage (parents done) as an M1
-  contract; respects per-workflow and per-board concurrency caps.
-- `hermes_swarm_stage_advance(workflow_id, stage_id, confirm, dry_run)` —
-  workspace, dry-run-first. Runs the M1 validator against observed state;
-  records the handoff (`from` / `to` / `artifact_refs` / `contract_verdict`);
-  promotes next ready stages. Failed validation → `returned_for_rework` once,
-  then `blocked`.
-- `hermes_swarm_approve(workflow_id, confirm, dry_run)` — **owner** level,
-  direct. Records the final human approval; the workflow never auto-advances
-  past this gate.
-
-Caps (per workflow, env-overridable `HERMES_GPT_SWARM_MAX_PARALLEL`,
-`HERMES_GPT_SWARM_BOARD_CAP`, `HERMES_GPT_SWARM_MAX_STAGES`): default 3
-concurrent stages per workflow, 4 per board, 12 stages per workflow. Workflow
-state is stored as operational JSON under the Hermes data root
-(`swarm-workflows/`), never surfaced raw; status surfaces are bounded and
-redacted via the Mission Control envelope. Every call is audited with
-`workflow_id` / `stage` / `owner` / `verdict`; no objective text is logged.
-Worktrees and Codex verdict/transcript artifacts persist for review; `default`
-cleans them after the release gate (see the retention note on every workflow).
-
-## Dry-run vs direct: the important bit
-
-`HERMES_GPT_OPERATOR_APPLY_MODE=dry_run` means mutating tools only preview.
-`HERMES_GPT_OPERATOR_APPLY_MODE=direct` means the server permits direct mutation.
-
-But every mutating call still defaults to `dry_run=true`.
-Actual mutation requires both:
-
-- `HERMES_GPT_OPERATOR_APPLY_MODE=direct`
-- tool argument `dry_run=false`
-
-Dry-run cron move:
+plus:
 
 ```json
 {
-  "source_profile": "hermes-researcher",
-  "target_profile": "default",
-  "job_id": "example-job-id",
-  "pause_source": true,
-  "test_run_target": false,
-  "dry_run": true
-}
-```
-
-Direct cron move:
-
-```json
-{
-  "source_profile": "hermes-researcher",
-  "target_profile": "default",
-  "job_id": "example-job-id",
-  "pause_source": true,
-  "test_run_target": false,
   "dry_run": false
 }
 ```
 
-The direct version only mutates if the server is already running with apply mode `direct`.
+Tools that create or dispatch external work also require `confirm=true` when their schema includes that gate.
 
-## Recommended tunnel setup
+A refusal caused by a missing gate is expected behavior, not a failure to execute the request.
 
-Keep the MCP server bound to `127.0.0.1`.
-Put the tunnel in front of loopback only.
-Keep always-on tunnel mode in `dry_run`.
-Switch to `direct` only for a deliberate maintenance session.
-Switch back to `dry_run` afterward.
-Never enable Owner Mode on an always-on tunnel.
+## Mission Control
 
-Safe tunnel posture example:
+Mission Control is the read-only `hermes_mission_*` operational view of the Hermes deployment.
 
-```powershell
-$env:HERMES_HOME="C:\Users\<YOU>\AppData\Local\hermes"
-$env:HERMES_GPT_OPERATOR_ENABLED="1"
-$env:HERMES_GPT_OPERATOR_LEVEL="skills_config"
-$env:HERMES_GPT_OPERATOR_APPLY_MODE="dry_run"
-$env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES="default,hermes-researcher,hermes-trt-manager,hermes-nexus-wiki"
+Surfaces:
 
-python server.py --http --host 127.0.0.1 --port 4750
+- `overview`
+- `health`
+- `profiles`
+- `fleet`
+- `codex`
+- `cron`
+- `delegations`
+- `failures`
+- `approvals`
+- `vault`
+- `usage`
+- `audit`
+
+Mission Control is structurally read-only:
+
+- SQLite sources are opened read-only;
+- no Mission tool accepts write/apply arguments;
+- no mutating shell action is performed;
+- every Mission call is audited as unchanged/read-only;
+- missing optional sources return a bounded unavailable reason instead of crashing the whole view.
+
+### Data boundary
+
+Mission Control never returns raw message, memory, transcript, request-dump, credential, token, vault-secret, or profile-secret bodies.
+
+Prompt-like text is represented by bounded metadata such as `prompt_len` and `prompt_sha256`. Free-text operational fields such as failures, audit summaries, cron names, and delegation summaries receive conservative secret and PII stripping before they leave the host.
+
+### Surface allowlist
+
+`HERMES_GPT_MISSION_ALLOWED_SURFACES` is **restrictive when configured**.
+
+- **unset:** all read-only Mission Control surfaces are available;
+- **comma-separated list:** only listed valid surfaces are available;
+- **empty value:** every Mission Control surface is denied.
+
+Do not describe the unset state as deny-by-default. The implementation deliberately makes all read-only Mission surfaces available when the variable is absent.
+
+Mission Control requires only `read_only` authority and never needs direct apply mode.
+
+## Work Contracts
+
+Work Contracts add a structured, verifiable work-order layer through `hermes_contract_*`.
+
+| Tool | Authority | Purpose |
+| --- | --- | --- |
+| `hermes_contract_define(contract_json)` | read-only | Validate and canonicalize a contract. |
+| `hermes_contract_dispatch(contract_json, confirm, dry_run)` | workspace | Dispatch a validated contract through the existing fleet authority model. |
+| `hermes_contract_validate(contract_json)` | read-only by default | Validate completion from observed evidence. |
+| `hermes_contract_status(contract_json)` | read-only | Link the contract to bounded observed run/delegation state. |
+
+### Validation model
+
+A worker's claim that work is complete is never proof by itself. Validation inspects observed state such as runs, artifacts, tests, audit evidence, and required review evidence.
+
+Verdicts are bounded to:
+
+- `SATISFIED`
+- `NOT_SATISFIED`
+- `INCONCLUSIVE`
+- `INVALID_CONTRACT`
+
+Missing evidence fails closed. A valid contract with no observed run cannot become `SATISFIED`.
+
+Retry selection is deterministic. Forbidden-action audit evidence is scoped to the contract's task identity so unrelated concurrent work does not contaminate the verdict.
+
+### Review limitation in v0.6.0
+
+v0.6.0 has no production review-accept writer. If a contract requires review, the necessary evidence must already exist through an authorized external reviewer/audit path or human approval reference. If it does not exist, validation returns `NOT_SATISFIED`.
+
+Required test checks execute only through the workspace test allowlist and inherit the workspace/direct policy gates.
+
+## Swarm Orchestration
+
+Swarm Orchestration is the `hermes_swarm_*` DAG workflow layer built on Work Contracts.
+
+Canonical workflow shape:
+
+```text
+research -> architecture -> implementation/tests/docs
+         -> integration review -> Codex review
+         -> acceptance validation -> HUMAN APPROVAL
 ```
 
-## Profile root normalization
+Tools:
 
-Hermes data root is usually:
+| Tool | Authority | Purpose |
+| --- | --- | --- |
+| `hermes_swarm_workflow_validate(workflow_json)` | read-only | Validate schema, owners, caps, contracts, dependencies, and cycles. |
+| `hermes_swarm_workflow_create(workflow_json, confirm, dry_run)` | workspace | Register a workflow instance. |
+| `hermes_swarm_workflow_list()` | read-only | List bounded workflow status. |
+| `hermes_swarm_workflow_status(workflow_id)` | read-only | Return one bounded stage/owner/verdict/handoff view. |
+| `hermes_swarm_stage_dispatch(workflow_id, stage_id, confirm, dry_run)` | workspace | Dispatch one ready stage as a Work Contract. |
+| `hermes_swarm_stage_advance(workflow_id, stage_id, confirm, dry_run)` | workspace | Validate observed completion, record handoff, and promote ready children. |
+| `hermes_swarm_approve(workflow_id, confirm, dry_run)` | owner | Record the final human approval. |
 
-- Windows: `C:\Users\<YOU>\AppData\Local\hermes`
-- Unix/macOS style: `~/.hermes`
+Default caps, unless explicitly overridden by the supported environment variables:
 
-If `HERMES_HOME` points to a named profile or `hermes-agent`, `hermes-gpt` normalizes back to the data root for operator profile operations.
-The default profile maps to the data root.
-Named profiles map to `profiles/<profile-name>`.
+- 3 concurrent stages per workflow;
+- 4 concurrent stages per board;
+- 12 stages per workflow.
 
-## Audit logs
+Failed validation can return a stage for one bounded rework retry. A second failure blocks the stage for human attention.
 
-Audit log path:
+Codex may provide a bounded review verdict, but Codex is never an implementation owner. Final workflow approval is human and Owner-gated.
 
-- `%USERPROFILE%\AppData\Local\hermes\logs\hermes_gpt_operator_audit.jsonl` (preferred)
-- `<hermes-gpt>\logs\hermes_gpt_operator_audit.jsonl` (fallback)
+## Fleet routing through the local A2A registry
 
-What is logged:
+Fleet routing uses only peers already present in the authenticated local Hermes A2A registry.
 
-- timestamp
-- tool name
-- level
-- apply mode
-- dry_run flag
-- success / changed / summary
-- error summary when a call fails
-- profile or profiles involved
-- path summary
-- job id, skill name, or key when relevant
-- prompt/content length plus SHA-256 for content-bearing calls
+| Tool | Authority | Behavior |
+| --- | --- | --- |
+| `hermes_fleet_list` | read-only | List named peers without exposing tokens or peer URLs. |
+| `hermes_fleet_status` | read-only | Return bounded compatibility metadata for one peer. |
+| `hermes_fleet_dispatch` | workspace + direct + confirm | Submit bounded work to one named peer. |
+| `hermes_fleet_task` | read-only | Return bounded task state. |
+| `hermes_fleet_dispatch_work_order` | workspace + direct + confirm | Validate and submit a structured profile-aware work order. |
+| `hermes_fleet_result` | read-only | Return a validated safe completion bundle. |
+| `hermes_fleet_authority_drift` | read-only | Report registry/manifest/profile/role/Agent Card drift. |
 
-What is never logged:
+MCP callers cannot supply an arbitrary peer endpoint, bearer token, SSH command, or executable.
 
-- raw `.env` values
-- full prompts
-- full config values when they may contain secrets
-- vault contents
-- command output likely to contain secrets
+### Fleet authority manifest
 
-Prompt/content is represented by length and hash only, not raw text.
+Set `HERMES_GPT_FLEET_AUTHORITY_MANIFEST` to an absolute JSON path or use the default location under the Hermes data root:
+
+```text
+<Hermes data root>/config/fleet-authority.json
+```
+
+Start from `examples/fleet-authority.example.json`.
+
+The manifest defines expected peer identity/role/profile authority. It must not contain URLs, credentials, or tokens. Before direct structured dispatch, Hermes GPT rechecks live peer identity and role against this server-controlled manifest. A mismatch stops dispatch.
+
+High-impact structured work additionally requires bounded approval metadata. Public-action detection and role authority are enforced locally before work is sent.
+
+## Codex CLI jobs through the Operator server
+
+This is different from installing Hermes GPT as an MCP server inside Codex.
+
+The normal Operator server exposes asynchronous delegated Codex tools:
+
+- `hermes_codex_status`
+- `hermes_codex_plan`
+- `hermes_codex_start`
+- `hermes_codex_review_start`
+- `hermes_codex_jobs`
+- `hermes_codex_job_status`
+- `hermes_codex_job_result`
+- `hermes_codex_cancel`
+
+Real execution requires:
+
+- Operator Mode at `workspace` or acknowledged `owner` level;
+- an allowed work directory;
+- `HERMES_GPT_ENABLE_CODEX_RUNNER=1`;
+- direct apply mode;
+- `confirm=true`;
+- `dry_run=false`.
+
+`HERMES_GPT_ALLOW_CODEX_WRITE=1` is required only for `workspace-write`. Read-only Codex jobs do not need it.
+
+`HERMES_GPT_CODEX_EXE` can pin an absolute standalone Codex CLI executable. Hermes GPT rejects protected WindowsApps shims and executables that fail a version probe.
+
+For Codex acting as an MCP client, use [docs/codex.md](codex.md). For the Windows ChatGPT -> Hermes GPT -> Codex CLI deployment, use [windows-chatgpt-codex.md](windows-chatgpt-codex.md).
+
+## Audit behavior
+
+Preferred audit path on Windows:
+
+```text
+%USERPROFILE%\AppData\Local\hermes\logs\hermes_gpt_operator_audit.jsonl
+```
+
+Fallback:
+
+```text
+<hermes-gpt>\logs\hermes_gpt_operator_audit.jsonl
+```
+
+Audit records contain bounded operational metadata such as tool, level, apply mode, dry-run state, changed/success state, relevant IDs, and length/hash metadata for content-bearing operations.
+
+Audit records do not intentionally persist raw prompts, `.env` values, vault contents, credentials, or full secret-bearing config values.
 
 ## Diagnostics and recovery
 
-v0.3.0 adds reliability tools to inspect and recover the operator surface safely.
+### `hermes_operator_doctor`
 
-### hermes_operator_doctor
+Read-only deep health check across the Operator surface. Checks include gateway state, config/env readability, cron/skills, policy, audit readability, and connector capability.
 
-Run this when something feels off: gateway not responding, cron jobs not firing, skills missing, or tools return unexpected failures.
+Status vocabulary:
 
-It checks:
+- `PASS`
+- `WARN`
+- `FAIL`
+- `UNSUPPORTED`
 
-- operator runtime reachability
-- gateway PID / heartbeat
-- config.yaml readability
-- .env readability (names only)
-- cron registry readability
-- skills registry readability
-- operator policy validity
-- last audit record readability
-- connector / API bridge capability (reported as UNSUPPORTED unless a real command/API exists)
+### `hermes_operator_snapshot`
 
-Each check returns one of: `PASS`, `WARN`, `FAIL`, `UNSUPPORTED`. The overall result is the worst non-unsupported status. If anything fails, the tool recommends `hermes_operator_recover` with `apply=false` first.
+Returns one bounded current-state summary with a recommended next action.
 
-Example overall statuses:
+### `hermes_operator_recover`
 
-- `PASS` — everything looks healthy.
-- `WARN` — attention recommended (e.g., stale heartbeat, missing optional files).
-- `FAIL` — action required (e.g., dead gateway PID, unreadable cron registry).
-- `UNSUPPORTED` — a capability is not implemented; not a failure.
+Conservative recovery planner. Dry-run is the default. Use `apply=false` first.
 
-### hermes_operator_snapshot
+Actual recovery mutation requires `apply=true` plus the normal direct/workspace policy gates.
 
-Returns a single JSON summary of current state: version, profile, gateway status, cron summary, env summary, skills count, last audit timestamp, repo status, known issues, and a recommended next action. Use it for quick status checks or before running recovery.
+### `hermes_release_doctor`
 
-### hermes_operator_recover
+Use before preparing a release. It checks repository state, secret-file hygiene, package version/docs consistency, import/compile health, and that the server is not left in direct mode. `full_tests=true` also runs the test suite.
 
-Dry-run by default. It plans a recovery sequence:
+Release statuses are `PASS`, `WARN`, or `BLOCKED`.
 
-1. read config
-2. validate env
-3. restart gateway if the doctor check failed
-4. check connector routes (reported as UNSUPPORTED)
-5. recheck cron
-6. recheck skill index
-7. write audit record
+## Profile and path normalization
 
-To actually mutate, pass `apply=true` and ensure the server is in direct operator mode with level `workspace` or higher. Without those gates, recovery stays a plan.
+Typical Hermes data roots:
 
-### hermes_release_doctor
+- Windows: `C:\Users\<YOU>\AppData\Local\hermes`
+- Unix/macOS: `~/.hermes`
 
-Run before tagging a release. Fast checks by default:
+If `HERMES_HOME` points at a named profile or the Hermes Agent source directory, Operator profile operations normalize back to the Hermes data root. The default profile maps to that root; named profiles map under `profiles/<profile-name>`.
 
-- git repo / branch / dirty tree
-- secret-file scan (`.env`, `*.pem`, `*.key`, auth/token files, etc.)
-- `pyproject.toml` version
-- CHANGELOG/README/docs mention the current package version
-- import / py_compile checks
-- operator apply mode is not direct
+`HERMES_GPT_OPERATOR_ALLOWED_PATHS` should contain only the workspaces the Operator server is expected to touch.
 
-Pass `full_tests=true` to also run the pytest suite. Results are classified as `PASS`, `WARN`, or `BLOCKED`; the expected release version is derived from package metadata.
+## Remote access posture
 
-### Structured errors
+Keep the MCP server bound to `127.0.0.1`.
 
-Operator-facing failures now return a safe envelope:
+For a remote client:
 
-```json
-{
-  "success": false,
-  "ok": false,
-  "error": "safe human message",
-  "layer": "gateway",
-  "code": "GATEWAY_UNREACHABLE",
-  "safe_message": "Gateway status could not be verified.",
-  "suggested_action": "Run hermes_operator_recover with apply=false first.",
-  "trace_id": "..."
-}
-```
+1. keep Hermes GPT on loopback;
+2. put an authenticated/private boundary in front of it;
+3. use `dry_run` for routine always-on access;
+4. switch to `direct` only for a deliberate maintenance session;
+5. switch back after the session;
+6. never leave Owner Mode enabled on an always-on connector.
 
-Legacy fields (`success`, `error`) are preserved. Secrets, env values, and absolute paths are redacted.
+Operator Mode itself does not add public-network authentication.
 
-## What is still denied
+## Secret-path policy
 
-The server still refuses or redacts access to:
+The server refuses or redacts access to secret-looking locations even at high authority, including categories such as:
 
-- `.env`
-- auth files
-- token files
-- vault files
-- SSH keys
-- OAuth files
-- cookies
-- MCP token files
-- secret-looking filenames
+- `.env` files;
+- auth/token/cookie stores;
+- vault secrets;
+- SSH keys;
+- AWS credential paths;
+- MCP token files;
+- other secret-looking filenames.
 
-That denial applies even in higher modes.
+Owner Mode does not disable this policy.
 
 ## Troubleshooting
 
-### I only see 5 tools
+### Connector shows an old or incomplete tool list
 
-- Reconnect the connector.
-- Create a new connector name if the old one is cached.
-- Verify `/mcp` directly with list-tools.
-- If direct list-tools shows 39 tools, the server is fine and the connector registration is stale.
+- Verify the running server process is the one you expect.
+- Inspect the MCP tool list directly.
+- Reconnect or recreate the client connector if it cached an older schema.
+- Do not rely on a fixed expected tool count; the count changes as gated surfaces evolve.
 
-### Profile appears missing
+### A profile appears missing
 
 - Check `HERMES_HOME`.
-- Confirm root normalization back to the data root.
-- Remember that default resolves to the data root, while named profiles map under `profiles/<profile-name>`.
+- Confirm root normalization.
+- Remember that `default` resolves to the data root while named profiles live under `profiles/<profile-name>`.
 
-### Mutating tools refuse
+### A mutating tool refuses
 
-Check all of these:
+Check the exact tool's requirements plus:
 
 - `HERMES_GPT_OPERATOR_ENABLED`
 - `HERMES_GPT_OPERATOR_LEVEL`
 - `HERMES_GPT_OPERATOR_APPLY_MODE`
-- the tool call’s `dry_run` argument
+- `dry_run`
+- `confirm` when the tool defines that gate
 
-A refusal here is usually correct behavior, not a bug.
+A policy refusal is often the correct result.
 
 ### Owner tools refuse
 
-That is expected unless the exact owner acknowledgement is set:
+Verify both Owner activation and the exact acknowledgement string:
 
 ```powershell
+$env:HERMES_GPT_OWNER_ACTIVE="1"
 $env:HERMES_GPT_OWNER_ACK="I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE"
 ```
 
-If the string differs, owner tools should still refuse.
+## Related docs
 
-## Keep in mind
-
-- Operator Mode is not a sandbox.
-- Public exposure is not safe without real auth.
-- Direct mode is not the default.
-- Owner Mode is not safe for always-on use.
-- Use OS isolation for untrusted input.
+- [Documentation map](README.md)
+- [Codex integration](codex.md)
+- [Windows ChatGPT -> Codex](windows-chatgpt-codex.md)
+- [Updating](updating.md)
+- [Retention policy](retention-policy.md)
+- [v0.6.0 release notes](release-notes-v0.6.0.md)

--- a/docs/release-notes-v0.6.0.md
+++ b/docs/release-notes-v0.6.0.md
@@ -2,28 +2,70 @@
 
 ## Status
 
-Release candidate only. This document does not authorize a tag, publication, connector re-registration, or live ChatGPT data transmission.
+**Released.** `v0.6.0` is a final GitHub release, not a release candidate.
+
+Distribution channels are independent. A GitHub release does not prove that the same version is already available from PyPI. Check the PyPI version badge/page before telling a user or agent that `pip install hermes-gpt` installs v0.6.0.
+
+These notes describe the shipped v0.6.0 behavior. Pre-release design, risk, counsel, and planning artifacts under `docs/design/` and `docs/releases/` are retained for provenance but do not override the implementation, tests, or current operational docs.
 
 ## Mission Control (M0)
 
-v0.6.0 adds the read-only `hermes_mission_*` operational surface for bounded, audited fleet status. It uses per-surface authorization and excludes raw messages, prompts, request dumps, transcripts, memory bodies, profile secrets, and vault secrets.
+v0.6.0 adds the read-only `hermes_mission_*` operational surface for bounded, audited fleet status. It excludes raw messages, prompts, request dumps, transcripts, memory bodies, profile secrets, and vault secrets.
 
-Free-text failure, audit, cron, and delegation fields now receive a conservative PII-strip pass before surfacing: email addresses, phone-like contact numbers, `@` usernames, explicit identity labels, and common personal-name patterns are removed. Redaction can reduce diagnostic detail by design.
+Mission Control surface authorization is controlled by `HERMES_GPT_MISSION_ALLOWED_SURFACES`:
+
+- unset: all read-only Mission Control surfaces are available;
+- comma-separated list: only listed valid surfaces are available;
+- empty value: all Mission Control surfaces are denied.
+
+Free-text failure, audit, cron, and delegation fields receive a conservative PII-strip pass before surfacing. Email addresses, phone-like contact numbers, `@` usernames, explicit identity labels, and common personal-name patterns are removed. Redaction can reduce diagnostic detail by design.
 
 ## Work Contracts (M1)
 
-`hermes_contract_*` defines, dispatches, validates, and reports declarative work contracts using observed state rather than worker self-report. Validation remains fail-closed. Retry run selection is deterministic: the latest observed retry is authoritative. Forbidden-action audit checks are scoped to the specific contract task identity, preventing unrelated concurrent work from failing a contract.
+`hermes_contract_*` defines, dispatches, validates, and reports declarative work contracts using observed state rather than worker self-report. Validation is fail-closed.
 
-Review evidence remains fail-closed: a distinct reviewer audit record or a human approval reference is required. There is no production accept/review-write tool in v0.6.0, so audit-based review evidence must be produced by an already-authorized external review path; otherwise validation returns `NOT_SATISFIED`.
+Retry run selection is deterministic: the latest observed retry is authoritative. Forbidden-action audit checks are scoped to the contract task identity so unrelated concurrent work cannot fail a contract.
+
+Review evidence also remains fail-closed. A distinct reviewer audit acceptance or a human approval reference is required when the contract requires review.
+
+### Known v0.6 limitation
+
+v0.6.0 does **not** ship a production review-accept writer. Audit-based review evidence must therefore be produced by an already-authorized external review path. If required review evidence is unavailable, validation returns `NOT_SATISFIED` rather than inventing acceptance.
 
 ## Swarm Orchestration (M2)
 
-`hermes_swarm_*` provides bounded workflow orchestration on top of Work Contracts, including canonical DAG validation, capped scheduling, isolated-worktree plans, explicit ownership, dry-run/direct gates, and Codex verdict constraints. Codex is never an implementation owner and receives only bounded verdict material, never transcript or prompt bodies.
+`hermes_swarm_*` provides bounded workflow orchestration on top of Work Contracts. It includes:
+
+- canonical DAG validation;
+- capped scheduling;
+- isolated-worktree plans;
+- explicit stage ownership;
+- dry-run/direct mutation gates;
+- bounded rework;
+- Codex verdict constraints;
+- final human approval.
+
+Codex is never an implementation owner and receives only bounded verdict material, never raw transcript or prompt bodies.
 
 ## Retention
 
-See [retention-policy.md](retention-policy.md). Request dumps, Codex transcripts, M2 worktrees, and workflow/verdict records have concrete local retention windows and cleanup procedures. v0.6.0 does not install automatic deletion; cleanup is an audited maintainer operation.
+See [retention-policy.md](retention-policy.md).
 
-## Remaining release gates
+- Request dumps have a 7-day maximum retention window.
+- Codex job metadata/transcript artifacts use a 30-day retention window; `operator_codex` performs age-based cleanup during reconciliation.
+- Terminal Swarm worktrees have a 7-day maximum window once declared artifacts are preserved.
+- Terminal workflow/verdict records have a 30-day maximum window.
 
-Before any live client transmission or public release, Tony must confirm the OpenAI account tier; if consumer ChatGPT is used, confirm training opt-out and/or Temporary Chat; approve the exact surface manifest and current data-usage terms; and approve the final release/tag action. See the counsel packet and release checklist.
+There is no general background deletion daemon for every artifact class. Non-Codex cleanup remains a bounded maintainer operation unless later implementation explicitly adds and tests automation.
+
+## Security posture
+
+Hermes GPT remains a local-first MCP sidecar for a trusted machine.
+
+- Operator access is opt-in.
+- Mutations are dry-run-first and explicitly gated.
+- Owner Mode remains break-glass and does not bypass secret-path restrictions.
+- Protected subprocess execution uses fixed argv and `shell=False`.
+- Public unauthenticated Operator hosting remains unsupported.
+
+For current setup and authority rules, use [Operator Mode](operator-mode.md). For the documentation authority map, use [docs/README.md](README.md).

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -1,0 +1,35 @@
+# v0.6 release-planning artifacts
+
+Files in this directory preserve the v0.6.0 brief, integrated plan, risk reviews, counsel packet, and related pre-release evidence.
+
+They are retained for provenance. They are **not current release-status or runtime instructions**.
+
+Some files intentionally contain language such as:
+
+- candidate;
+- gate pending;
+- before release;
+- approval required;
+- do not publish yet.
+
+That language records the state at the time the artifact was written. The final v0.6.0 GitHub release occurred later.
+
+Agents should read [../README.md](../README.md) before using these files.
+
+Use these artifacts for:
+
+- reconstructing release rationale and approval history;
+- understanding identified risks and mitigations;
+- reviewing the intended surface inventory;
+- tracing how v0.6 requirements were decomposed.
+
+Do not use them alone to determine:
+
+- whether v0.6.0 is currently released;
+- whether PyPI has a particular version;
+- current tool names or schemas;
+- current environment defaults;
+- current retention enforcement;
+- whether a historical release gate remains open.
+
+Verify current claims against implementation/tests, current operational docs, and the active distribution channel.

--- a/docs/retention-policy.md
+++ b/docs/retention-policy.md
@@ -1,28 +1,64 @@
 # Hermes GPT data retention and cleanup policy
 
-Status: v0.6.0 release policy
-Owner: Hermes GPT maintainer
+**Status:** current v0.6.0 operational policy  
+**Owner:** Hermes GPT maintainer
 
-## Scope and exclusion
+For documentation authority rules, see [docs/README.md](README.md).
 
-Mission Control never returns request dumps, Codex CLI transcripts, raw prompts, messages, memory bodies, or profile secrets. This policy governs the diagnostic artifacts that remain local despite that exclusion.
+## Scope
+
+This policy covers local diagnostic and orchestration artifacts that can remain on the host even though Mission Control does not return their raw contents.
+
+Mission Control does not return raw request dumps, Codex CLI transcripts, prompts, messages, memory bodies, credentials, or profile-secret bodies.
 
 ## Retention windows
 
-- Request dumps (`request_dump_*.json`): retain at most 7 days from file modification time. They are diagnostic-only and may contain raw request bodies.
-- Codex transcripts and job artifacts: retain at most 30 days after terminal job completion. `operator_codex` enforces this automatically (`RETENTION_DAYS=30`) during reconciliation; keep only bounded job metadata required for operational status.
-- M2 swarm worktrees: retain at most 7 days after a workflow reaches a terminal state and its declared artifacts are copied to the owning repository or attached to its Kanban card.
-- M2 verdict JSON/workflow records: retain at most 30 days after terminal state. Records must remain bounded and redacted; no transcript or prompt body is permitted.
-- Failed/abandoned workflow records: apply the same windows from the last state transition; do not preserve them indefinitely for debugging.
+| Artifact class | Maximum window | Enforcement in v0.6.0 |
+| --- | --- | --- |
+| `request_dump_*.json` | 7 days from file mtime | maintainer cleanup |
+| Codex job metadata/transcript artifacts | 30 days after terminal completion | age-based cleanup during `operator_codex` reconciliation |
+| terminal Swarm worktrees | 7 days after terminal state and declared artifact preservation | maintainer cleanup through normal Git worktree handling |
+| terminal Swarm workflow/verdict records | 30 days after terminal state | maintainer cleanup |
+| failed/abandoned workflow records | same windows, measured from last state transition | maintainer cleanup |
+
+### Codex-specific automatic cleanup
+
+`operator_codex` defines `RETENTION_DAYS=30` and performs age-based cleanup as part of job reconciliation.
+
+This is **not** a general background deletion daemon. If no Codex reconciliation occurs, do not describe the policy as a continuously scheduled purge.
+
+### Other artifact classes
+
+v0.6.0 does not install a global cleanup service for request dumps, Swarm worktrees, or Swarm workflow/verdict records. The maintainer remains responsible for keeping those classes within the stated windows unless later code explicitly adds and tests automation.
 
 ## Cleanup procedure
 
-1. Run cleanup locally under the authenticated maintainer account; do not send artifact contents to a client or log them in a summary.
-2. Identify candidates by mtime/terminal timestamp, confirm they are within the directories above, and delete only the eligible files/worktrees.
-3. Remove request dumps and transcripts without opening or copying their content. Remove worktrees through the repository's normal worktree cleanup path only after confirming the workflow is terminal.
-4. Record only aggregate counts, paths or IDs, and timestamps in the operator audit/maintenance receipt. Never record raw text.
-5. If an artifact is subject to an investigation, legal hold, or active incident response, suspend deletion for that item and document the exception with the responsible owner.
+1. Run cleanup locally under the authenticated maintainer account.
+2. Identify candidates only inside the expected artifact directories and use mtime / terminal timestamps rather than opening sensitive content.
+3. Confirm the item is outside its retention window and is no longer required by an active workflow.
+4. For Swarm worktrees, first confirm the workflow is terminal and declared artifacts have been copied to the owning repository or attached to the intended work record.
+5. Remove worktrees through the repository's normal worktree cleanup path.
+6. Record only bounded operational metadata in the maintenance/audit receipt, such as aggregate counts, safe IDs/paths, and timestamps.
+7. Never copy raw prompt, transcript, request, credential, or secret content into the audit record or client response.
 
-## Enforcement and release posture
+## Exceptions
 
-This is an operational policy and release gate, not a claim of legal compliance. v0.6.0 does not install an automatic deletion daemon; the maintainer must perform and audit the bounded cleanup procedure before artifacts exceed the stated window. Any automation added later must be dry-run-first, path-allowlisted, and independently tested.
+If an artifact is subject to an investigation, legal hold, or active incident response:
+
+- suspend deletion for that specific item;
+- record the exception and responsible owner using bounded metadata;
+- do not broaden the exception to unrelated artifacts.
+
+## Release and compliance posture
+
+This is an operational retention policy, not a claim of legal or regulatory compliance.
+
+Any future cleanup automation must remain:
+
+- path-allowlisted;
+- bounded;
+- independently tested;
+- auditable;
+- conservative around active workflows and legal-hold exceptions.
+
+If documentation and implementation disagree about cleanup behavior, verify `operator_codex.py`, Swarm storage code, and the relevant tests before updating the claim.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,44 +1,97 @@
 # Updating Hermes GPT
 
-`hermes-gpt update` is deliberately check-first. It reports the current and available revision or package version without changing files, environments, or Git history.
+`hermes-gpt update` is deliberately check-first. It reports whether an update is available without changing files, packages, environments, or Git history.
+
+For documentation authority rules, see [docs/README.md](README.md).
+
+## Check first
 
 ```powershell
 hermes-gpt update
 ```
 
-When the report shows an update is available, apply it explicitly:
+Apply only after reviewing the result:
 
 ```powershell
 hermes-gpt update --apply
 ```
 
+## Identify the installation type first
+
+Hermes GPT has two update paths:
+
+- a Git checkout checks the repository remote and default branch;
+- an installed package checks PyPI through pip.
+
+GitHub releases and PyPI are separate distribution channels and can temporarily report different current versions. A newer GitHub release does not mean an installed-package update will be available before that version is published to PyPI.
+
+Agents should determine whether they are operating a checkout or an installed package before describing update availability.
+
 ## Git checkout updates
 
-When Hermes GPT runs from a Git checkout, the updater:
+For a Git checkout, the updater:
 
-1. Refuses to act if tracked files have local changes.
-2. Refuses to update from a feature branch; it operates only on the remote default branch.
-3. Checks the remote branch without modifying the checkout.
-4. On `--apply`, fetches the default branch and runs `git merge --ff-only`.
+1. refuses to apply over tracked local changes;
+2. refuses to apply from a feature branch;
+3. checks the remote default branch without changing the working tree;
+4. on `--apply`, fetches the default branch and uses fast-forward-only merge behavior.
 
-It never creates a merge commit, rebases, stashes changes, force-resets, or deletes untracked files. Untracked files are left alone. If a checkout has diverged, the command stops and tells you to resolve it manually.
+It does not create merge commits, rebase, stash tracked edits, force-reset the checkout, downgrade, or delete untracked files.
+
+If local history has diverged, the updater stops for manual resolution.
+
+```powershell
+hermes-gpt update
+hermes-gpt update --apply
+```
+
+Restart a running Hermes GPT server after a successful checkout update.
 
 ## Installed-package updates
 
-When Hermes GPT is installed from PyPI rather than a Git checkout, the updater checks the latest package version through pip. `--apply` runs the current Python environment's pip with `install --upgrade hermes-gpt` only if the available version is newer.
+For an installed package, the updater asks pip for the latest available `hermes-gpt` version.
 
-It never downgrades a package. Add `--pre` only when you want pip to consider prerelease packages:
+`--apply` upgrades only when the available package version is newer.
+
+```powershell
+hermes-gpt update
+hermes-gpt update --apply
+```
+
+It does not intentionally downgrade the package.
+
+To include prerelease packages in the pip check:
 
 ```powershell
 hermes-gpt update --pre
 hermes-gpt update --pre --apply
 ```
 
-Restart any running Hermes GPT server or Codex MCP process after a successful installed-package update.
+Restart any running Hermes GPT server or Codex MCP process after a successful package update.
+
+## What the updater does not synchronize
+
+The updater does not automatically synchronize:
+
+- GitHub release publication with PyPI publication;
+- feature branches with the default branch;
+- tracked local edits with upstream changes;
+- cached MCP schemas in external clients;
+- already-running server processes after files or packages change.
+
+After an update that changes the MCP surface, restart Hermes GPT and reconnect or recreate clients that cached the previous tool schema.
 
 ## Troubleshooting
 
-- `WORKTREE_DIRTY`: commit, stash, or otherwise resolve tracked changes first. The updater intentionally ignores untracked files but will not update over tracked edits.
-- `NOT_ON_DEFAULT_BRANCH`: switch to the default branch before applying an update.
-- `FAST_FORWARD_REQUIRED`: the checkout has diverged. Resolve the history manually; the updater will not merge or rebase it.
-- `UPDATE_CHECK_FAILED`: verify network/PyPI access and retry. No update was applied.
+| Code or symptom | Meaning | Action |
+| --- | --- | --- |
+| `WORKTREE_DIRTY` | tracked files have local changes | resolve the tracked changes before applying |
+| `NOT_ON_DEFAULT_BRANCH` | checkout is on a feature branch | switch to the remote default branch before applying |
+| `FAST_FORWARD_REQUIRED` | local and remote history diverged | resolve history manually; updater will not merge or rebase it |
+| `UPDATE_CHECK_FAILED` | remote or PyPI check failed | verify network and channel access; no update was applied |
+| GitHub has a newer release but package updater reports no update | the newer version is not available from PyPI yet | use the intended source/GitHub distribution or wait for the package publication |
+| client still shows old tools after updating | the running process or client schema is stale | restart Hermes GPT, then refresh the client connector |
+
+## Safety invariant
+
+A failed or refused update should leave the existing checkout or package usable. Keep the clean-tree, default-branch, and fast-forward requirements intact.

--- a/docs/windows-chatgpt-codex.md
+++ b/docs/windows-chatgpt-codex.md
@@ -1,27 +1,43 @@
 # ChatGPT to Codex through Hermes GPT on Windows
 
-This guide describes a Windows deployment in which ChatGPT is the conversational client and Hermes GPT dispatches explicitly approved jobs to the standalone Codex CLI.
+This guide covers one specific deployment path:
 
 ```text
 ChatGPT
-  -> authenticated private tunnel
-  -> Hermes GPT MCP on 127.0.0.1:4750/mcp
+  -> authenticated/private boundary
+  -> normal Hermes GPT Operator MCP on 127.0.0.1:4750/mcp
   -> Hermes Operator policy
   -> standalone Codex CLI
   -> approved Git workspace
 ```
 
-This is an advanced local setup. Hermes Operator Mode is not a sandbox, and an unauthenticated public MCP endpoint is unsafe. Keep the server on loopback, protect the tunnel, restrict the allowed workspace list, and start with read-only Codex jobs.
+This is **Codex CLI as a delegated worker/reviewer**. It is not the separate workflow where Codex itself loads Hermes GPT as an MCP server.
+
+For documentation authority rules, see [docs/README.md](README.md).
+
+## Security posture
+
+This is an advanced local setup.
+
+- Keep Hermes GPT bound to loopback.
+- Put a private or authenticated boundary in front of it for ChatGPT access.
+- Restrict allowed workspaces narrowly.
+- Start with `sandbox=read-only`.
+- Do not enable Owner Mode for an always-on connector.
+- Operator Mode is not an OS sandbox.
+- Public unauthenticated Operator hosting is unsupported.
 
 ## Prerequisites
 
 - Windows 10 or 11
-- Python 3.10 or later and a working Hermes GPT checkout
-- A private tunnel that can forward HTTPS to `http://127.0.0.1:4750`
-- The standalone Codex CLI, installed separately from the Codex or ChatGPT desktop application
-- A dedicated Git repository to use as the approved Codex work directory
+- Python 3.10+
+- Hermes GPT installed or checked out locally
+- Hermes Agent available to the Hermes GPT runtime
+- A private/authenticated HTTPS boundary that forwards to `http://127.0.0.1:4750`
+- The standalone Codex CLI
+- A dedicated Git repository to use as the approved work directory
 
-Install and authenticate the standalone CLI:
+Install and authenticate the standalone Codex CLI:
 
 ```powershell
 npm install -g @openai/codex
@@ -29,61 +45,123 @@ codex login
 codex --version
 ```
 
-The desktop application may remain installed. Confirm that the executable resolved by the Hermes launch environment is the standalone CLI and does not point into `C:\Program Files\WindowsApps`:
+The Codex or ChatGPT desktop application can remain installed. Hermes GPT must resolve a standalone CLI executable that can actually launch.
+
+## 1. Resolve the Codex CLI cleanly
+
+Inspect candidates:
 
 ```powershell
 Get-Command codex -All | Select-Object Source
 ```
 
-On systems with more than one Codex installation, put the standalone CLI directory first in `PATH` in the same process that starts Hermes. Do not rely on an interactive shell's `PATH`, because Task Scheduler can receive a different environment.
-
-## Start Hermes with the required gates
-
-The following example enables real read-only Codex dispatch for one approved workspace. Replace every placeholder before use.
+If multiple installations exist, the safest approach is to pin the standalone CLI explicitly in the environment that launches Hermes GPT:
 
 ```powershell
-$env:HERMES_GPT_ENABLE_SESSION_SEARCH = "1"
+$env:HERMES_GPT_CODEX_EXE="C:\path\to\standalone\codex.exe"
+```
+
+Hermes GPT validates this override before use. The path must:
+
+- be absolute;
+- exist as a regular file;
+- not resolve under protected `WindowsApps`;
+- pass a `codex --version` probe.
+
+Without an override, Hermes GPT searches `PATH` and skips protected or unlaunchable candidates.
+
+Task Scheduler can receive a different `PATH` from an interactive terminal, so verify resolution in the actual launch environment.
+
+## 2. Start Hermes GPT with the runner gates
+
+A minimal real **read-only Codex runner** setup looks like this:
+
+```powershell
 $env:HERMES_GPT_OPERATOR_ENABLED = "1"
 $env:HERMES_GPT_OPERATOR_LEVEL = "workspace"
 $env:HERMES_GPT_OPERATOR_APPLY_MODE = "direct"
 $env:HERMES_GPT_OPERATOR_ALLOWED_PROFILES = "default"
 $env:HERMES_GPT_OPERATOR_ALLOWED_PATHS = "C:\path\to\approved-workspace"
 $env:HERMES_GPT_ENABLE_CODEX_RUNNER = "1"
+$env:HERMES_GPT_CODEX_EXE = "C:\path\to\standalone\codex.exe"
 
 Set-Location -LiteralPath "C:\path\to\hermes-gpt"
 & ".venv\Scripts\python.exe" ".\server.py" --http --host 127.0.0.1 --port 4750
 ```
 
-Leave `HERMES_GPT_ALLOW_CODEX_WRITE` unset while validating the connection. Read-only jobs do not require it. Real job dispatch still requires `confirm=true` and `dry_run=false` on the tool call.
+`HERMES_GPT_CODEX_EXE` is optional if Hermes GPT already resolves the correct standalone CLI from `PATH`.
 
-The approved work directory must be a trusted Git repository. For a new dedicated test directory:
+Leave `HERMES_GPT_ALLOW_CODEX_WRITE` unset while validating the system. It is needed only for `sandbox=workspace-write`.
+
+### Gates you do not need for this path
+
+Do **not** add these merely because Codex is involved:
+
+```text
+HERMES_GPT_ENABLE_CODEX
+HERMES_GPT_ENABLE_MCP
+HERMES_GPT_ENABLE_SESSION_SEARCH
+```
+
+`HERMES_GPT_ENABLE_CODEX` and `HERMES_GPT_ENABLE_MCP` belong to the separate **Codex-as-MCP-client** workflow. Session search is unrelated to launching bounded Codex runner jobs.
+
+Real runner execution still requires `confirm=true` and `dry_run=false` on the job call.
+
+## 3. Prepare the approved workspace
+
+The work directory must satisfy two independent checks:
+
+1. Hermes GPT must allow it through `HERMES_GPT_OPERATOR_ALLOWED_PATHS`.
+2. The Codex CLI must accept it as a trusted Git workspace.
+
+For a new dedicated test repository:
 
 ```powershell
 Set-Location -LiteralPath "C:\path\to\approved-workspace"
 git init
 ```
 
-Do not initialize Git in a broad personal directory merely to satisfy this requirement.
+Do not initialize Git in a broad personal directory merely to satisfy the CLI.
 
-## Connect ChatGPT
+## 4. Connect ChatGPT
 
-ChatGPT cannot connect to the computer's loopback address directly. Forward the local endpoint through an authenticated private tunnel, then configure the ChatGPT connector with:
+ChatGPT cannot directly reach the computer's loopback address.
+
+Forward the local MCP endpoint through your private/authenticated boundary, then configure the connector with the resulting HTTPS endpoint:
 
 ```text
 Protocol: Streaming HTTP
-URL: https://<private-tunnel-host>/mcp
-Authentication: the protection configured for the private tunnel
+URL: https://<private-host>/mcp
+Authentication: the protection configured for that boundary
 ```
 
-Do not enter `http://127.0.0.1:4750/mcp` in ChatGPT. Do not publish an unauthenticated Operator endpoint to the public internet.
+Do not enter `http://127.0.0.1:4750/mcp` as a remote ChatGPT connector URL. Do not expose the Operator endpoint to the public internet without authentication.
 
-If ChatGPT shows an old or incomplete tool list after changing Hermes gates, reconnect or recreate the connector so its schema is refreshed.
+If the client shows an old or incomplete tool list after changing Hermes GPT, restart the intended server process and reconnect/recreate the connector so its MCP schema refreshes.
 
-## Validate the connection
+## 5. Validate policy before running Codex
 
-First ask ChatGPT to call `hermes_operator_policy`. A read-only runner setup should report Operator Mode enabled at `workspace` level, direct apply mode, a narrow allowed-path count, and Owner Mode disabled.
+First call:
 
-Next ask ChatGPT to call `hermes_codex_status`. Expected fields include:
+```text
+hermes_operator_policy
+```
+
+Confirm:
+
+- Operator Mode is enabled;
+- effective level is `workspace`;
+- apply mode is `direct` only because this deployment is intended to execute confirmed jobs;
+- allowed paths are narrow;
+- Owner Mode is not active.
+
+Then call:
+
+```text
+hermes_codex_status
+```
+
+Expected fields include values like:
 
 ```json
 {
@@ -93,11 +171,16 @@ Next ask ChatGPT to call `hermes_codex_status`. Expected fields include:
   "operator_enabled": true,
   "operator_level": "workspace",
   "apply_mode": "direct",
-  "codex_available": true
+  "codex_available": true,
+  "codex_source": "env"
 }
 ```
 
-Finally, start a minimal read-only job:
+Also inspect `codex_path` and `codex_version`. If `codex_available` is false, read `codex_reason` instead of attempting a job.
+
+## 6. Run the first read-only job
+
+Start with a minimal inspection task:
 
 ```text
 Start a Hermes Codex job in <approved-workspace> with sandbox=read-only,
@@ -105,13 +188,28 @@ confirm=true, and dry_run=false. Ask Codex only to report its working
 directory and confirm that it changed no files. Monitor it to completion.
 ```
 
-A successful job completes with return code `0`, reports the approved directory, and makes no file changes.
+A successful validation job should:
 
-## Start automatically without visible consoles
+- run in the approved repository;
+- use the standalone Codex CLI reported by `hermes_codex_status`;
+- complete without write authority;
+- make no file changes.
 
-Task Scheduler can start both the MCP server and the tunnel at logon. A task whose action launches `powershell.exe` directly may display a console even when `-WindowStyle Hidden` is present. A small Windows Script Host wrapper avoids that flash while allowing Task Scheduler to monitor the long-running child process.
+Only after that should you consider `workspace-write` and `HERMES_GPT_ALLOW_CODEX_WRITE=1` for deliberately approved write jobs.
 
-Save the following as `run-powershell-hidden.vbs` in a controlled local directory:
+## 7. Run Codex reviews
+
+Use `hermes_codex_review_start` for bounded review jobs. Review targets are constrained by the runner rather than accepting arbitrary command-line arguments.
+
+In Swarm Orchestration, Codex can provide a review verdict but is never an implementation owner.
+
+## 8. Start automatically without visible consoles
+
+Task Scheduler can start both Hermes GPT and the private tunnel/boundary at logon.
+
+Launching `powershell.exe` directly can flash a console even with `-WindowStyle Hidden`. A small Windows Script Host wrapper can hide the launcher while letting Task Scheduler monitor the process.
+
+Save as `run-powershell-hidden.vbs` in a controlled local directory:
 
 ```vbscript
 Option Explicit
@@ -125,7 +223,7 @@ command = "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Fi
 WScript.Quit shell.Run(command, 0, True)
 ```
 
-Use this Task Scheduler action for each long-running PowerShell launcher:
+Task Scheduler action:
 
 ```text
 Program/script: C:\Windows\System32\wscript.exe
@@ -133,38 +231,47 @@ Arguments: "C:\path\to\run-powershell-hidden.vbs" "C:\path\to\launcher.ps1"
 Start in: the launcher's working directory
 ```
 
-Create separate tasks for Hermes and the tunnel. Configure restart-on-failure as appropriate for the machine, and keep logs free of credentials.
+Use separate tasks for Hermes GPT and the tunnel/boundary. Configure restart-on-failure as appropriate and keep logs free of credentials.
 
-## Restart safely
+## 9. Restart safely
 
-Ending a scheduled task can occasionally leave its child `python.exe` running. If a new task run produces fresh startup output but Hermes still behaves like the previous configuration, check the listener before starting another server:
+A stopped scheduled task can occasionally leave a child `python.exe` running. If a new launch appears successful but Hermes GPT still behaves like the previous process, check the listener:
 
 ```powershell
 netstat -ano | Select-String '127.0.0.1:4750'
 ```
 
-Match the listening PID to the old Hermes Python process in Task Manager before ending it. Never terminate an arbitrary Python process. After the verified stale process exits, start the Hermes task again and confirm that exactly one process is listening on port `4750`.
+Match the PID to the known Hermes GPT process before terminating anything. Never kill an arbitrary Python process.
+
+After stopping the verified stale process, restart Hermes GPT and confirm exactly one expected listener owns port `4750`.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Resolution |
 | --- | --- | --- |
-| `CODEX_START_FAILED: [WinError 5] Access is denied` | Hermes found a protected WindowsApps Codex executable | Put the standalone npm Codex directory first in the launcher's `PATH`, restart Hermes, and verify `Get-Command codex -All`. |
-| `codex_available=true` followed by `WinError 5` | The availability check found a binary that cannot be executed by Hermes | Verify the exact executable selected in the scheduled launch environment; it must not resolve into WindowsApps. |
-| `Not inside a trusted directory and --skip-git-repo-check was not specified` | The selected work directory is not a trusted Git repository | Use a dedicated repository or initialize Git in the intended workspace. |
-| New server cannot bind to port `4750` | A stale server still owns the port | Identify the listener PID, confirm that it is the old Hermes Python process, end only that process, and restart the task. |
-| PowerShell consoles appear at logon | The scheduled task launches PowerShell directly | Use the `wscript.exe` wrapper shown above. |
-| ChatGPT shows old tools or gates | The connector schema or server process is stale | Verify the listener, restart Hermes, then reconnect or recreate the ChatGPT connector. |
-| Codex stops authenticating after an update | The standalone CLI credentials or executable path changed | Run `codex login` and `codex --version`, verify executable resolution, and restart Hermes. |
+| `codex_available=false` | No launchable standalone CLI resolved | Inspect `codex_reason`; install Codex or set `HERMES_GPT_CODEX_EXE` to a valid standalone CLI. |
+| Access denied / path mentions `WindowsApps` | Old process, external launcher, or stale config is selecting a protected desktop-app shim | Update/restart Hermes GPT, pin `HERMES_GPT_CODEX_EXE`, and re-check `hermes_codex_status`. |
+| `Not inside a trusted directory...` | Codex does not trust the selected work directory | Use an intended Git repository and establish trust there. |
+| Job returns `POLICY_REFUSED` | Operator level/path gates do not authorize the workdir | Inspect `hermes_operator_policy`; narrow and correct `HERMES_GPT_OPERATOR_ALLOWED_PATHS`. |
+| Job returns runner disabled | `HERMES_GPT_ENABLE_CODEX_RUNNER=1` is missing in the running process | Set it in the actual launch environment and restart Hermes GPT. |
+| Job previews but does not execute | Server/call is still dry-run | For an approved real job, use direct mode plus `confirm=true` and `dry_run=false`. |
+| New server cannot bind port 4750 | Stale server still owns the listener | Identify and verify the listener PID before ending that specific process. |
+| ChatGPT shows old tools/gates | Stale server or cached connector schema | Verify the listener, restart Hermes GPT, then reconnect/recreate the connector. |
 
 ## Security checklist
 
-- Keep Hermes bound to `127.0.0.1`.
-- Require authentication or an equivalent private boundary on the tunnel.
-- Keep `HERMES_GPT_OPERATOR_ALLOWED_PATHS` limited to specific workspaces.
-- Leave `HERMES_GPT_ALLOW_CODEX_WRITE` unset until write jobs are deliberately required.
-- Do not enable Owner Mode for an always-on connector.
-- Use `sandbox=read-only` for initial inspection and validation jobs.
-- Never place tunnel credentials, API keys, or authentication tokens in launch scripts, logs, or documentation.
+- Keep Hermes GPT on `127.0.0.1`.
+- Require a private/authenticated remote boundary.
+- Restrict `HERMES_GPT_OPERATOR_ALLOWED_PATHS` to specific workspaces.
+- Leave `HERMES_GPT_ALLOW_CODEX_WRITE` unset until a write job is deliberately required.
+- Keep Owner Mode off for always-on access.
+- Validate with `sandbox=read-only` first.
+- Pin `HERMES_GPT_CODEX_EXE` when executable ambiguity exists.
+- Never put tunnel credentials, API keys, tokens, or private keys in launch scripts, logs, prompts, or documentation.
 
-See [Hermes GPT for Codex](codex.md) for the Codex-facing MCP connector and runner safety model, and [Operator Mode](operator-mode.md) for policy levels, gates, diagnostics, and recovery.
+## Related docs
+
+- [Documentation map](README.md)
+- [Hermes GPT and Codex](codex.md)
+- [Operator Mode](operator-mode.md)
+- [Updating](updating.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ py-modules = [
   "CHANGELOG.md",
 ]
 "share/hermes-gpt/docs" = [
+  "docs/README.md",
   "docs/operator-mode.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",
@@ -71,6 +72,7 @@ py-modules = [
   "docs/release-notes-v0.5.0.md",
   "docs/release-notes-v0.6.0.md",
   "docs/retention-policy.md",
+  "docs/windows-chatgpt-codex.md",
 ]
 "share/hermes-gpt/examples" = [
   "examples/start-hermes-gpt.example.ps1",


### PR DESCRIPTION
## What this fixes

This is a full v0.6 documentation accuracy and information-architecture pass.

### Accuracy
- correct `docs/release-notes-v0.6.0.md` from stale release-candidate status to the shipped v0.6.0 state
- document the current GitHub/PyPI distribution-channel distinction instead of implying they are synchronized
- correct Mission Control allowlist semantics: unset means all read-only surfaces, explicit list restricts, empty denies all
- remove the unrelated session-search gate from the Windows ChatGPT -> Codex runner path
- separate Codex-as-MCP-client gates from Codex-CLI-as-delegated-worker gates
- document the intentional `hermes_web_extract` vs `hermes_extract_page` namespace difference
- clarify Codex retention reconciliation vs maintainer cleanup for other artifact classes

### Logical order
- rewrite README around current v0.6 behavior, quickstart, authority model, and task-based navigation
- reorganize Operator Mode around authority -> Mission Control -> Contracts -> Swarms -> fleet -> Codex jobs -> diagnostics
- reorganize Codex docs around the two distinct integration workflows
- tighten the Windows deployment guide into a sequential validation path

### Agent friendliness
- add root `AGENTS.md`
- add `docs/README.md` as a documentation authority/source-of-truth map
- add historical indexes under `docs/design/` and `docs/releases/`
- mark `FEASIBILITY.md` as a historical machine-specific probe
- remove fixed MCP tool-count assumptions from troubleshooting
- update release checklist with exact docs/tool/channel verification rules

### Packaging
- include `docs/README.md` and `docs/windows-chatgpt-codex.md` in wheel data files
- include `docs/README.md` in the sdist manifest

No runtime code behavior changes.