### PR TITLE
feat: add secure OAuth for remote MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Added an opt-in authenticated remote boundary: static bearer compatibility or
+  a single-confidential-client OAuth authorization-code flow with optional PKCE
+  S256, stateless signed authorization codes, bounded memory-backed replay and
+  token state, one-hour access tokens, 30-day
+  rotating refresh tokens, replay/client/scope/resource validation, explicit
+  direct-TLS or loopback trusted-proxy enforcement, and ChatGPT-compatible
+  streamable-HTTP request normalization.
+
 ## 0.6.0 - 2026-08-13
 
 - Added the v0.6 Mission Control, Work Contracts, and Swarm Orchestration surfaces with bounded, audited, fail-closed operator controls.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See the [v0.6.0 release notes](docs/release-notes-v0.6.0.md) and [retention poli
 | --- | --- |
 | Understand the repository and current docs | [Documentation map](docs/README.md) |
 | Run Hermes GPT locally | [Local quickstart](#local-quickstart) |
+| Authenticate a remote MCP connector | [OAuth and bearer authentication](docs/oauth.md) |
 | Use Codex as an MCP client | [Codex guide](docs/codex.md) |
 | Use ChatGPT or another trusted client to operate Hermes | [Operator Mode](docs/operator-mode.md) |
 | Let ChatGPT dispatch bounded work to the Codex CLI on Windows | [Windows ChatGPT -> Codex guide](docs/windows-chatgpt-codex.md) |
@@ -115,6 +116,13 @@ http://127.0.0.1:7677/mcp
 ```
 
 Keep the server on loopback. A remote client such as ChatGPT cannot use your machine's `127.0.0.1` directly, so remote access requires a deliberately configured private/authenticated boundary. Do not publish an unauthenticated Operator endpoint to the internet.
+
+Hermes GPT can enforce either a strong static bearer token or a built-in,
+single-confidential-client OAuth authorization-code flow with rotating refresh
+tokens. OAuth credentials are memory-backed and fail closed on missing client
+authentication, unsupported scope/resource, expiry, or replay. See
+[OAuth and bearer authentication](docs/oauth.md) before enabling the `remote`
+profile; authentication does not activate Operator mutation or Owner Mode.
 
 ## Operator Mode
 
@@ -254,6 +262,7 @@ Git checkout updates require a clean checkout on the default branch and use fast
 Current operational documentation:
 
 - [Documentation map and source-of-truth rules](docs/README.md)
+- [OAuth and bearer authentication](docs/oauth.md)
 - [Operator Mode](docs/operator-mode.md)
 - [Codex integration](docs/codex.md)
 - [Windows ChatGPT -> Codex deployment](docs/windows-chatgpt-codex.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The final GitHub release is `v0.6.0`. PyPI is an independent distribution channe
 | Document | Authority | Use it for |
 | --- | --- | --- |
 | [`../README.md`](../README.md) | current | project overview, current release, quickstart, safety invariants, entry-point selection |
+| [`oauth.md`](oauth.md) | current | static bearer and confidential-client OAuth configuration, token lifecycle, refresh rotation, and remote authentication limits |
 | [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,123 @@
+# OAuth and bearer authentication
+
+Hermes GPT remains local-first. Remote Operator or Owner access is supported only when the HTTP endpoint is carried over HTTPS and protected with either a static bearer token or the built-in single-client OAuth boundary described here.
+
+## Security model
+
+The built-in authorization server is intentionally narrow:
+
+- one statically configured confidential client;
+- exact HTTPS redirect-URI allowlisting;
+- client authentication on every authorization-code and refresh exchange;
+- optional PKCE S256 validation when a client supplies a challenge;
+- one configured Hermes resource scope (required on every issued token) plus the connector compatibility scopes `openid` and `offline_access`;
+- one-hour access tokens;
+- 30-day refresh tokens with rotation and replay rejection;
+- signed, five-minute stateless authorization codes plus bounded process-memory replay, access-token, and refresh-token stores;
+- no dynamic client registration, user accounts, persistent plaintext token database, or OpenID Provider claims.
+
+`openid` is accepted because ChatGPT may add it even with OIDC disabled. Hermes GPT does not advertise OpenID Provider metadata and does not issue ID tokens. Configure the ChatGPT connector with OIDC disabled.
+
+The client secret is the credential that prevents an arbitrary network caller from exchanging an authorization code. Public clients using token endpoint authentication method `none` are not supported. Do not expose an OAuth-enabled endpoint until a strong client secret is configured.
+
+## Generate a client secret
+
+Generate a fresh URL-safe secret. Do not reuse a Hermes, GitHub, gateway, or provider credential.
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+The result must contain 43 to 128 URL-safe characters. Store it in a service-owned secret environment source, not in the repository, shell history, documentation, or command-line arguments.
+
+## Required OAuth configuration
+
+```text
+HERMES_GPT_OAUTH_ENABLE=1
+HERMES_GPT_OAUTH_ISSUER=https://mcp.example.com
+HERMES_GPT_OAUTH_CLIENT_ID=chatgpt-client
+HERMES_GPT_OAUTH_CLIENT_SECRET=<43-to-128-character-generated-secret>
+HERMES_GPT_OAUTH_REDIRECT_URI=https://chatgpt.com/connector/oauth/<exact-callback-id>
+HERMES_GPT_OAUTH_SCOPE=hermes
+```
+
+Multiple exact redirect URIs may be comma-separated. Wildcards are not accepted. The issuer must use HTTPS except for an explicitly loopback-only test server.
+
+The built-in OAuth boundary is available only with streamable HTTP (`--http`);
+legacy SSE is rejected when OAuth is enabled so discovery and resource binding
+cannot disagree.
+
+Authenticated `remote` mode also requires one of these transport boundaries:
+
+- direct TLS using both `--cert` and `--key`; or
+- a loopback bind behind a trusted HTTPS reverse proxy, with every local proxy
+  address explicitly listed in `HERMES_GPT_TRUSTED_PROXY_IPS`.
+
+Wildcard, non-IP, and non-loopback trusted-proxy entries are rejected. Forwarded
+headers are ignored unless this explicit loopback-proxy mode is active.
+
+For a local HTTPS-terminating proxy, set:
+
+```text
+HERMES_GPT_TRUSTED_PROXY_IPS=127.0.0.1,::1
+```
+
+Then start the remote safety profile only after the configuration validates:
+
+```bash
+hermes-gpt --http --host 127.0.0.1 --port 4750 --profile remote
+```
+
+Keep the process loopback-bound and terminate HTTPS in a deliberately configured trusted proxy or private tunnel. The public issuer must resolve to that exact server.
+
+## ChatGPT connector values
+
+Configure the connector using values derived from the issuer:
+
+```text
+MCP URL:               https://mcp.example.com/mcp
+Authorization endpoint:https://mcp.example.com/oauth/authorize
+Token endpoint:        https://mcp.example.com/oauth/token
+Client ID:             chatgpt-client
+Client secret:         the generated confidential-client secret
+Token auth method:     client_secret_post or client_secret_basic
+Default scope:         hermes offline_access
+OIDC:                  disabled
+```
+
+ChatGPT may add `openid` to the authorization request. `offline_access` is required for refresh-token issuance. A connector authorized before refresh discovery was available must be disconnected and connected once so discovery and authorization run again.
+
+## Token lifecycle
+
+An authorization-code exchange returns an access token with `expires_in=3600`. If `offline_access` was granted, it also returns a refresh token. A successful refresh returns a new access token and rotates the refresh token; replaying the old refresh token fails with `invalid_grant`.
+
+Authorization codes are short-lived signed values. Only used-code replay state,
+access tokens, and refresh tokens are held in process memory. Restarting Hermes
+GPT invalidates all issued credentials and requires the connector to authorize
+again. This avoids introducing a persistent plaintext credential store. Durable
+encrypted token storage and explicit revocation administration are separate
+future features.
+
+## Static bearer alternative
+
+For clients that directly support a preconfigured bearer credential, set:
+
+```text
+HERMES_GPT_BEARER_TOKEN=<strong-random-token>
+```
+
+Static bearer authentication remains compatible with OAuth access tokens. Never put the bearer value in a URL, repository, log, prompt, or Operator audit record.
+
+## Failure behavior
+
+Hermes GPT fails closed when:
+
+- OAuth is enabled but required configuration is missing;
+- the client secret is absent, malformed, or incorrect;
+- the redirect URI, resource, grant type, or scope is unsupported;
+- PKCE is supplied with a method other than S256 or the verifier does not match;
+- an authorization code or refresh token is unknown, expired, used, or replayed;
+- a refresh request attempts to increase scope;
+- a bounded credential store is full.
+
+Operator and Owner policy remains independent from transport authentication. Authenticating a connector does not activate mutations, direct mode, or Owner Mode.

--- a/oauth_auth.py
+++ b/oauth_auth.py
@@ -1,0 +1,609 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import time
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+AUTH_CODE_TTL_SECONDS = 300
+ACCESS_TOKEN_TTL_SECONDS = 3600
+REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60
+MAX_AUTH_CODES = 1024
+MAX_ACCESS_TOKENS = 4096
+MAX_REFRESH_TOKENS = 4096
+MAX_TOKEN_REQUEST_BYTES = 16384
+AUTH_TOKEN_ENV = "HERMES_GPT_BEARER_TOKEN"
+OAUTH_ENABLE_ENV = "HERMES_GPT_OAUTH_ENABLE"
+OAUTH_ISSUER_ENV = "HERMES_GPT_OAUTH_ISSUER"
+OAUTH_CLIENT_ID_ENV = "HERMES_GPT_OAUTH_CLIENT_ID"
+OAUTH_CLIENT_SECRET_ENV = "HERMES_GPT_OAUTH_CLIENT_SECRET"
+OAUTH_REDIRECT_URI_ENV = "HERMES_GPT_OAUTH_REDIRECT_URI"
+OAUTH_SCOPE_ENV = "HERMES_GPT_OAUTH_SCOPE"
+_PKCE_VALUE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
+_CLIENT_SECRET = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
+_BASE64URL = re.compile(r"^[A-Za-z0-9_-]+$")
+_NONCE = re.compile(r"^[A-Za-z0-9_-]{32,128}$")
+
+
+def _base64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _base64url_decode(value: str) -> bytes:
+    if not value or not _BASE64URL.fullmatch(value):
+        raise ValueError("invalid base64url value")
+    padding = "=" * (-len(value) % 4)
+    decoded = base64.b64decode(value + padding, altchars=b"-_", validate=True)
+    if _base64url_encode(decoded) != value:
+        raise ValueError("non-canonical base64url value")
+    return decoded
+
+
+class OAuthError(RuntimeError):
+    def __init__(self, error: str, description: str, *, status_code: int = 400) -> None:
+        super().__init__(description)
+        self.error = error
+        self.description = description
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class OAuthConfig:
+    issuer: str
+    client_id: str
+    client_secret: str
+    redirect_uris: tuple[str, ...]
+    scope: str = "hermes"
+
+    def __post_init__(self) -> None:
+        issuer = self.issuer.rstrip("/")
+        parsed = urllib.parse.urlparse(issuer)
+        if parsed.scheme != "https" and parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+            raise ValueError("OAuth issuer must use HTTPS except on loopback.")
+        if (
+            not parsed.netloc
+            or parsed.path not in {"", "/"}
+            or parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+        ):
+            raise ValueError("OAuth issuer must be an origin URL without path, userinfo, query, or fragment.")
+        if not self.client_id.strip():
+            raise ValueError("OAuth client_id is required.")
+        if not _CLIENT_SECRET.fullmatch(self.client_secret):
+            raise ValueError("OAuth client_secret must contain 43 to 128 URL-safe characters.")
+        if not self.redirect_uris:
+            raise ValueError("At least one OAuth redirect URI is required.")
+        for redirect_uri in self.redirect_uris:
+            redirect = urllib.parse.urlparse(redirect_uri)
+            if (
+                redirect.scheme != "https"
+                or not redirect.netloc
+                or not redirect.hostname
+                or redirect.fragment
+                or redirect.username is not None
+                or redirect.password is not None
+            ):
+                raise ValueError("OAuth redirect URIs must be absolute HTTPS URLs without userinfo or fragments.")
+        if not self.scope.strip() or len(self.scope.split()) != 1:
+            raise ValueError("OAuth scope must be one non-empty scope token.")
+        object.__setattr__(self, "issuer", issuer)
+        object.__setattr__(self, "client_id", self.client_id.strip())
+        object.__setattr__(self, "redirect_uris", tuple(dict.fromkeys(self.redirect_uris)))
+        object.__setattr__(self, "scope", self.scope.strip())
+
+    @property
+    def resource(self) -> str:
+        return f"{self.issuer}/mcp"
+
+    @property
+    def supported_scopes(self) -> tuple[str, ...]:
+        # ChatGPT currently adds `openid` even when its OIDC toggle is disabled.
+        # It is accepted as a compatibility scope; this server does not advertise
+        # OpenID Provider metadata or issue ID tokens.
+        return tuple(dict.fromkeys((self.scope, "openid", "offline_access")))
+
+
+class OAuthState:
+    def __init__(
+        self,
+        config: OAuthConfig,
+        *,
+        max_auth_codes: int = MAX_AUTH_CODES,
+        max_access_tokens: int = MAX_ACCESS_TOKENS,
+        max_refresh_tokens: int = MAX_REFRESH_TOKENS,
+    ) -> None:
+        self.config = config
+        self.max_auth_codes = max_auth_codes
+        self.max_access_tokens = max_access_tokens
+        self.max_refresh_tokens = max_refresh_tokens
+        self._authorization_code_key = secrets.token_bytes(32)
+        self.used_auth_codes: dict[str, dict[str, Any]] = {}
+        self.access_tokens: dict[str, dict[str, Any]] = {}
+        self.refresh_tokens: dict[str, dict[str, Any]] = {}
+
+    def cleanup(self) -> None:
+        now = time.time()
+        for store in (self.used_auth_codes, self.access_tokens, self.refresh_tokens):
+            for credential, item in list(store.items()):
+                if item.get("expires_at", 0) <= now:
+                    store.pop(credential, None)
+
+    def normalize_scope(self, scope: str) -> str:
+        requested = list(dict.fromkeys(scope.split()))
+        if (
+            not requested
+            or self.config.scope not in requested
+            or not set(requested).issubset(self.config.supported_scopes)
+        ):
+            raise OAuthError("invalid_scope", "Requested scope is not supported.")
+        return " ".join(requested)
+
+    def _require_capacity(self, store: dict[str, Any], maximum: int, credential_type: str) -> None:
+        self.cleanup()
+        if len(store) >= maximum:
+            raise OAuthError(
+                "temporarily_unavailable",
+                f"{credential_type} capacity is temporarily unavailable.",
+                status_code=503,
+            )
+
+    def issue_authorization_code(
+        self,
+        *,
+        client_id: str,
+        redirect_uri: str,
+        scope: str,
+        resource: str,
+        code_challenge: str,
+    ) -> str:
+        payload = {
+            "v": 1,
+            "nonce": secrets.token_urlsafe(24),
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "resource": resource,
+            "code_challenge": code_challenge,
+            "expires_at": int(time.time()) + AUTH_CODE_TTL_SECONDS,
+        }
+        encoded = _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+        signature = hmac.new(self._authorization_code_key, encoded.encode("ascii"), hashlib.sha256).digest()
+        return f"{encoded}.{_base64url_encode(signature)}"
+
+    def _decode_authorization_code(self, code: str) -> dict[str, Any]:
+        if len(code) > 4096:
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.")
+        encoded, separator, encoded_signature = code.partition(".")
+        if not separator:
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.")
+        try:
+            supplied_signature = _base64url_decode(encoded_signature)
+            expected_signature = hmac.new(
+                self._authorization_code_key,
+                encoded.encode("ascii"),
+                hashlib.sha256,
+            ).digest()
+            if not hmac.compare_digest(supplied_signature, expected_signature):
+                raise ValueError("signature mismatch")
+            payload = json.loads(_base64url_decode(encoded))
+        except (UnicodeError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.") from exc
+        required_types = {
+            "v": int,
+            "nonce": str,
+            "client_id": str,
+            "redirect_uri": str,
+            "scope": str,
+            "resource": str,
+            "code_challenge": str,
+            "expires_at": int,
+        }
+        if not isinstance(payload, dict) or any(not isinstance(payload.get(key), kind) for key, kind in required_types.items()):
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.")
+        if payload["v"] != 1 or not _NONCE.fullmatch(payload["nonce"]):
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.")
+        return payload
+
+    def _new_access_token(self, *, client_id: str, scope: str, resource: str) -> tuple[str, dict[str, Any]]:
+        token_value = secrets.token_urlsafe(48)
+        item = {
+            "client_id": client_id,
+            "scope": scope,
+            "resource": resource,
+            "expires_at": time.time() + ACCESS_TOKEN_TTL_SECONDS,
+        }
+        return token_value, item
+
+    def _new_refresh_token(self, *, client_id: str, scope: str) -> tuple[str, dict[str, Any]]:
+        token_value = secrets.token_urlsafe(48)
+        item = {
+            "client_id": client_id,
+            "scope": scope,
+            "expires_at": time.time() + REFRESH_TOKEN_TTL_SECONDS,
+        }
+        return token_value, item
+
+    def exchange_authorization_code(
+        self,
+        *,
+        code: str,
+        client_id: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict[str, Any]:
+        self.cleanup()
+        item = self._decode_authorization_code(code)
+        nonce = item["nonce"]
+        if nonce in self.used_auth_codes or item.get("expires_at", 0) <= time.time():
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used authorization code.")
+        if item.get("client_id") != client_id or item.get("redirect_uri") != redirect_uri:
+            raise OAuthError("invalid_grant", "Authorization code validation failed.")
+        challenge = item.get("code_challenge", "")
+        if challenge:
+            if not _valid_pkce_verifier(code_verifier) or not hmac.compare_digest(_s256(code_verifier), challenge):
+                raise OAuthError("invalid_grant", "Authorization code validation failed.")
+
+        scope = self.normalize_scope(item["scope"])
+        self._require_capacity(self.used_auth_codes, self.max_auth_codes, "Authorization-code replay cache")
+        self._require_capacity(self.access_tokens, self.max_access_tokens, "Access-token")
+        if "offline_access" in scope.split():
+            self._require_capacity(self.refresh_tokens, self.max_refresh_tokens, "Refresh-token")
+
+        access_value, access_item = self._new_access_token(
+            client_id=client_id,
+            scope=scope,
+            resource=item["resource"],
+        )
+        response: dict[str, Any] = {
+            "access_token": access_value,
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_TTL_SECONDS,
+            "scope": scope,
+        }
+        refresh_value = ""
+        refresh_item: dict[str, Any] | None = None
+        if "offline_access" in scope.split():
+            refresh_value, refresh_item = self._new_refresh_token(client_id=client_id, scope=scope)
+            response["refresh_token"] = refresh_value
+
+        self.used_auth_codes[nonce] = {"expires_at": item["expires_at"]}
+        self.access_tokens[access_value] = access_item
+        if refresh_item is not None:
+            self.refresh_tokens[refresh_value] = refresh_item
+        return response
+
+    def exchange_refresh_token(
+        self,
+        *,
+        refresh_token: str,
+        client_id: str,
+        requested_scope: str,
+    ) -> dict[str, Any]:
+        self.cleanup()
+        item = self.refresh_tokens.get(refresh_token)
+        if not item or item.get("expires_at", 0) <= time.time():
+            self.refresh_tokens.pop(refresh_token, None)
+            raise OAuthError("invalid_grant", "Invalid, expired, or already used refresh token.")
+        if item.get("client_id") != client_id:
+            raise OAuthError("invalid_grant", "Refresh token validation failed.")
+        original_scope = self.normalize_scope(item["scope"])
+        scope = self.normalize_scope(requested_scope) if requested_scope.strip() else original_scope
+        if not set(scope.split()).issubset(original_scope.split()):
+            raise OAuthError("invalid_scope", "Requested scope exceeds the originally granted scope.")
+
+        self._require_capacity(self.access_tokens, self.max_access_tokens, "Access-token")
+        access_value, access_item = self._new_access_token(
+            client_id=client_id,
+            scope=scope,
+            resource=self.config.resource,
+        )
+        rotated_value, rotated_item = self._new_refresh_token(client_id=client_id, scope=scope)
+        self.refresh_tokens.pop(refresh_token, None)
+        self.refresh_tokens[rotated_value] = rotated_item
+        self.access_tokens[access_value] = access_item
+        return {
+            "access_token": access_value,
+            "token_type": "Bearer",
+            "expires_in": ACCESS_TOKEN_TTL_SECONDS,
+            "refresh_token": rotated_value,
+            "scope": scope,
+        }
+
+    def validate_access_token(self, token_value: str) -> bool:
+        if not token_value:
+            return False
+        self.cleanup()
+        item = self.access_tokens.get(token_value)
+        return bool(
+            item
+            and item.get("expires_at", 0) > time.time()
+            and item.get("resource") == self.config.resource
+        )
+
+
+def config_from_env() -> OAuthConfig | None:
+    if os.environ.get(OAUTH_ENABLE_ENV) != "1":
+        return None
+    required = {
+        OAUTH_ISSUER_ENV: os.environ.get(OAUTH_ISSUER_ENV, "").strip(),
+        OAUTH_CLIENT_ID_ENV: os.environ.get(OAUTH_CLIENT_ID_ENV, "").strip(),
+        OAUTH_CLIENT_SECRET_ENV: os.environ.get(OAUTH_CLIENT_SECRET_ENV, ""),
+        OAUTH_REDIRECT_URI_ENV: os.environ.get(OAUTH_REDIRECT_URI_ENV, "").strip(),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise ValueError(f"OAuth is enabled but required configuration is missing: {', '.join(missing)}")
+    redirects = tuple(
+        item.strip()
+        for item in required[OAUTH_REDIRECT_URI_ENV].replace("\n", ",").split(",")
+        if item.strip()
+    )
+    return OAuthConfig(
+        issuer=required[OAUTH_ISSUER_ENV],
+        client_id=required[OAUTH_CLIENT_ID_ENV],
+        client_secret=required[OAUTH_CLIENT_SECRET_ENV],
+        redirect_uris=redirects,
+        scope=os.environ.get(OAUTH_SCOPE_ENV, "hermes").strip() or "hermes",
+    )
+
+
+def static_bearer_from_env() -> str | None:
+    token_value = os.environ.get(AUTH_TOKEN_ENV, "")
+    if not token_value:
+        return None
+    if not _CLIENT_SECRET.fullmatch(token_value):
+        raise ValueError(f"{AUTH_TOKEN_ENV} must contain 43 to 128 URL-safe characters.")
+    return token_value
+
+
+def _s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _valid_pkce_verifier(verifier: str) -> bool:
+    return bool(_PKCE_VALUE.fullmatch(verifier))
+
+
+def _error_response(exc: OAuthError) -> JSONResponse:
+    headers = {"Cache-Control": "no-store", "Pragma": "no-cache"}
+    if exc.error == "invalid_client":
+        headers["WWW-Authenticate"] = "Basic realm=oauth-token"
+    return JSONResponse(
+        {"error": exc.error, "error_description": exc.description},
+        status_code=exc.status_code,
+        headers=headers,
+    )
+
+
+def validate_bearer_token(token_value: str, state: OAuthState | None, *, static_token: str | None = None) -> bool:
+    expected = (static_bearer_from_env() or "") if static_token is None else static_token
+    if expected and token_value and hmac.compare_digest(token_value, expected):
+        return True
+    return bool(state and state.validate_access_token(token_value))
+
+
+class DefaultMcpAcceptMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/mcp":
+            headers = list(scope.get("headers") or [])
+            accept_indexes = [index for index, (key, _value) in enumerate(headers) if key.lower() == b"accept"]
+            replacement = b"application/json, text/event-stream"
+            if not accept_indexes:
+                headers.append((b"accept", replacement))
+                scope = {**scope, "headers": headers}
+            else:
+                index = accept_indexes[-1]
+                value = headers[index][1].decode("latin-1").strip()
+                if not value or value == "*/*":
+                    headers[index] = (b"accept", replacement)
+                    scope = {**scope, "headers": headers}
+        await self.app(scope, receive, send)
+
+
+class BearerAuthMiddleware:
+    PUBLIC_PATHS = {
+        "/",
+        "/.well-known/oauth-protected-resource",
+        "/.well-known/oauth-protected-resource/mcp",
+        "/.well-known/oauth-authorization-server",
+        "/oauth/authorize",
+        "/oauth/token",
+    }
+
+    def __init__(self, app: ASGIApp, state: OAuthState | None = None, *, static_token: str | None = None) -> None:
+        self.app = app
+        self.state = state
+        self.static_token = static_token
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        expected_static = (static_bearer_from_env() or "") if self.static_token is None else self.static_token
+        if not expected_static and self.state is None:
+            await self.app(scope, receive, send)
+            return
+        if scope.get("method") == "OPTIONS" or scope.get("path") in self.PUBLIC_PATHS:
+            await self.app(scope, receive, send)
+            return
+        headers = {key.lower(): value for key, value in scope.get("headers") or []}
+        authorization = headers.get(b"authorization", b"").decode("latin-1")
+        supplied = authorization[7:].strip() if authorization.lower().startswith("bearer ") else ""
+        if not validate_bearer_token(supplied, self.state, static_token=expected_static):
+            response = JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+
+def authorization_metadata(_request: Request, state: OAuthState) -> JSONResponse:
+    issuer = state.config.issuer
+    return JSONResponse(
+        {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/oauth/authorize",
+            "token_endpoint": f"{issuer}/oauth/token",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "token_endpoint_auth_methods_supported": ["client_secret_post", "client_secret_basic"],
+            "code_challenge_methods_supported": ["S256"],
+            "scopes_supported": list(state.config.supported_scopes),
+        }
+    )
+
+
+def protected_resource_metadata(_request: Request, state: OAuthState) -> JSONResponse:
+    return JSONResponse(
+        {
+            "resource": state.config.resource,
+            "authorization_servers": [state.config.issuer],
+            "bearer_methods_supported": ["header"],
+            "scopes_supported": list(state.config.supported_scopes),
+        }
+    )
+
+
+def _redirect_response(redirect_uri: str, values: list[tuple[str, str]]) -> RedirectResponse:
+    parsed = urllib.parse.urlparse(redirect_uri)
+    existing = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    location = urllib.parse.urlunparse(parsed._replace(query=urllib.parse.urlencode(existing + values)))
+    return RedirectResponse(location, status_code=302)
+
+
+def authorize(request: Request, state: OAuthState) -> JSONResponse | RedirectResponse:
+    params = request.query_params
+    client_id = params.get("client_id", "")
+    redirect_uri = params.get("redirect_uri", "")
+    if client_id != state.config.client_id:
+        return _error_response(OAuthError("invalid_client", "Unknown OAuth client.", status_code=401))
+    if redirect_uri not in state.config.redirect_uris:
+        return _error_response(OAuthError("invalid_request", "redirect_uri is not registered."))
+    try:
+        if params.get("response_type", "") != "code":
+            raise OAuthError("unsupported_response_type", "Only response_type=code is supported.")
+        scope = state.normalize_scope(params.get("scope", "") or state.config.scope)
+        resource = params.get("resource", "") or state.config.resource
+        if resource != state.config.resource:
+            raise OAuthError("invalid_target", "Requested resource is not supported.")
+        challenge = params.get("code_challenge", "")
+        method = params.get("code_challenge_method", "")
+        if challenge and (method != "S256" or not _PKCE_VALUE.fullmatch(challenge)):
+            raise OAuthError("invalid_request", "Only a valid S256 PKCE challenge is supported.")
+        if method and not challenge:
+            raise OAuthError("invalid_request", "code_challenge is required when a method is supplied.")
+        code = state.issue_authorization_code(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scope=scope,
+            resource=resource,
+            code_challenge=challenge,
+        )
+    except OAuthError as exc:
+        error_query = [("error", exc.error), ("error_description", exc.description)]
+        if params.get("state"):
+            error_query.append(("state", params["state"]))
+        return _redirect_response(redirect_uri, error_query)
+    query = [("code", code)]
+    if params.get("state"):
+        query.append(("state", params["state"]))
+    return _redirect_response(redirect_uri, query)
+
+
+def _form_value(form: dict[str, list[str]], name: str) -> str:
+    values = form.get(name) or []
+    return values[0] if values else ""
+
+
+def _client_credentials(request: Request, form: dict[str, list[str]]) -> tuple[str, str]:
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("basic "):
+        try:
+            decoded = base64.b64decode(authorization.split(" ", 1)[1], validate=True).decode("utf-8")
+        except Exception as exc:
+            raise OAuthError("invalid_client", "Invalid OAuth client credentials.", status_code=401) from exc
+        client_id, separator, client_secret = decoded.partition(":")
+        if not separator:
+            raise OAuthError("invalid_client", "Invalid OAuth client credentials.", status_code=401)
+        return urllib.parse.unquote(client_id), urllib.parse.unquote(client_secret)
+    return _form_value(form, "client_id"), _form_value(form, "client_secret")
+
+
+def _authenticate_client(request: Request, form: dict[str, list[str]], state: OAuthState) -> str:
+    client_id, client_secret = _client_credentials(request, form)
+    if not hmac.compare_digest(client_id, state.config.client_id):
+        raise OAuthError("invalid_client", "Invalid OAuth client credentials.", status_code=401)
+    if not hmac.compare_digest(client_secret, state.config.client_secret):
+        raise OAuthError("invalid_client", "Invalid OAuth client credentials.", status_code=401)
+    return client_id
+
+
+async def token(request: Request, state: OAuthState) -> JSONResponse:
+    try:
+        content_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        if content_type != "application/x-www-form-urlencoded":
+            raise OAuthError("invalid_request", "Token requests must use form encoding.")
+        content_length = request.headers.get("content-length", "")
+        if content_length:
+            try:
+                if int(content_length) > MAX_TOKEN_REQUEST_BYTES:
+                    raise OAuthError("invalid_request", "Token request is too large.")
+            except ValueError as exc:
+                raise OAuthError("invalid_request", "Invalid Content-Length header.") from exc
+        buffered = bytearray()
+        async for chunk in request.stream():
+            if len(buffered) + len(chunk) > MAX_TOKEN_REQUEST_BYTES:
+                raise OAuthError("invalid_request", "Token request is too large.")
+            buffered.extend(chunk)
+        body = bytes(buffered).decode("utf-8")
+        try:
+            form = urllib.parse.parse_qs(body, keep_blank_values=True, max_num_fields=32)
+        except ValueError as exc:
+            raise OAuthError("invalid_request", "Token request form is invalid.") from exc
+        grant_type = _form_value(form, "grant_type")
+        if not grant_type:
+            raise OAuthError("invalid_request", "grant_type is required.")
+        if grant_type not in {"authorization_code", "refresh_token"}:
+            raise OAuthError("unsupported_grant_type", "The requested grant type is not supported.")
+        client_id = _authenticate_client(request, form, state)
+        if grant_type == "authorization_code":
+            response = state.exchange_authorization_code(
+                code=_form_value(form, "code"),
+                client_id=client_id,
+                redirect_uri=_form_value(form, "redirect_uri"),
+                code_verifier=_form_value(form, "code_verifier"),
+            )
+        else:
+            refresh_token = _form_value(form, "refresh_token")
+            if not refresh_token:
+                raise OAuthError("invalid_request", "refresh_token is required.")
+            response = state.exchange_refresh_token(
+                refresh_token=refresh_token,
+                client_id=client_id,
+                requested_scope=_form_value(form, "scope"),
+            )
+        return JSONResponse(response, headers={"Cache-Control": "no-store", "Pragma": "no-cache"})
+    except UnicodeDecodeError:
+        return _error_response(OAuthError("invalid_request", "Token request is malformed."))
+    except OAuthError as exc:
+        return _error_response(exc)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ hermes-gpt = "server:main"
 include-package-data = true
 py-modules = [
   "server",
+  "oauth_auth",
   "operator_policy",
   "operator_cron",
   "operator_skills",
@@ -61,6 +62,7 @@ py-modules = [
 ]
 "share/hermes-gpt/docs" = [
   "docs/README.md",
+  "docs/oauth.md",
   "docs/operator-mode.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",

--- a/server.py
+++ b/server.py
@@ -2,14 +2,23 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import ipaddress
 import importlib.metadata
 import inspect
 import json
 import os
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any, List
 
+from starlette.applications import Starlette
+from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.routing import BaseRoute, Mount, Route
+
+import oauth_auth
 import operator_policy as op_policy
 import operator_cron as op_cron
 import operator_skills as op_skills
@@ -28,6 +37,7 @@ LOCAL_DEV_PROFILE = "local-dev"
 REMOTE_PROFILE = "remote"
 UNSAFE_REMOTE_ACK = "--i-understand-this-is-unsafe"
 UNSAFE_REMOTE_ENV = "HERMES_GPT_UNSAFE_REMOTE_NOAUTH"
+TRUSTED_PROXY_IPS_ENV = "HERMES_GPT_TRUSTED_PROXY_IPS"
 ENABLE_WRITE_ENV = "HERMES_GPT_ENABLE_WRITE"
 ENABLE_MEMORY_WRITE_ENV = "HERMES_GPT_ENABLE_MEMORY_WRITE"
 ENABLE_SESSION_SEARCH_ENV = "HERMES_GPT_ENABLE_SESSION_SEARCH"
@@ -290,12 +300,21 @@ def clean_error(tool_name: str, exc: Exception) -> RuntimeError:
 
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 import_hermes()
 
 
 def tool_meta(extra: dict[str, Any] | None = None) -> dict[str, Any]:
-    meta = dict(NOAUTH_META)
+    oauth_config = oauth_auth.config_from_env()
+    if oauth_config is not None:
+        meta: dict[str, Any] = {
+            "securitySchemes": [{"type": "oauth2", "scopes": [oauth_config.scope]}]
+        }
+    elif oauth_auth.static_bearer_from_env() is not None:
+        meta = {"securitySchemes": [{"type": "http", "scheme": "bearer"}]}
+    else:
+        meta = dict(NOAUTH_META)
     if extra:
         meta.update(extra)
     return meta
@@ -1302,6 +1321,107 @@ def hermes_swarm_approve(workflow_id: str, confirm: bool = False, dry_run: bool 
     )
 
 
+def oauth_state_from_env() -> oauth_auth.OAuthState | None:
+    config = oauth_auth.config_from_env()
+    return oauth_auth.OAuthState(config) if config is not None else None
+
+
+def auth_enabled() -> bool:
+    return oauth_auth.static_bearer_from_env() is not None or oauth_auth.config_from_env() is not None
+
+
+def trusted_proxy_ips_from_env() -> str:
+    raw_value = os.environ.get(TRUSTED_PROXY_IPS_ENV, "").strip()
+    if not raw_value:
+        return ""
+    addresses: list[str] = []
+    for value in raw_value.split(","):
+        candidate = value.strip()
+        try:
+            address = ipaddress.ip_address(candidate)
+        except ValueError as exc:
+            raise ValueError(f"{TRUSTED_PROXY_IPS_ENV} must contain only comma-separated IP addresses.") from exc
+        if not address.is_loopback:
+            raise ValueError(f"{TRUSTED_PROXY_IPS_ENV} accepts loopback proxy addresses only.")
+        addresses.append(str(address))
+    return ",".join(dict.fromkeys(addresses))
+
+
+def authenticated_http_security_options(
+    *,
+    profile: str,
+    host: str,
+    cert: str | None,
+    key: str | None,
+    configured_auth: bool,
+) -> tuple[bool, str]:
+    if bool(cert) != bool(key):
+        raise SystemExit("TLS requires both --cert and --key.")
+    if profile != REMOTE_PROFILE or not configured_auth:
+        return False, ""
+    if cert and key:
+        return False, ""
+    try:
+        trusted_proxies = trusted_proxy_ips_from_env()
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if not trusted_proxies or not is_loopback_host(host):
+        raise SystemExit(
+            "Authenticated remote mode requires direct TLS (--cert and --key), or a loopback bind behind an "
+            f"explicit trusted HTTPS proxy configured with {TRUSTED_PROXY_IPS_ENV}."
+        )
+    return True, trusted_proxies
+
+
+async def health_root(_request: Request) -> JSONResponse:
+    return JSONResponse({"status": "ok", "server": "hermes-gpt", "mcp_path": "/mcp"})
+
+
+def build_asgi_app(server: FastMCP, *, http: bool) -> Any:
+    oauth_state = getattr(server, "_hermes_oauth_state", None)
+    if oauth_state is not None and not http:
+        raise ValueError("Built-in OAuth is supported only with streamable HTTP (--http).")
+    raw_mcp_app = server.streamable_http_app() if http else server.sse_app()
+    mcp_app = oauth_auth.DefaultMcpAcceptMiddleware(raw_mcp_app)
+    routes: list[BaseRoute] = [Route("/", health_root, methods=["GET", "POST", "OPTIONS"])]
+    if oauth_state is not None:
+        async def resource_metadata(request: Request) -> JSONResponse:
+            return oauth_auth.protected_resource_metadata(request, oauth_state)
+
+        async def authorization_server_metadata(request: Request) -> JSONResponse:
+            return oauth_auth.authorization_metadata(request, oauth_state)
+
+        async def authorize(request: Request) -> Response:
+            return oauth_auth.authorize(request, oauth_state)
+
+        async def token(request: Request) -> JSONResponse:
+            return await oauth_auth.token(request, oauth_state)
+
+        routes.extend(
+            [
+                Route("/.well-known/oauth-protected-resource", resource_metadata, methods=["GET"]),
+                Route("/.well-known/oauth-protected-resource/mcp", resource_metadata, methods=["GET"]),
+                Route("/.well-known/oauth-authorization-server", authorization_server_metadata, methods=["GET"]),
+                Route("/oauth/authorize", authorize, methods=["GET"]),
+                Route("/oauth/token", token, methods=["POST"]),
+            ]
+        )
+    routes.append(Mount("/", app=mcp_app))
+    app = Starlette(routes=routes, lifespan=raw_mcp_app.router.lifespan_context)
+    issuer = oauth_state.config.issuer if oauth_state is not None else ""
+    parsed_issuer = urllib.parse.urlparse(issuer)
+    issuer_origin = f"{parsed_issuer.scheme}://{parsed_issuer.netloc}" if parsed_issuer.netloc else ""
+    origins = [origin for origin in ("https://chatgpt.com", issuer_origin) if origin]
+    static_bearer = oauth_auth.static_bearer_from_env() or ""
+    return CORSMiddleware(
+        oauth_auth.BearerAuthMiddleware(app, oauth_state, static_token=static_bearer),
+        allow_origins=origins,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+        max_age=86400,
+    )
+
+
 def build_server(
     *,
     host: str = "127.0.0.1",
@@ -1309,6 +1429,16 @@ def build_server(
     http: bool = False,
     include_local_settings: bool = False,
 ) -> FastMCP:
+    oauth_state = oauth_state_from_env()
+    allowed_hosts = [host, f"{host}:{port}", "127.0.0.1", f"127.0.0.1:{port}", "localhost", f"localhost:{port}"]
+    allowed_origins = ["https://chatgpt.com"]
+    if oauth_state is not None:
+        issuer = urllib.parse.urlparse(oauth_state.config.issuer)
+        if issuer.hostname:
+            allowed_hosts.append(issuer.hostname)
+            if issuer.port:
+                allowed_hosts.append(f"{issuer.hostname}:{issuer.port}")
+        allowed_origins.append(f"{issuer.scheme}://{issuer.netloc}")
     server = FastMCP(
         "hermes-gpt",
         host=host,
@@ -1318,7 +1448,12 @@ def build_server(
         message_path="/messages/",
         stateless_http=http,
         json_response=http,
+        transport_security=TransportSecuritySettings(
+            allowed_hosts=list(dict.fromkeys(allowed_hosts)),
+            allowed_origins=list(dict.fromkeys(allowed_origins)),
+        ),
     )
+    setattr(server, "_hermes_oauth_state", oauth_state)
     register_tools(server)
     return server
 
@@ -1573,7 +1708,7 @@ def _run_legacy_server(argv: list[str]) -> None:
         "--profile",
         choices=[LOCAL_DEV_PROFILE, REMOTE_PROFILE],
         default=LOCAL_DEV_PROFILE,
-        help="Release safety profile. Remote no-auth is refused unless explicitly acknowledged.",
+        help="Release safety profile. Remote mode requires authentication unless unsafe no-auth is explicitly acknowledged.",
     )
     parser.add_argument(
         UNSAFE_REMOTE_ACK,
@@ -1585,17 +1720,26 @@ def _run_legacy_server(argv: list[str]) -> None:
 
     if args.http and args.sse:
         raise SystemExit("Choose only one of --http or --sse.")
-    if args.profile == REMOTE_PROFILE and not (args.unsafe_remote_ack and env_enabled(UNSAFE_REMOTE_ENV)):
+    configured_auth = auth_enabled()
+    proxy_headers, forwarded_allow_ips = authenticated_http_security_options(
+        profile=args.profile,
+        host=args.host,
+        cert=args.cert,
+        key=args.key,
+        configured_auth=configured_auth,
+    )
+    remote_unsafe_noauth = args.unsafe_remote_ack and env_enabled(UNSAFE_REMOTE_ENV)
+    if args.profile == REMOTE_PROFILE and not (configured_auth or remote_unsafe_noauth):
         raise SystemExit(
-            "Remote profile requires real authentication, which is not implemented yet. "
+            "Remote profile requires real authentication. Configure a static bearer token or confidential-client OAuth. "
             f"For temporary experiments only, pass {UNSAFE_REMOTE_ACK} and set {UNSAFE_REMOTE_ENV}=1."
         )
-    if args.profile == LOCAL_DEV_PROFILE and not is_loopback_host(args.host):
+    if args.profile == LOCAL_DEV_PROFILE and not is_loopback_host(args.host) and not configured_auth:
         eprint(
             "WARNING: local-dev profile is bound to a non-loopback host. "
             "Do not expose hermes-gpt without real authentication."
         )
-    if args.profile == REMOTE_PROFILE:
+    if args.profile == REMOTE_PROFILE and remote_unsafe_noauth and not configured_auth:
         eprint("WARNING: remote no-auth mode is explicitly unsafe and intended only for temporary experiments.")
 
     transport = "streamable-http" if args.http else "sse" if args.sse else "stdio"
@@ -1610,7 +1754,7 @@ def _run_legacy_server(argv: list[str]) -> None:
         # Run with uvicorn instead of FastMCP.run() so TLS can be enabled for
         # local-only testing when cert/key are provided.
         import uvicorn
-        app = server.streamable_http_app() if args.http else server.sse_app()
+        app = build_asgi_app(server, http=args.http)
 
         uvicorn.run(
             app,
@@ -1618,8 +1762,8 @@ def _run_legacy_server(argv: list[str]) -> None:
             port=args.port,
             ssl_certfile=args.cert if args.cert else None,
             ssl_keyfile=args.key if args.key else None,
-            proxy_headers=True,
-            forwarded_allow_ips="*",
+            proxy_headers=proxy_headers,
+            forwarded_allow_ips=forwarded_allow_ips,
         )
 
 

--- a/test_oauth_auth.py
+++ b/test_oauth_auth.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import time
+import urllib.parse
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from oauth_auth import (
+    ACCESS_TOKEN_TTL_SECONDS,
+    AUTH_TOKEN_ENV,
+    BearerAuthMiddleware,
+    DefaultMcpAcceptMiddleware,
+    MAX_ACCESS_TOKENS,
+    MAX_AUTH_CODES,
+    MAX_REFRESH_TOKENS,
+    OAUTH_CLIENT_ID_ENV,
+    OAUTH_CLIENT_SECRET_ENV,
+    OAUTH_ENABLE_ENV,
+    OAUTH_ISSUER_ENV,
+    OAUTH_REDIRECT_URI_ENV,
+    OAUTH_SCOPE_ENV,
+    OAuthConfig,
+    OAuthError,
+    OAuthState,
+    authorization_metadata,
+    authorize,
+    config_from_env,
+    protected_resource_metadata,
+    token,
+    validate_bearer_token,
+)
+
+
+CLIENT_ID = "chatgpt-client"
+CLIENT_SECRET = "test-client-secret-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+REDIRECT_URI = "https://chatgpt.com/connector/oauth/callback"
+ISSUER = "https://mcp.example.com"
+RESOURCE = f"{ISSUER}/mcp"
+STATIC_BEARER = "test-static-bearer-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+@pytest.fixture
+def oauth_state() -> OAuthState:
+    return OAuthState(
+        OAuthConfig(
+            issuer=ISSUER,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            redirect_uris=(REDIRECT_URI,),
+            scope="hermes",
+        )
+    )
+
+
+@pytest.fixture
+def oauth_client(oauth_state: OAuthState) -> TestClient:
+    async def resource_endpoint(request):
+        return protected_resource_metadata(request, oauth_state)
+
+    async def metadata_endpoint(request):
+        return authorization_metadata(request, oauth_state)
+
+    async def authorize_endpoint(request):
+        return authorize(request, oauth_state)
+
+    async def token_endpoint(request):
+        return await token(request, oauth_state)
+
+    app = Starlette(
+        routes=[
+            Route("/.well-known/oauth-protected-resource", resource_endpoint),
+            Route("/.well-known/oauth-protected-resource/mcp", resource_endpoint),
+            Route("/.well-known/oauth-authorization-server", metadata_endpoint),
+            Route("/oauth/authorize", authorize_endpoint),
+            Route("/oauth/token", token_endpoint, methods=["POST"]),
+        ]
+    )
+    return TestClient(app)
+
+
+def authorize_code(
+    client: TestClient,
+    *,
+    scope: str = "openid hermes offline_access",
+    code_challenge: str | None = None,
+    resource: str = RESOURCE,
+) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": scope,
+        "state": "state-value",
+        "resource": resource,
+    }
+    if code_challenge:
+        params.update({"code_challenge": code_challenge, "code_challenge_method": "S256"})
+    response = client.get("/oauth/authorize", params=params, follow_redirects=False)
+    assert response.status_code == 302
+    location = urllib.parse.urlparse(response.headers["location"])
+    return urllib.parse.parse_qs(location.query)["code"][0]
+
+
+def exchange_code(
+    client: TestClient,
+    code: str,
+    *,
+    secret: str = CLIENT_SECRET,
+    code_verifier: str | None = None,
+):
+    data = {
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "client_secret": secret,
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+    }
+    if code_verifier:
+        data["code_verifier"] = code_verifier
+    return client.post("/oauth/token", data=data)
+
+
+def refresh(client: TestClient, refresh_token: str, *, secret: str = CLIENT_SECRET, scope: str | None = None):
+    data = {
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "client_secret": secret,
+        "refresh_token": refresh_token,
+    }
+    if scope is not None:
+        data["scope"] = scope
+    return client.post("/oauth/token", data=data)
+
+
+def s256(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+
+
+def test_config_requires_a_confidential_client_secret():
+    with pytest.raises(ValueError, match="43 to 128"):
+        OAuthConfig(
+            issuer=ISSUER,
+            client_id=CLIENT_ID,
+            client_secret="short",
+            redirect_uris=(REDIRECT_URI,),
+            scope="hermes",
+        )
+
+
+@pytest.mark.parametrize(
+    ("issuer", "redirect_uri"),
+    [
+        ("https://mcp.example.com/subpath", REDIRECT_URI),
+        ("https://user:pass@mcp.example.com", REDIRECT_URI),
+        (ISSUER, "https://user:pass@chatgpt.com/connector/oauth/callback"),
+    ],
+)
+def test_config_rejects_subpath_issuers_and_url_userinfo(issuer: str, redirect_uri: str):
+    with pytest.raises(ValueError):
+        OAuthConfig(
+            issuer=issuer,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+            redirect_uris=(redirect_uri,),
+        )
+
+
+def test_environment_config_is_disabled_by_default_and_requires_complete_confidential_client(monkeypatch):
+    for name in (
+        OAUTH_ENABLE_ENV,
+        OAUTH_ISSUER_ENV,
+        OAUTH_CLIENT_ID_ENV,
+        OAUTH_CLIENT_SECRET_ENV,
+        OAUTH_REDIRECT_URI_ENV,
+        OAUTH_SCOPE_ENV,
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert config_from_env() is None
+
+    monkeypatch.setenv(OAUTH_ENABLE_ENV, "1")
+    monkeypatch.setenv(OAUTH_ISSUER_ENV, ISSUER)
+    monkeypatch.setenv(OAUTH_CLIENT_ID_ENV, CLIENT_ID)
+    monkeypatch.setenv(OAUTH_REDIRECT_URI_ENV, REDIRECT_URI)
+    with pytest.raises(ValueError, match=OAUTH_CLIENT_SECRET_ENV):
+        config_from_env()
+
+    monkeypatch.setenv(OAUTH_CLIENT_SECRET_ENV, CLIENT_SECRET)
+    configured = config_from_env()
+    assert configured is not None
+    assert configured.client_id == CLIENT_ID
+    assert configured.redirect_uris == (REDIRECT_URI,)
+
+
+def test_discovery_truthfully_advertises_implemented_capabilities(oauth_client: TestClient):
+    metadata = oauth_client.get("/.well-known/oauth-authorization-server").json()
+    assert metadata["grant_types_supported"] == ["authorization_code", "refresh_token"]
+    assert metadata["token_endpoint_auth_methods_supported"] == ["client_secret_post", "client_secret_basic"]
+    assert metadata["code_challenge_methods_supported"] == ["S256"]
+    assert set(metadata["scopes_supported"]) == {"hermes", "openid", "offline_access"}
+    assert "none" not in metadata["token_endpoint_auth_methods_supported"]
+    assert "jwks_uri" not in metadata
+    assert "id_token_signing_alg_values_supported" not in metadata
+
+
+def test_protected_resource_metadata_matches_authorization_server(oauth_client: TestClient):
+    resource = oauth_client.get("/.well-known/oauth-protected-resource").json()
+    path_derived_resource = oauth_client.get("/.well-known/oauth-protected-resource/mcp").json()
+    authorization = oauth_client.get("/.well-known/oauth-authorization-server").json()
+    assert resource["resource"] == RESOURCE
+    assert resource["authorization_servers"] == [ISSUER]
+    assert resource["scopes_supported"] == authorization["scopes_supported"]
+    assert path_derived_resource == resource
+
+
+def test_code_is_useless_without_client_authentication(oauth_client: TestClient):
+    code = authorize_code(oauth_client)
+    response = exchange_code(oauth_client, code, secret="")
+    assert response.status_code == 401
+    assert response.json()["error"] == "invalid_client"
+
+
+def test_wrong_client_secret_does_not_consume_authorization_code(oauth_client: TestClient):
+    code = authorize_code(oauth_client)
+    assert exchange_code(oauth_client, code, secret="wrong-secret-that-is-still-long-enough").status_code == 401
+    assert exchange_code(oauth_client, code).status_code == 200
+
+
+def test_signed_authorization_code_rejects_tampering_and_replay(oauth_client: TestClient):
+    code = authorize_code(oauth_client)
+    replacement = "A" if code[-1] != "A" else "B"
+    tampered = exchange_code(oauth_client, code[:-1] + replacement)
+    assert tampered.status_code == 400
+    assert tampered.json()["error"] == "invalid_grant"
+
+    assert exchange_code(oauth_client, code).status_code == 200
+    replay = exchange_code(oauth_client, code)
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "invalid_grant"
+
+
+def test_signed_authorization_code_rejects_noncanonical_base64url_spelling(
+    oauth_client: TestClient,
+):
+    code = authorize_code(oauth_client)
+    payload, signature = code.split(".", 1)
+    padding = "=" * (-len(signature) % 4)
+    decoded = base64.urlsafe_b64decode(signature + padding)
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    alternate = next(
+        candidate
+        for candidate in alphabet
+        if candidate != signature[-1]
+        and base64.urlsafe_b64decode(signature[:-1] + candidate + padding) == decoded
+    )
+    response = exchange_code(oauth_client, f"{payload}.{signature[:-1]}{alternate}")
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_grant"
+
+
+def test_process_restart_invalidates_signed_authorization_codes(oauth_state: OAuthState):
+    code = oauth_state.issue_authorization_code(
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        scope="hermes",
+        resource=RESOURCE,
+        code_challenge="",
+    )
+    restarted = OAuthState(oauth_state.config)
+    with pytest.raises(OAuthError) as exc_info:
+        restarted.exchange_authorization_code(
+            code=code,
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            code_verifier="",
+        )
+    assert exc_info.value.error == "invalid_grant"
+
+
+def test_token_endpoint_rejects_oversized_form_body(oauth_client: TestClient):
+    response = oauth_client.post(
+        "/oauth/token",
+        content=b"grant_type=authorization_code&padding=" + (b"x" * 17000),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_request"
+
+
+def test_token_endpoint_stops_reading_chunked_body_at_limit(oauth_state: OAuthState):
+    chunks = [b"x" * 10000, b"y" * 10000, b"z" * 10000]
+    receive_calls = 0
+
+    async def receive():
+        nonlocal receive_calls
+        chunk = chunks[receive_calls]
+        receive_calls += 1
+        return {"type": "http.request", "body": chunk, "more_body": receive_calls < len(chunks)}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/oauth/token",
+            "headers": [(b"content-type", b"application/x-www-form-urlencoded")],
+        },
+        receive,
+    )
+    response = asyncio.run(token(request, oauth_state))
+    assert response.status_code == 400
+    assert receive_calls == 2
+
+
+def test_authorization_code_exchange_preserves_legacy_chatgpt_request_without_pkce(oauth_client: TestClient):
+    code = authorize_code(oauth_client, scope="openid hermes")
+    response = exchange_code(oauth_client, code)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["expires_in"] == ACCESS_TOKEN_TTL_SECONDS
+    assert body["scope"] == "openid hermes"
+    assert "refresh_token" not in body
+
+
+def test_pkce_s256_is_enforced_when_the_client_supplies_a_challenge(oauth_client: TestClient):
+    verifier = "a" * 64
+    code = authorize_code(oauth_client, code_challenge=s256(verifier))
+    missing = exchange_code(oauth_client, code)
+    assert missing.status_code == 400
+    assert missing.json()["error"] == "invalid_grant"
+    wrong = exchange_code(oauth_client, code, code_verifier="b" * 64)
+    assert wrong.status_code == 400
+    assert wrong.json()["error"] == "invalid_grant"
+    assert exchange_code(oauth_client, code, code_verifier=verifier).status_code == 200
+
+
+def test_invalid_pkce_method_and_resource_redirect_errors_with_state(oauth_client: TestClient):
+    common = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": "hermes",
+        "state": "opaque-state",
+    }
+    bad_method = oauth_client.get(
+        "/oauth/authorize",
+        params={**common, "code_challenge": "x" * 43, "code_challenge_method": "plain"},
+        follow_redirects=False,
+    )
+    assert bad_method.status_code == 302
+    method_error = urllib.parse.parse_qs(urllib.parse.urlparse(bad_method.headers["location"]).query)
+    assert method_error["error"] == ["invalid_request"]
+    assert method_error["state"] == ["opaque-state"]
+
+    bad_resource = oauth_client.get(
+        "/oauth/authorize",
+        params={**common, "resource": "https://attacker.example/mcp"},
+        follow_redirects=False,
+    )
+    assert bad_resource.status_code == 302
+    resource_error = urllib.parse.parse_qs(urllib.parse.urlparse(bad_resource.headers["location"]).query)
+    assert resource_error["error"] == ["invalid_target"]
+    assert resource_error["state"] == ["opaque-state"]
+
+
+def test_resource_scope_is_required_for_authorization_and_refresh(oauth_client: TestClient):
+    denied = oauth_client.get(
+        "/oauth/authorize",
+        params={
+            "response_type": "code",
+            "client_id": CLIENT_ID,
+            "redirect_uri": REDIRECT_URI,
+            "scope": "openid offline_access",
+        },
+        follow_redirects=False,
+    )
+    denied_query = urllib.parse.parse_qs(urllib.parse.urlparse(denied.headers["location"]).query)
+    assert denied_query["error"] == ["invalid_scope"]
+
+    issued = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    narrowed_too_far = refresh(oauth_client, issued["refresh_token"], scope="openid offline_access")
+    assert narrowed_too_far.status_code == 400
+    assert narrowed_too_far.json()["error"] == "invalid_scope"
+
+
+def test_offline_access_issues_rotating_client_bound_refresh_token(oauth_client: TestClient):
+    initial = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    assert initial["refresh_token"]
+    refreshed_response = refresh(oauth_client, initial["refresh_token"])
+    assert refreshed_response.status_code == 200
+    refreshed = refreshed_response.json()
+    assert refreshed["access_token"] != initial["access_token"]
+    assert refreshed["refresh_token"] != initial["refresh_token"]
+    replay = refresh(oauth_client, initial["refresh_token"])
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "invalid_grant"
+
+
+def test_wrong_refresh_client_secret_does_not_consume_token(oauth_client: TestClient):
+    initial = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    denied = refresh(oauth_client, initial["refresh_token"], secret="wrong-secret-that-is-still-long-enough")
+    assert denied.status_code == 401
+    assert refresh(oauth_client, initial["refresh_token"]).status_code == 200
+
+
+def test_refresh_expiry_unknown_and_scope_escalation_fail_closed(oauth_client: TestClient, oauth_state: OAuthState):
+    unknown = refresh(oauth_client, "unknown-refresh-token")
+    assert unknown.status_code == 400
+    assert unknown.json()["error"] == "invalid_grant"
+
+    initial = exchange_code(
+        oauth_client,
+        authorize_code(oauth_client, scope="hermes offline_access"),
+    ).json()
+    escalated = refresh(oauth_client, initial["refresh_token"], scope="openid hermes offline_access")
+    assert escalated.status_code == 400
+    assert escalated.json()["error"] == "invalid_scope"
+
+    oauth_state.refresh_tokens[initial["refresh_token"]]["expires_at"] = time.time() - 1
+    expired = refresh(oauth_client, initial["refresh_token"])
+    assert expired.status_code == 400
+    assert expired.json()["error"] == "invalid_grant"
+
+
+def test_authorization_code_replay_access_and_refresh_stores_are_bounded(oauth_state: OAuthState):
+    assert oauth_state.max_auth_codes == MAX_AUTH_CODES
+    assert oauth_state.max_access_tokens == MAX_ACCESS_TOKENS
+    assert oauth_state.max_refresh_tokens == MAX_REFRESH_TOKENS
+
+    code = oauth_state.issue_authorization_code(
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        scope="hermes",
+        resource=RESOURCE,
+        code_challenge="",
+    )
+    oauth_state.used_auth_codes.update(
+        {f"nonce-{index}": {"expires_at": time.time() + 60} for index in range(MAX_AUTH_CODES)}
+    )
+    with pytest.raises(OAuthError, match="capacity") as exc_info:
+        oauth_state.exchange_authorization_code(
+            code=code,
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            code_verifier="",
+        )
+    assert exc_info.value.error == "temporarily_unavailable"
+
+
+def test_public_authorization_requests_do_not_consume_replay_cache(oauth_state: OAuthState):
+    latest = ""
+    for _index in range(MAX_AUTH_CODES * 2):
+        latest = oauth_state.issue_authorization_code(
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            scope="hermes",
+            resource=RESOURCE,
+            code_challenge="",
+        )
+    assert oauth_state.used_auth_codes == {}
+    assert oauth_state.exchange_authorization_code(
+        code=latest,
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        code_verifier="",
+    )["access_token"]
+
+
+def test_access_store_exact_capacity_fails_closed_without_consuming_code(oauth_state: OAuthState):
+    code = oauth_state.issue_authorization_code(
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        scope="hermes",
+        resource=RESOURCE,
+        code_challenge="",
+    )
+    oauth_state.access_tokens.update(
+        {f"access-{index}": {"expires_at": time.time() + 60} for index in range(MAX_ACCESS_TOKENS)}
+    )
+    with pytest.raises(OAuthError, match="capacity") as exc_info:
+        oauth_state.exchange_authorization_code(
+            code=code,
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            code_verifier="",
+        )
+    assert exc_info.value.error == "temporarily_unavailable"
+    oauth_state.access_tokens.pop("access-0")
+    assert oauth_state.exchange_authorization_code(
+        code=code,
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        code_verifier="",
+    )["access_token"]
+
+
+def test_refresh_store_exact_capacity_fails_closed_without_consuming_code(oauth_state: OAuthState):
+    code = oauth_state.issue_authorization_code(
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        scope="hermes offline_access",
+        resource=RESOURCE,
+        code_challenge="",
+    )
+    oauth_state.refresh_tokens.update(
+        {f"refresh-{index}": {"expires_at": time.time() + 60} for index in range(MAX_REFRESH_TOKENS)}
+    )
+    with pytest.raises(OAuthError, match="capacity") as exc_info:
+        oauth_state.exchange_authorization_code(
+            code=code,
+            client_id=CLIENT_ID,
+            redirect_uri=REDIRECT_URI,
+            code_verifier="",
+        )
+    assert exc_info.value.error == "temporarily_unavailable"
+    oauth_state.refresh_tokens.pop("refresh-0")
+    assert oauth_state.exchange_authorization_code(
+        code=code,
+        client_id=CLIENT_ID,
+        redirect_uri=REDIRECT_URI,
+        code_verifier="",
+    )["refresh_token"]
+
+
+def test_cleanup_removes_only_expired_credentials(oauth_client: TestClient, oauth_state: OAuthState):
+    expired = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    active = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    oauth_state.access_tokens[expired["access_token"]]["expires_at"] = time.time() - 1
+    oauth_state.refresh_tokens[expired["refresh_token"]]["expires_at"] = time.time() - 1
+    oauth_state.cleanup()
+    assert expired["access_token"] not in oauth_state.access_tokens
+    assert expired["refresh_token"] not in oauth_state.refresh_tokens
+    assert active["access_token"] in oauth_state.access_tokens
+    assert active["refresh_token"] in oauth_state.refresh_tokens
+
+
+def test_credentials_are_absent_from_metadata_and_errors(oauth_client: TestClient):
+    issued = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    observed = str(oauth_client.get("/.well-known/oauth-authorization-server").json())
+    observed += str(refresh(oauth_client, issued["refresh_token"], secret="wrong-secret-that-is-still-long-enough").json())
+    assert CLIENT_SECRET not in observed
+    assert issued["access_token"] not in observed
+    assert issued["refresh_token"] not in observed
+
+
+def test_bearer_middleware_preserves_static_token_compatibility(monkeypatch: pytest.MonkeyPatch, oauth_state: OAuthState):
+    async def endpoint(_request):
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setenv(AUTH_TOKEN_ENV, STATIC_BEARER)
+    app = BearerAuthMiddleware(Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])]), oauth_state)
+    client = TestClient(app)
+    assert client.post("/mcp").status_code == 401
+    assert client.post("/mcp", headers={"Authorization": f"Bearer {STATIC_BEARER}"}).status_code == 200
+
+
+def test_refreshed_access_token_passes_bearer_middleware(oauth_client: TestClient, oauth_state: OAuthState):
+    issued = exchange_code(oauth_client, authorize_code(oauth_client)).json()
+    refreshed = refresh(oauth_client, issued["refresh_token"]).json()
+    assert validate_bearer_token(refreshed["access_token"], oauth_state, static_token="")
+
+
+def test_accept_middleware_normalizes_only_missing_or_wildcard_accept_header():
+    async def endpoint(request):
+        return JSONResponse({"accept": request.headers.get("accept")})
+
+    app = DefaultMcpAcceptMiddleware(Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])]))
+    client = TestClient(app)
+    missing = client.post("/mcp", headers={"Accept": ""}).json()["accept"]
+    wildcard = client.post("/mcp", headers={"Accept": "*/*"}).json()["accept"]
+    explicit = client.post("/mcp", headers={"Accept": "application/json"}).json()["accept"]
+    assert missing == "application/json, text/event-stream"
+    assert wildcard == "application/json, text/event-stream"
+    assert explicit == "application/json"

--- a/test_server.py
+++ b/test_server.py
@@ -5,12 +5,15 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from starlette.testclient import TestClient
 
+import oauth_auth
 import server
 
 
@@ -22,6 +25,14 @@ GATE_ENVS = [
     server.ENABLE_VISION_ENV,
     server.ENABLE_WEB_ENV,
     server.UNSAFE_REMOTE_ENV,
+    oauth_auth.AUTH_TOKEN_ENV,
+    oauth_auth.OAUTH_ENABLE_ENV,
+    oauth_auth.OAUTH_ISSUER_ENV,
+    oauth_auth.OAUTH_CLIENT_ID_ENV,
+    oauth_auth.OAUTH_CLIENT_SECRET_ENV,
+    oauth_auth.OAUTH_REDIRECT_URI_ENV,
+    oauth_auth.OAUTH_SCOPE_ENV,
+    server.TRUSTED_PROXY_IPS_ENV,
 ]
 
 
@@ -297,6 +308,158 @@ def test_remote_profile_requires_explicit_unsafe_ack(monkeypatch):
 
     with pytest.raises(SystemExit, match="Remote profile requires real authentication"):
         server.main()
+
+
+def test_http_asgi_app_exposes_confidential_oauth_and_protects_mcp(monkeypatch):
+    monkeypatch.setenv(oauth_auth.OAUTH_ENABLE_ENV, "1")
+    monkeypatch.setenv(oauth_auth.OAUTH_ISSUER_ENV, "https://mcp.example.com")
+    monkeypatch.setenv(oauth_auth.OAUTH_CLIENT_ID_ENV, "chatgpt-client")
+    monkeypatch.setenv(
+        oauth_auth.OAUTH_CLIENT_SECRET_ENV,
+        "test-client-secret-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    )
+    monkeypatch.setenv(
+        oauth_auth.OAUTH_REDIRECT_URI_ENV,
+        "https://chatgpt.com/connector/oauth/callback",
+    )
+    built = server.build_server(http=True)
+    for tool in tools_by_name(built).values():
+        assert tool.meta == {"securitySchemes": [{"type": "oauth2", "scopes": ["hermes"]}]}
+    app = server.build_asgi_app(built, http=True)
+    with TestClient(app, base_url="https://mcp.example.com") as client:
+        metadata = client.get("/.well-known/oauth-authorization-server")
+        assert metadata.status_code == 200
+        assert "refresh_token" in metadata.json()["grant_types_supported"]
+        unauthenticated = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert unauthenticated.status_code == 401
+
+        authorization = client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": "chatgpt-client",
+                "redirect_uri": "https://chatgpt.com/connector/oauth/callback",
+                "scope": "openid hermes offline_access",
+                "resource": "https://mcp.example.com/mcp",
+            },
+            follow_redirects=False,
+        )
+        code = urllib.parse.parse_qs(
+            urllib.parse.urlparse(authorization.headers["location"]).query
+        )["code"][0]
+        issued = client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "chatgpt-client",
+                "client_secret": "test-client-secret-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+                "code": code,
+                "redirect_uri": "https://chatgpt.com/connector/oauth/callback",
+            },
+        ).json()
+        authenticated = client.post(
+            "/mcp",
+            headers={"Authorization": f"Bearer {issued['access_token']}"},
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        )
+        assert authenticated.status_code == 200
+
+
+def test_auth_enabled_requires_complete_valid_oauth_configuration(monkeypatch):
+    monkeypatch.setenv(oauth_auth.OAUTH_ENABLE_ENV, "1")
+    monkeypatch.delenv(oauth_auth.OAUTH_CLIENT_SECRET_ENV, raising=False)
+    with pytest.raises(ValueError, match=oauth_auth.OAUTH_CLIENT_SECRET_ENV):
+        server.auth_enabled()
+
+
+def test_auth_enabled_rejects_weak_static_bearer(monkeypatch):
+    monkeypatch.delenv(oauth_auth.OAUTH_ENABLE_ENV, raising=False)
+    monkeypatch.setenv(oauth_auth.AUTH_TOKEN_ENV, "weak")
+    with pytest.raises(ValueError, match="43 to 128"):
+        server.auth_enabled()
+
+
+def test_static_bearer_tool_metadata_is_truthful(monkeypatch):
+    monkeypatch.delenv(oauth_auth.OAUTH_ENABLE_ENV, raising=False)
+    monkeypatch.setenv(
+        oauth_auth.AUTH_TOKEN_ENV,
+        "test-static-bearer-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    )
+    built = server.build_server(http=True)
+    for tool in tools_by_name(built).values():
+        assert tool.meta == {"securitySchemes": [{"type": "http", "scheme": "bearer"}]}
+
+
+def test_authenticated_remote_http_requires_tls_or_explicit_loopback_proxy(monkeypatch):
+    monkeypatch.delenv(server.TRUSTED_PROXY_IPS_ENV, raising=False)
+    with pytest.raises(SystemExit, match="direct TLS"):
+        server.authenticated_http_security_options(
+            profile=server.REMOTE_PROFILE,
+            host="127.0.0.1",
+            cert=None,
+            key=None,
+            configured_auth=True,
+        )
+
+    assert server.authenticated_http_security_options(
+        profile=server.REMOTE_PROFILE,
+        host="0.0.0.0",
+        cert="server.crt",
+        key="server.key",
+        configured_auth=True,
+    ) == (False, "")
+
+    monkeypatch.setenv(server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1,::1")
+    assert server.authenticated_http_security_options(
+        profile=server.REMOTE_PROFILE,
+        host="127.0.0.1",
+        cert=None,
+        key=None,
+        configured_auth=True,
+    ) == (True, "127.0.0.1,::1")
+
+
+def test_trusted_proxy_configuration_rejects_wildcards_and_nonloopback(monkeypatch):
+    for value in ("*", "0.0.0.0", "192.0.2.1"):
+        monkeypatch.setenv(server.TRUSTED_PROXY_IPS_ENV, value)
+        with pytest.raises(SystemExit):
+            server.authenticated_http_security_options(
+                profile=server.REMOTE_PROFILE,
+                host="127.0.0.1",
+                cert=None,
+                key=None,
+                configured_auth=True,
+            )
+
+    monkeypatch.setenv(server.TRUSTED_PROXY_IPS_ENV, "127.0.0.1")
+    with pytest.raises(SystemExit, match="loopback bind"):
+        server.authenticated_http_security_options(
+            profile=server.REMOTE_PROFILE,
+            host="0.0.0.0",
+            cert=None,
+            key=None,
+            configured_auth=True,
+        )
+
+
+def test_oauth_is_rejected_for_legacy_sse_transport(monkeypatch):
+    monkeypatch.setenv(oauth_auth.OAUTH_ENABLE_ENV, "1")
+    monkeypatch.setenv(oauth_auth.OAUTH_ISSUER_ENV, "https://mcp.example.com")
+    monkeypatch.setenv(oauth_auth.OAUTH_CLIENT_ID_ENV, "chatgpt-client")
+    monkeypatch.setenv(
+        oauth_auth.OAUTH_CLIENT_SECRET_ENV,
+        "test-client-secret-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    )
+    monkeypatch.setenv(
+        oauth_auth.OAUTH_REDIRECT_URI_ENV,
+        "https://chatgpt.com/connector/oauth/callback",
+    )
+    built = server.build_server(http=False)
+    with pytest.raises(ValueError, match="streamable HTTP"):
+        server.build_asgi_app(built, http=False)
 
 
 def test_default_hermes_root_normalizes_profile_scoped_env(monkeypatch):


### PR DESCRIPTION
Maintainer replacement for PR #11, preserving the exact contribution from @Dadmin88 at commit `826aa43f6c1316ce30faf622ec5e136805e8e243`.

Why this replacement exists:
- the original fork workflow remained stuck in `action_required` after approval;
- GitHub refused to rerun that attempt;
- this same-repository mirror allowed the exact contributor SHA to run through normal repository CI without modifying the code.

Validation on the exact contributor SHA is green:
- Python 3.10: pytest + py_compile PASS
- Python 3.11: pytest + py_compile PASS
- Python 3.12: pytest + py_compile PASS
- package build PASS
- twine check PASS
- artifact upload PASS

No contribution code was changed during the mirror. Original contribution and authorship: PR #11 by @Dadmin88.