### PR TITLE
fix: harden MCP reliability under sustained use

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,15 +1,38 @@
 """Keep unit tests isolated from the operator posture of the invoking shell."""
 
+import os
+
 import pytest
+
+
+_ISOLATED_ENV_VARS = (
+    "HERMES_GPT_OPERATOR_ENABLED",
+    "HERMES_GPT_OPERATOR_LEVEL",
+    "HERMES_GPT_OPERATOR_APPLY_MODE",
+    "HERMES_GPT_OPERATOR_ALLOWED_PATHS",
+    "HERMES_GPT_OPERATOR_ALLOWED_PROFILES",
+    "HERMES_GPT_OWNER_ACK",
+    "HERMES_GPT_OWNER_ACTIVE",
+    "HERMES_GPT_ENABLE_CODEX_RUNNER",
+    "HERMES_GPT_ALLOW_CODEX_WRITE",
+    "HERMES_GPT_CODEX_TOOLSET",
+    "HERMES_GPT_CODEX_EXE",
+    "HERMES_GPT_OAUTH_ENABLE",
+    "HERMES_GPT_OAUTH_ISSUER",
+    "HERMES_GPT_OAUTH_CLIENT_ID",
+    "HERMES_GPT_OAUTH_CLIENT_SECRET",
+    "HERMES_GPT_OAUTH_REDIRECT_URI",
+    "HERMES_GPT_OAUTH_SCOPE",
+    "HERMES_GPT_BEARER_TOKEN",
+)
+
+# conftest.py is imported before test modules are collected. Clear live auth
+# posture here as well as in the fixture so top-level imports remain hermetic.
+for _name in _ISOLATED_ENV_VARS:
+    os.environ.pop(_name, None)
 
 
 @pytest.fixture(autouse=True)
 def isolate_operator_environment(monkeypatch):
-    for name in (
-        "HERMES_GPT_OPERATOR_ENABLED", "HERMES_GPT_OPERATOR_LEVEL",
-        "HERMES_GPT_OPERATOR_APPLY_MODE", "HERMES_GPT_OPERATOR_ALLOWED_PATHS",
-        "HERMES_GPT_OPERATOR_ALLOWED_PROFILES", "HERMES_GPT_OWNER_ACK", "HERMES_GPT_OWNER_ACTIVE",
-        "HERMES_GPT_ENABLE_CODEX_RUNNER", "HERMES_GPT_ALLOW_CODEX_WRITE",
-        "HERMES_GPT_CODEX_TOOLSET", "HERMES_GPT_CODEX_EXE",
-    ):
+    for name in _ISOLATED_ENV_VARS:
         monkeypatch.delenv(name, raising=False)

--- a/operator_policy.py
+++ b/operator_policy.py
@@ -902,14 +902,18 @@ def run_argv(
     max_output_chars: int = 4096,
     timeout_cap: int = 600,
 ) -> tuple[int, str, str]:
-    """Run ``argv`` as a subprocess with shell=False (hard rule).
+    """Run ``argv`` with bounded output and process-group cleanup.
 
-    Returns (returncode, stdout, stderr). Output is truncated to a sane
-    bound to avoid filling the audit log or context window. ``timeout_cap``
-    defaults to 10 minutes; narrowly scoped callers such as the cron runner
-    may explicitly raise it, up to the hard two-hour ceiling below.
+    Every invocation gets its own process group on POSIX. If the command
+    times out, terminate the entire group before collecting stdout/stderr so
+    descendants cannot keep the pipes open and wedge the MCP tool call.
+    ``timeout_cap`` defaults to 10 minutes; narrowly scoped callers such as
+    the cron runner may explicitly raise it, up to the hard two-hour ceiling.
     """
+    import os
+    import signal
     import subprocess
+    import time
 
     if not isinstance(argv, list) or not argv:
         raise ValueError("argv must be a non-empty list")
@@ -917,31 +921,76 @@ def run_argv(
     safe_timeout_cap = max(1, min(int(timeout_cap), 7200))
     capped_timeout = max(1, min(int(timeout), safe_timeout_cap))
     capped_output = max(1, min(int(max_output_chars), 1_048_576))
+
+    popen_kwargs: dict[str, Any] = {
+        "cwd": workdir,
+        "env": env,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "shell": False,
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+
     try:
-        proc = subprocess.run(
-            argv,
-            cwd=workdir,
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=capped_timeout,
-            shell=False,  # hard rule: never shell=True
-        )
-    except subprocess.TimeoutExpired as exc:
-        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
-        err = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
-        return (
-            124,
-            _truncate(out, capped_output),
-            _truncate(err or f"timed out after {capped_timeout}s", capped_output),
-        )
+        proc = subprocess.Popen(argv, **popen_kwargs)
     except FileNotFoundError as exc:
         return (127, "", _truncate(str(exc), capped_output))
 
+    def terminate_process_group() -> None:
+        if os.name == "posix":
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                return
+
+            deadline = time.monotonic() + 0.25
+            while time.monotonic() < deadline:
+                try:
+                    os.killpg(proc.pid, 0)
+                except (ProcessLookupError, OSError):
+                    return
+                time.sleep(0.02)
+
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                pass
+        else:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+    try:
+        out, err = proc.communicate(timeout=capped_timeout)
+    except subprocess.TimeoutExpired as exc:
+        terminate_process_group()
+        try:
+            out, err = proc.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            out, err = proc.communicate()
+
+        if not out and isinstance(exc.stdout, str):
+            out = exc.stdout
+        if not err and isinstance(exc.stderr, str):
+            err = exc.stderr
+
+        return (
+            124,
+            _truncate(out or "", capped_output),
+            _truncate(err or f"timed out after {capped_timeout}s", capped_output),
+        )
+
     return (
         proc.returncode,
-        _truncate(proc.stdout, capped_output),
-        _truncate(proc.stderr, capped_output),
+        _truncate(out or "", capped_output),
+        _truncate(err or "", capped_output),
     )
 
 

--- a/test_mcp_transport_mode.py
+++ b/test_mcp_transport_mode.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+def test_http_defaults_to_stateless_json_transport(monkeypatch):
+    for name in (
+        "HERMES_GPT_OAUTH_ENABLE",
+        "HERMES_GPT_OAUTH_ISSUER",
+        "HERMES_GPT_OAUTH_CLIENT_ID",
+        "HERMES_GPT_OAUTH_CLIENT_SECRET",
+        "HERMES_GPT_OAUTH_REDIRECT_URI",
+        "HERMES_GPT_OAUTH_SCOPE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    import server
+
+    mcp = server.build_server(http=True)
+    assert mcp.settings.stateless_http is True
+    assert mcp.settings.json_response is True

--- a/test_operator_policy.py
+++ b/test_operator_policy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -497,20 +498,31 @@ def test_run_argv_runs_without_shell(tmp_path):
 
 def test_run_argv_allows_explicit_higher_timeout_cap(monkeypatch):
     import subprocess
-    from types import SimpleNamespace
 
     captured = {}
 
-    def fake_run(*_args, **kwargs):
-        captured["timeout"] = kwargs["timeout"]
-        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+    class FakeProcess:
+        pid = 12345
+        returncode = 0
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+        def communicate(self, *, timeout=None):
+            captured["timeout"] = timeout
+            return ("ok", "")
+
+    def fake_popen(*_args, **kwargs):
+        captured["start_new_session"] = kwargs.get("start_new_session")
+        return FakeProcess()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
     rc, out, err = op.run_argv(
         ["example"], timeout=1800, timeout_cap=7200
     )
     assert rc == 0
+    assert out == "ok"
+    assert err == ""
     assert captured["timeout"] == 1800
+    if os.name == "posix":
+        assert captured["start_new_session"] is True
 
 
 def test_run_argv_refuses_empty_argv():
@@ -522,3 +534,33 @@ def test_run_argv_handles_missing_executable():
     rc, out, err = op.run_argv(["this-binary-does-not-exist-xyz"], timeout=5)
     assert rc == 127
     assert err  # non-empty error
+
+
+def test_run_argv_timeout_kills_descendant_process_group(tmp_path):
+    if os.name != "posix":
+        pytest.skip("process-group timeout cleanup is POSIX-specific")
+
+    pid_file = tmp_path / "child.pid"
+    parent_script = (
+        "import pathlib, subprocess, sys, time; "
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']); "
+        "pathlib.Path(sys.argv[1]).write_text(str(child.pid)); "
+        "time.sleep(60)"
+    )
+
+    rc, out, err = op.run_argv(
+        [sys.executable, "-c", parent_script, str(pid_file)],
+        timeout=1,
+        workdir=str(tmp_path),
+    )
+
+    assert rc == 124
+    assert "timed out after 1s" in err
+    assert pid_file.exists()
+
+    child_pid = int(pid_file.read_text())
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and Path(f"/proc/{child_pid}").exists():
+        time.sleep(0.05)
+
+    assert not Path(f"/proc/{child_pid}").exists()


### PR DESCRIPTION
## Summary

This is a focused follow-up to the ChatGPT connector reliability work.

- run operator subprocesses in their own POSIX process group
- on timeout, terminate the entire group before draining stdout/stderr so descendants cannot keep pipes open and wedge an MCP tool call
- preserve the existing timeout-cap and bounded-output behavior
- add regression coverage that HTTP MCP remains stateless + JSON by default for ChatGPT-style streamable HTTP clients
- isolate tests from a live OAuth/bearer environment during collection and per-test execution so an operator shell cannot poison the suite

## Why

Under sustained tool use, a timed-out command could leave descendant processes alive. Those descendants could inherit the parent's stdout/stderr pipes, preventing the MCP request from unwinding cleanly and accumulating stuck work over time.

Current upstream `master` already uses stateless HTTP/JSON for the ChatGPT transport, so this PR does not duplicate or replace the OAuth/transport implementation merged through #13. It adds regression coverage for that invariant and ports only the still-missing subprocess-group cleanup.

## Validation

- `python -m pytest -q` — PASS (2 existing skips)
- `python -m pytest test_operator_policy.py -q -k run_argv` — 5 passed
- `python -m pytest test_mcp_transport_mode.py -q` — 1 passed
- `python -m py_compile operator_policy.py conftest.py test_operator_policy.py test_mcp_transport_mode.py` — PASS
- `git diff --check` — PASS

Branch is based directly on the current upstream `master` head at the time of submission.