### PR TITLE
feat: pluggable execution backends (Pi RPC, OMX) with runner tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
   workflow_call:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,50 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: python -m pip install -e ".[dev]"
-      - run: python -m pytest
-      - run: python -m py_compile server.py codex_core.py codex_mcp.py codex_config.py operator_codex.py updater.py operator_recovery.py operator_review.py operator_events.py operator_oauth.py token_store.py seams.py
+      - name: Run non-UI test suite
+        run: >-
+          python -m pytest -q
+          --ignore=test_ui_chat.py
+          --ignore=test_ui_security.py
+          --ignore=test_ui_static_assets.py
+      - name: Run runner regression tests
+        run: python -m pytest -q test_operator_runners.py
+      - name: Compile operator modules
+        run: >-
+          python -m py_compile
+          server.py
+          codex_core.py
+          codex_mcp.py
+          codex_config.py
+          operator_codex.py
+          operator_contract.py
+          operator_fleet.py
+          operator_runners.py
+          operator_swarm.py
+          operator_swarm_workflows.py
+          operator_workspace.py
+          updater.py
+          operator_recovery.py
+          operator_review.py
+          operator_events.py
+          operator_oauth.py
+          token_store.py
+          seams.py
+      - name: Check whitespace
+        run: git diff --check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install -e ".[dev]"
+      - run: python -m ruff check operator_runners.py test_operator_runners.py
 
   build:
-    needs: test
+    needs: [test, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,8 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - run: python -m pip install -e ".[dev]"
-      - name: Run non-UI test suite
-        run: >-
-          python -m pytest -q
-          --ignore=test_ui_chat.py
-          --ignore=test_ui_security.py
-          --ignore=test_ui_static_assets.py
+      - name: Run full test suite
+        run: python -m pytest -q
       - name: Run runner regression tests
         run: python -m pytest -q test_operator_runners.py
       - name: Compile operator modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Flight Deck: durable, interactive, verifiable autonomy.
 - Fixed CI hermeticity: `_call_skill_manager` no longer fails when the Hermes
   Agent source tree is absent (optional-import degradation); profile-scoping
   tests skip only when `hermes_constants` is unavailable.
+- Fixed explicit local-runner cancellation on Windows by routing durable worker
+  PIDs through the same platform-aware process-tree cleanup used by timeout
+  paths. A direct-process fallback now covers missing, timed-out, or failing
+  `taskkill` invocations.
 
 - Added explicit per-job Codex `execution_mode` with `normal` default and opt-in `nolo`. NOLO now uses Codex 0.147.0's `-a never` approval policy while retaining the requested read-only/workspace-write sandbox, Hermes approved-workspace, direct-mode, confirmation, audit, timeout, and redaction controls. The write gate is required only for `workspace-write`; NOLO expires with the job and does not create persistent global approval-bypass state.
 - Added Codex parity for the four session-history capabilities that were previously available only through the full ChatGPT connector, delivered through the separately installed Hermes GPT Session History integration and verified with direct native-tool calls.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,6 +14,10 @@ Files in this directory preserve technical design work produced before or during
 These are **design authority, not runtime authority**: verify any implementation
 claim against the current module and its tests before acting.
 
+## Active implementation notes
+
+- `pluggable-runner-architecture.md` — execution backend boundary for work contracts and swarm stages, including Pi RPC, OMX, Fleet/Codex compatibility adapters, third-party runner registration, observed-state validation, and deployment/source-of-truth policy.
+
 ## Historical v0.6 artifacts
 
 The following preserve v0.6.0 design work. They are **historical design

--- a/docs/design/pluggable-runner-architecture.md
+++ b/docs/design/pluggable-runner-architecture.md
@@ -44,7 +44,7 @@ Compatibility adapter for the existing raw Codex operator runner. It is not requ
 
 ## Extension mechanism
 
-External Python packages may register additional backends through the `hermes_gpt.runners` entry-point group. This allows OpenCode or other execution runtimes to be added without changing the contract dispatcher.
+External Python packages may register additional backends through the `hermes_gpt.runners` entry-point group. Automatic entry-point loading is opt-in via `HERMES_GPT_ENABLE_RUNNER_PLUGINS=1`; the default runtime loads only built-in backends. This allows OpenCode or other execution runtimes to be added without changing the contract dispatcher while avoiding import-time execution of unapproved third-party plugins.
 
 ## Contract shape
 
@@ -64,7 +64,7 @@ Example:
 }
 ```
 
-The `execution` block is optional. Secret-like option keys (tokens, API keys, credentials, passwords, private keys) are rejected; credentials belong in the runner's trusted environment/configuration, not in contracts.
+The `execution` block is optional. Secret-like option keys (tokens, API keys, credentials, passwords, private keys) are rejected; credentials belong in the runner's trusted environment/configuration, not in contracts. Runner options may narrow permissions but may not exceed the contract authorization class: read-only contracts cannot enable Pi write-capable tools or OMX/Codex workspace-write sandboxes.
 
 ## Swarm behavior
 
@@ -74,7 +74,7 @@ Explicit stage execution configuration takes precedence over legacy backend-spec
 
 ## Durable runner state
 
-Local runner state is stored under the Hermes data root in `runner-jobs`. This state is bounded and feeds the observed-run layer used by contract validation.
+Local runner state is stored under the Hermes data root in `runner-jobs`. This state is bounded and feeds the observed-run layer used by contract validation. The transient request envelope is mode `0600` and is deleted by the worker immediately after loading; model response text is not persisted in runner metadata. Cancellation is scoped to the job workspace and recorded through the operator audit trail.
 
 The invariant is:
 

--- a/docs/design/pluggable-runner-architecture.md
+++ b/docs/design/pluggable-runner-architecture.md
@@ -1,0 +1,97 @@
+# Pluggable execution runners
+
+Status: implementation-backed design note for `feat/pluggable-runners`.
+
+## Decision
+
+Hermes-gpt work contracts separate **work ownership** from **execution transport/runtime**.
+
+- `assigned_agent` and `assigned_profile` describe semantic ownership and authority.
+- Optional `execution.backend` selects how the work is executed.
+- Contracts without `execution` retain legacy behavior and dispatch through `fleet`.
+
+The runner boundary is implemented by `operator_runners.py` and consumed by `operator_contract.py` and swarm orchestration.
+
+## Runner interface
+
+A runner backend is responsible for:
+
+- availability/capability reporting;
+- dry-run planning;
+- dispatching one canonical work contract;
+- returning bounded status/observed-run state;
+- cancellation where the backend supports it.
+
+Runner output is not accepted as proof that a contract is complete. Contract validation continues to use observed state, declared artifacts/tests, review evidence, and authorization checks.
+
+## Built-in backends
+
+### `fleet`
+
+Compatibility backend for the pre-existing A2A/fleet work-order path. This remains the implicit default for contracts that omit `execution`.
+
+### `pi_rpc`
+
+Pi coding agent through its JSONL RPC protocol (`pi --mode rpc`). This is a protocol integration rather than scraping interactive CLI output.
+
+### `omx`
+
+Oh My Codex through its non-interactive `omx exec --json` automation surface.
+
+### `codex`
+
+Compatibility adapter for the existing raw Codex operator runner. It is not required when OMX is the preferred Codex orchestration layer.
+
+## Extension mechanism
+
+External Python packages may register additional backends through the `hermes_gpt.runners` entry-point group. This allows OpenCode or other execution runtimes to be added without changing the contract dispatcher.
+
+## Contract shape
+
+Example:
+
+```json
+{
+  "schema": "hermes.work-contract/v1",
+  "assigned_agent": "implementation",
+  "assigned_profile": "default",
+  "execution": {
+    "backend": "pi_rpc",
+    "options": {
+      "model": "provider/model"
+    }
+  }
+}
+```
+
+The `execution` block is optional. Secret-like option keys (tokens, API keys, credentials, passwords, private keys) are rejected; credentials belong in the runner's trusted environment/configuration, not in contracts.
+
+## Swarm behavior
+
+Workflow stages may select execution backends independently. A workflow can therefore route research, implementation, tests, review, or other stages to different runtimes without changing stage ownership semantics.
+
+Explicit stage execution configuration takes precedence over legacy backend-specific behavior. Existing workflows without execution selectors remain compatible.
+
+## Durable runner state
+
+Local runner state is stored under the Hermes data root in `runner-jobs`. This state is bounded and feeds the observed-run layer used by contract validation.
+
+The invariant is:
+
+> Runner self-report is transport data; Hermes validation decides whether the declared contract is satisfied.
+
+## Deployment and source-of-truth policy
+
+The Git checkout is the source of truth. Runtime `site-packages` must be produced from a tested commit/build, not edited manually as a normal development workflow.
+
+Promotion sequence:
+
+1. edit on a feature branch;
+2. run unit/integration tests and lint;
+3. commit the exact source revision;
+4. install/deploy that revision;
+5. restart/reload Hermes-gpt;
+6. smoke-test registered runners and a dry-run contract;
+7. record the deployed Git revision.
+
+Direct runtime patches are acceptable only as emergency/prototyping measures and must be reconciled back into Git before the next deployment.

--- a/docs/operator-mode.md
+++ b/docs/operator-mode.md
@@ -511,3 +511,41 @@ $env:HERMES_GPT_OWNER_ACK="I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE"
 - [Retention policy](retention-policy.md)
 - [v0.7.0 release notes](release-notes-v0.7.0.md)
 - [v0.6.0 release notes](release-notes-v0.6.0.md)
+
+
+## Runner backend trust boundaries
+
+Runner backends are execution transports for already-authorized work contracts;
+they are not completion authorities. Contract validation, expected artifacts,
+review requirements, and forbidden-action checks remain outside the backend.
+
+The built-in `pi_rpc` backend is intentionally **read-only** until Hermes GPT has
+a real filesystem confinement boundary. Starting a subprocess in a workspace is
+not a sandbox: absolute paths, `..` traversal, and shell `cd` can escape a plain
+current working directory. For that reason `pi_rpc` only permits Pi's `read` tool
+and rejects writable authorization classes. Use Fleet, Codex, or another backend
+with an appropriate sandbox boundary for write work.
+
+External runner plugins are trusted in-process code. Setting
+`HERMES_GPT_ENABLE_RUNNER_PLUGINS=1` only enables discovery; each external entry
+point must also be named in `HERMES_GPT_RUNNER_PLUGIN_ALLOWLIST`. Plugin code runs
+inside the Hermes GPT process and should be installed only from sources trusted
+as much as Hermes GPT itself.
+
+Deployments can constrain autonomous routing with comma-separated allowlists:
+
+- `HERMES_GPT_RUNNER_BACKEND_ALLOWLIST` for backend names such as `fleet`,
+  `pi_rpc`, `omx`, and `codex`.
+- `HERMES_GPT_RUNNER_PROVIDER_ALLOWLIST` for provider names selected by Pi.
+- `HERMES_GPT_RUNNER_MODEL_ALLOWLIST` for model names selected by Pi, OMX, or
+  Codex.
+
+Unset allowlists preserve compatibility and allow all values. Set allowlists are
+enforced before dispatch so contracts cannot silently route work into an
+unexpected backend, provider, or model.
+
+Local runner request envelopes are transient. Workers unlink `*.request.json`
+files immediately after loading them, and runner listing/status performs TTL
+cleanup of stale envelopes left by a process that died before loading its
+request. Durable runner metadata intentionally remains bounded state/exit data,
+not prompt text or model output.

--- a/docs/operator-mode.md
+++ b/docs/operator-mode.md
@@ -549,3 +549,8 @@ files immediately after loading them, and runner listing/status performs TTL
 cleanup of stale envelopes left by a process that died before loading its
 request. Durable runner metadata intentionally remains bounded state/exit data,
 not prompt text or model output.
+
+Local runner timeout and explicit-cancellation cleanup share one platform-aware
+path. POSIX signals the runner process group. Windows uses `taskkill /T /F` for
+the process tree and falls back to direct process termination if `taskkill` is
+unavailable, times out, or reports failure.

--- a/operator_contract.py
+++ b/operator_contract.py
@@ -55,6 +55,7 @@ import operator_policy as op
 import operator_fleet as op_fleet
 import operator_mission as mission
 import operator_workspace as op_workspace
+import operator_runners as op_runners
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -384,6 +385,7 @@ def _canonical_contract(raw: Any) -> tuple[str, dict[str, Any]]:
     if auth_value is None and isinstance(raw.get("completion_criteria"), dict):
         auth_value = raw["completion_criteria"].get("authorization")
     authorization = op_fleet._authorization(auth_value)
+    execution = op_runners.normalize_execution(raw.get("execution"))
 
     contract: dict[str, Any] = {
         "schema": CONTRACT_SCHEMA,
@@ -404,6 +406,11 @@ def _canonical_contract(raw: Any) -> tuple[str, dict[str, Any]]:
         "constraints": _string_list(raw.get("constraints") or [], field="constraints"),
         "authorization": authorization,
     }
+    # Backward compatibility: omit the default fleet selector from canonical
+    # contracts unless the caller explicitly supplied an execution block. This
+    # preserves hashes for pre-runner work contracts.
+    if execution is not None:
+        contract["execution"] = execution
     canonical = json.dumps(contract, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return canonical, contract
 
@@ -458,6 +465,12 @@ def _surface_contract(contract: dict[str, Any]) -> dict[str, Any]:
         }
         for a in contract.get("expected_artifacts", [])
     ]
+    if isinstance(contract.get("execution"), dict):
+        options = contract["execution"].get("options") or {}
+        surf["execution"] = {
+            "backend": contract["execution"].get("backend"),
+            "option_keys": sorted(str(k) for k in options.keys()),
+        }
     return surf
 
 
@@ -511,8 +524,16 @@ def _observed_delegations(task_id: str, hermes_root: Path) -> list[dict[str, Any
 
 
 def _observed_runs(task_id: str, hermes_root: Path) -> list[dict[str, Any]]:
-    """All observed run/outcome records for a task id (kanban + delegations)."""
-    return _observed_kanban_runs(task_id, hermes_root) + _observed_delegations(task_id, hermes_root)
+    """All observed run/outcome records for a task id.
+
+    Existing Mission Control sources remain authoritative for legacy/fleet work;
+    pluggable runner jobs contribute their own bounded durable state.
+    """
+    return (
+        _observed_kanban_runs(task_id, hermes_root)
+        + _observed_delegations(task_id, hermes_root)
+        + op_runners.observed_runs(task_id, hermes_root=hermes_root)
+    )
 
 
 def _observed_audit(limit: int = _MAX_REVIEW_EVIDENCE_SCAN) -> list[dict[str, Any]]:
@@ -936,56 +957,20 @@ def hermes_contract_dispatch(
         _audit_call(tool=tool, dry_run=True, success=False, changed=False, summary="duplicate task_id", contract_sha256=sha, task_id=task_id)
         return json.dumps(payload, ensure_ascii=False, indent=2)
 
-    # Map the contract onto the fleet work-order envelope (D2: extends it).
-    workspaces = contract["allowed_scope"]["workspaces"]
-    acceptance_checks = [
-        f"run_state outcome_ok={contract['completion_criteria']['run_state']['outcome_ok']}",
-        f"artifacts_present={contract['completion_criteria']['artifacts_present']}",
-        f"tests_pass={contract['completion_criteria']['tests_pass']}",
-        f"review_satisfied={contract['completion_criteria']['review_satisfied']}",
-        f"no_forbidden_actions={contract['completion_criteria']['no_forbidden_actions']}",
-    ]
-    deliverables = [a["path"] for a in contract["expected_artifacts"]]
+    # Dispatch through the selected execution backend. Contracts without an
+    # explicit selector continue to use the legacy fleet path.
+    payload = op_runners.dispatch_contract(
+        contract,
+        confirm=confirm,
+        dry_run=dry_run,
+        timeout=timeout,
+        hermes_root=root,
+        runner=runner,
+        hermes_bin=hermes_bin,
+        authority_manifest=authority_manifest,
+    )
 
-    try:
-        fleet_result = op_fleet.hermes_fleet_dispatch_work_order(
-            agent=contract["assigned_agent"],
-            task_id=task_id,
-            target_profile=contract["assigned_profile"],
-            objective=contract["objective"],
-            workspace=workspaces[0] if workspaces else "",
-            inputs=contract["inputs"],
-            constraints=contract["constraints"],
-            acceptance_checks=acceptance_checks,
-            deliverables=deliverables,
-            authorization=contract["authorization"],
-            confirm=confirm,
-            dry_run=dry_run,
-            timeout=timeout,
-            runner=runner,
-            hermes_bin=hermes_bin,
-            authority_manifest=authority_manifest,
-        )
-        payload = json.loads(fleet_result)
-    except Exception as exc:
-        payload = _contract_error(
-            code="CONTRACT_DISPATCH_ERROR",
-            safe_message=op.redact_output(str(exc))[:300],
-            suggested_action="Check fleet authority manifest, registry, and peer service.",
-            trace_id=tid,
-        )
-        _audit_call(
-            tool=tool,
-            dry_run=bool(policy.effective_dry_run(dry_run)),
-            success=False,
-            changed=False,
-            summary="dispatch failed",
-            contract_sha256=sha,
-            task_id=task_id,
-        )
-        return json.dumps(payload, ensure_ascii=False, indent=2)
-
-    # Augment the fleet envelope with the contract identity; keep shape bounded.
+    # Augment the backend envelope with the contract identity; keep shape bounded.
     payload["contract_sha256"] = sha
     payload["contract_task_id"] = task_id
     _audit_call(

--- a/operator_fleet.py
+++ b/operator_fleet.py
@@ -104,6 +104,11 @@ def _a2a_mode() -> str:
 
 
 def _hermes_bin(hermes_root: Path | None = None) -> str | None:
+    configured = os.environ.get("HERMES_CLI", "").strip()
+    if configured:
+        candidate = Path(configured).expanduser()
+        if candidate.is_file():
+            return str(candidate)
     root = hermes_root or op.normalize_hermes_data_root(os.environ.get("HERMES_HOME"))
     if root:
         for candidate in (root / "hermes-agent" / "venv" / "bin" / "hermes", root / "hermes-agent" / "venv" / "Scripts" / "hermes.exe"):
@@ -112,6 +117,9 @@ def _hermes_bin(hermes_root: Path | None = None) -> str | None:
     discovered = shutil.which("hermes")
     if discovered:
         return discovered
+    local_bin = Path.home() / ".local" / "bin" / "hermes"
+    if local_bin.is_file():
+        return str(local_bin)
     return None
 
 

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -116,24 +116,49 @@ def _popen_process_group(argv: list[str], **kwargs: Any) -> subprocess.Popen[str
     return subprocess.Popen(argv, **kwargs)
 
 
-def _terminate_process_tree(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
-    """Terminate the child process tree created by _popen_process_group.
+def _windows_taskkill(pid: int, *, timeout: float) -> bool:
+    """Terminate a Windows process tree, returning whether taskkill succeeded."""
+    try:
+        completed = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0
 
-    POSIX uses the child session/process group. Windows does not expose a true
-    process-tree kill through the Python standard library, so production Windows
-    cleanup uses taskkill /T /F for descendants and falls back to direct-child
-    terminate/kill if taskkill is unavailable.
+
+def _terminate_process_tree(proc: subprocess.Popen[Any] | int, *, timeout: float = 5.0) -> None:
+    """Terminate a process tree created by _popen_process_group.
+
+    Live Popen handles support bounded waits and escalation. Explicit runner
+    cancellation only has the durable worker PID, so an integer PID follows the
+    same platform dispatch without assuming this process owns a wait handle.
+
+    POSIX uses the child session/process group. Windows uses taskkill /T /F for
+    descendants and falls back to direct-process termination when taskkill is
+    unavailable, times out, or reports failure.
     """
-    if proc.poll() is not None:
+    detached = isinstance(proc, int)
+    pid = proc if detached else proc.pid
+    if pid <= 1 or (not detached and proc.poll() is not None):
         return
     if os.name == "nt":
-        try:
-            subprocess.run(["taskkill", "/PID", str(proc.pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout, check=False)
-        except (OSError, subprocess.TimeoutExpired):
+        tree_terminated = _windows_taskkill(pid, timeout=timeout)
+        if not tree_terminated:
             try:
-                proc.terminate()
-            except OSError:
+                if detached:
+                    # On Windows, os.kill(..., SIGTERM) uses TerminateProcess.
+                    os.kill(pid, signal.SIGTERM)
+                else:
+                    proc.terminate()
+            except (ProcessLookupError, PermissionError, OSError):
                 pass
+        if detached:
+            return
         try:
             proc.wait(timeout=timeout)
             return
@@ -148,16 +173,18 @@ def _terminate_process_tree(proc: subprocess.Popen[Any], *, timeout: float = 5.0
             pass
         return
     try:
-        os.killpg(proc.pid, signal.SIGTERM)
+        os.killpg(pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
         pass
+    if detached:
+        return
     try:
         proc.wait(timeout=timeout)
         return
     except subprocess.TimeoutExpired:
         pass
     try:
-        os.killpg(proc.pid, signal.SIGKILL)
+        os.killpg(pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError, OSError):
         pass
     try:
@@ -166,7 +193,7 @@ def _terminate_process_tree(proc: subprocess.Popen[Any], *, timeout: float = 5.0
         pass
 
 
-def _terminate_process_group(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
+def _terminate_process_group(proc: subprocess.Popen[Any] | int, *, timeout: float = 5.0) -> None:
     """Backward-compatible alias for the process-tree terminator."""
     _terminate_process_tree(proc, timeout=timeout)
 
@@ -754,10 +781,7 @@ class _LocalProcessBackend:
         _atomic_json(_cancel_path(task_id, hermes_root), {"task_id": task_id, "requested_at": _now()})
         pid = meta.get("pid")
         if isinstance(pid, int) and pid > 1:
-            try:
-                os.killpg(pid, signal.SIGTERM)
-            except (ProcessLookupError, PermissionError, OSError):
-                pass
+            _terminate_process_tree(pid)
         meta["state"] = "cancelled"
         meta["outcome"] = "cancelled"
         meta["ended_at"] = _now()

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -246,11 +246,18 @@ def load_entrypoint_backends() -> list[str]:
     except Exception as exc:
         logger.debug("runner entry-point discovery failed", exc_info=exc)
         return loaded
+    builtin_names = {"fleet", "pi_rpc", "omx", "codex"}
     for ep in selected:
         try:
             candidate = ep.load()
-            backend = candidate() if callable(candidate) and not hasattr(candidate, "name") else candidate
-            register_backend(backend, replace=True)
+            if isinstance(candidate, type) or (callable(candidate) and not hasattr(candidate, "dispatch")):
+                backend = candidate()
+            else:
+                backend = candidate
+            name = str(getattr(backend, "name", "") or "").strip().lower()
+            if name in builtin_names:
+                raise ValueError(f"external runner may not shadow built-in backend {name!r}")
+            register_backend(backend, replace=False)
             loaded.append(str(getattr(backend, "name", ep.name)))
         except Exception as exc:
             logger.debug("runner entry point %s failed to load", getattr(ep, "name", "unknown"), exc_info=exc)
@@ -309,6 +316,19 @@ def dispatch_contract(
             **kwargs,
         )
     except Exception as exc:  # noqa: BLE001
+        if backend_name == "fleet" and not isinstance(contract.get("execution"), dict):
+            # Legacy contract-dispatch compatibility applies only to contracts
+            # that omit the execution selector and therefore use the historical
+            # implicit fleet path. An explicit execution.backend="fleet" is a
+            # runner selection and uses the runner error contract below.
+            return {
+                "success": False,
+                "ok": False,
+                "code": "CONTRACT_DISPATCH_ERROR",
+                "safe_message": _bounded_text(exc, 300),
+                "suggested_action": "Check fleet authority manifest, registry, and peer service.",
+                "backend": backend_name,
+            }
         return {
             "success": False,
             "ok": False,
@@ -449,15 +469,41 @@ class _LocalProcessBackend:
             "error": "",
         }
         _atomic_json(meta_path, meta)
-        proc = subprocess.Popen(
-            [sys.executable, str(Path(__file__).resolve()), "--worker", task_id, "--root", str(_root(hermes_root))],
-            cwd=str(workspace),
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            close_fds=True,
-        )
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, str(Path(__file__).resolve()), "--worker", task_id, "--root", str(_root(hermes_root))],
+                cwd=str(workspace),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Spawn failed after the request/meta envelopes were written.
+            # Delete the request envelope so the raw objective/prompt cannot
+            # remain on disk, and leave only bounded failed metadata. Catch
+            # broadly because wrappers/test doubles can fail before a child
+            # process exists with exceptions other than OSError.
+            for path in (request_path, request_path.with_suffix(request_path.suffix + ".tmp")):
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+            meta.update({
+                "state": "failed",
+                "outcome": "failed",
+                "ended_at": _now(),
+                "error": _bounded_text(f"runner spawn failed: {exc}", 300),
+            })
+            _atomic_json(meta_path, meta)
+            return {
+                "success": False,
+                "code": "RUNNER_SPAWN_FAILED",
+                "backend": self.name,
+                "task_id": task_id,
+                "safe_message": _bounded_text(exc, 300),
+            }
         # The worker owns durable state transitions. Avoid a parent-side write
         # after spawn: a fast worker could otherwise complete and then be
         # overwritten back to "running" by the parent.
@@ -586,7 +632,9 @@ class CodexBackend:
     def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
         # Codex jobs use their own opaque job ids, so contract linkage is only
         # available when the operator metadata recorded task_id (newer stores).
-        root = (hermes_root or Path.home() / ".hermes") / "codex-jobs"
+        import operator_codex as op_codex
+
+        root = op_codex._root(hermes_root)
         if not root.is_dir():
             return []
         out: list[dict[str, Any]] = []
@@ -737,6 +785,36 @@ def _worker(task_id: str, jobs_root: Path) -> int:
         request_path.unlink()
     except OSError:
         pass
+    def _terminalize(meta: dict[str, Any], *, state: str, rc: int | None = None, error: str = "") -> None:
+        """Persist a terminal state, resolving to ``cancelled`` if a cancel
+        marker exists (cancellation wins over later completed/failed). Clean
+        the marker once the job is safely terminal."""
+        cancelled = (jobs_root / f"{task_id}.cancel.json").exists()
+        if cancelled:
+            meta.update({"state": "cancelled", "outcome": "cancelled", "error": ""})
+        else:
+            meta.update({"state": state, "outcome": state})
+            if error:
+                meta["error"] = error
+        if rc is not None:
+            meta["returncode"] = rc
+        meta["ended_at"] = _now()
+        _atomic_json(meta_path, meta)
+        # Close the check/write race with hermes_runner_cancel: cancellation
+        # writes the marker before publishing cancelled metadata. If that marker
+        # appeared after our first check but before/just after the terminal
+        # write, cancellation still wins and no later worker write follows.
+        cancel_path = jobs_root / f"{task_id}.cancel.json"
+        if not cancelled and cancel_path.exists():
+            cancelled = True
+            meta.update({"state": "cancelled", "outcome": "cancelled", "error": "", "ended_at": _now()})
+            _atomic_json(meta_path, meta)
+        if cancelled:
+            try:
+                cancel_path.unlink()
+            except OSError:
+                pass
+
     try:
         backend = get_backend(backend_name)
         exe = backend.executable() if isinstance(backend, _LocalProcessBackend) else None
@@ -745,8 +823,7 @@ def _worker(task_id: str, jobs_root: Path) -> int:
         meta.update({"state": "running", "started_at": meta.get("started_at") or _now(), "pid": os.getpid()})
         _atomic_json(meta_path, meta)
         if (jobs_root / f"{task_id}.cancel.json").exists():
-            meta.update({"state": "cancelled", "outcome": "cancelled", "ended_at": _now()})
-            _atomic_json(meta_path, meta)
+            _terminalize(meta, state="cancelled")
             return 0
         if backend_name == "pi_rpc":
             rc, _ = _worker_pi(exe, contract, timeout, log_path)
@@ -755,23 +832,16 @@ def _worker(task_id: str, jobs_root: Path) -> int:
         else:
             raise RuntimeError(f"local worker does not support backend {backend_name}")
         meta["returncode"] = rc
-        meta["ended_at"] = _now()
         if rc == 0:
-            meta["state"] = "completed"
-            meta["outcome"] = "completed"
-            meta["error"] = ""
+            _terminalize(meta, state="completed", rc=rc)
         else:
-            meta["state"] = "failed"
-            meta["outcome"] = "failed"
-            meta["error"] = "runner timed out" if rc == 124 else f"runner exited with code {rc}"
+            _terminalize(meta, state="failed", rc=rc, error="runner timed out" if rc == 124 else f"runner exited with code {rc}")
         # Completion evidence is state/exit metadata only. Do not persist the
         # model's final text in the runner store; contract validation must not
         # depend on worker self-report or retain prompt-derived output.
-        _atomic_json(meta_path, meta)
         return rc
     except Exception as exc:  # noqa: BLE001
-        meta.update({"state": "failed", "outcome": "failed", "ended_at": _now(), "error": _bounded_text(exc, 500)})
-        _atomic_json(meta_path, meta)
+        _terminalize(meta, state="failed", error=_bounded_text(exc, 500))
         return 1
 
 

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -38,6 +38,10 @@ import operator_policy as op
 
 SCHEMA_VERSION = "0.6-runner.1"
 RUNNER_PLUGINS_ENV = "HERMES_GPT_ENABLE_RUNNER_PLUGINS"
+RUNNER_PLUGIN_ALLOWLIST_ENV = "HERMES_GPT_RUNNER_PLUGIN_ALLOWLIST"
+RUNNER_BACKEND_ALLOWLIST_ENV = "HERMES_GPT_RUNNER_BACKEND_ALLOWLIST"
+RUNNER_PROVIDER_ALLOWLIST_ENV = "HERMES_GPT_RUNNER_PROVIDER_ALLOWLIST"
+RUNNER_MODEL_ALLOWLIST_ENV = "HERMES_GPT_RUNNER_MODEL_ALLOWLIST"
 _BACKEND_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 _TASK_ID_RE = op_fleet._TASK_ID_RE
 _MAX_OPTIONS_BYTES = 8_000
@@ -103,7 +107,7 @@ def _bounded_text(value: Any, maximum: int = _MAX_RESULT_CHARS) -> str:
 
 
 def _popen_process_group(argv: list[str], **kwargs: Any) -> subprocess.Popen[str]:
-    """Start a child in its own process group/session for bounded cleanup."""
+    """Start a child with a platform-specific process-tree boundary."""
     kwargs.setdefault("close_fds", True)
     if os.name == "nt":
         kwargs.setdefault("creationflags", subprocess.CREATE_NEW_PROCESS_GROUP)
@@ -112,15 +116,39 @@ def _popen_process_group(argv: list[str], **kwargs: Any) -> subprocess.Popen[str
     return subprocess.Popen(argv, **kwargs)
 
 
-def _terminate_process_group(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
-    """Terminate the child and descendants started by _popen_process_group."""
+def _terminate_process_tree(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
+    """Terminate the child process tree created by _popen_process_group.
+
+    POSIX uses the child session/process group. Windows does not expose a true
+    process-tree kill through the Python standard library, so production Windows
+    cleanup uses taskkill /T /F for descendants and falls back to direct-child
+    terminate/kill if taskkill is unavailable.
+    """
     if proc.poll() is not None:
         return
+    if os.name == "nt":
+        try:
+            subprocess.run(["taskkill", "/PID", str(proc.pid), "/T", "/F"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout, check=False)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=timeout)
+            return
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            pass
+        return
     try:
-        if os.name == "nt":
-            proc.terminate()
-        else:
-            os.killpg(proc.pid, signal.SIGTERM)
+        os.killpg(proc.pid, signal.SIGTERM)
     except (ProcessLookupError, PermissionError, OSError):
         pass
     try:
@@ -129,16 +157,18 @@ def _terminate_process_group(proc: subprocess.Popen[Any], *, timeout: float = 5.
     except subprocess.TimeoutExpired:
         pass
     try:
-        if os.name == "nt":
-            proc.kill()
-        else:
-            os.killpg(proc.pid, signal.SIGKILL)
+        os.killpg(proc.pid, signal.SIGKILL)
     except (ProcessLookupError, PermissionError, OSError):
         pass
     try:
         proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         pass
+
+
+def _terminate_process_group(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
+    """Backward-compatible alias for the process-tree terminator."""
+    _terminate_process_tree(proc, timeout=timeout)
 
 
 def _audit_runner(
@@ -165,6 +195,69 @@ def _audit_runner(
         )
     except Exception as exc:
         logger.debug("runner audit failed", exc_info=exc)
+
+
+def _split_allowlist(value: str | None) -> set[str]:
+    return {item.strip() for item in str(value or "").split(",") if item.strip()}
+
+
+def _allowed_by_env(value: str, env_name: str) -> bool:
+    allowed = _split_allowlist(os.environ.get(env_name))
+    return not allowed or value in allowed
+
+
+def _runner_allowed(name: str) -> bool:
+    return _allowed_by_env(name, RUNNER_BACKEND_ALLOWLIST_ENV)
+
+
+def _minimal_child_env() -> dict[str, str]:
+    """Return a non-secret, explicit child env baseline for local runners."""
+    allowed_keys = {
+        "PATH",
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "TERM",
+        "PYTHONIOENCODING",
+        "PI_CODING_AGENT_DIR",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "USERPROFILE",
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",
+        "PATHEXT",
+    }
+    return {key: value for key, value in os.environ.items() if key in allowed_keys and value}
+
+
+def _cleanup_stale_request_envelopes(*, hermes_root: Path | None = None, ttl_seconds: int = 3600) -> int:
+    """Delete stale transient request envelopes after their TTL expires."""
+    root = _root(hermes_root)
+    if not root.is_dir():
+        return 0
+    now = datetime.now(timezone.utc).timestamp()
+    removed = 0
+    for request_path in root.glob("*.request.json"):
+        try:
+            age = now - request_path.stat().st_mtime
+        except OSError:
+            continue
+        if age < ttl_seconds:
+            continue
+        try:
+            request_path.unlink()
+            removed += 1
+        except OSError:
+            pass
+    return removed
 
 
 def normalize_execution(value: Any) -> dict[str, Any] | None:
@@ -201,19 +294,27 @@ def _authorization_class(contract: dict[str, Any]) -> str:
 
 
 def _pi_tools(contract: dict[str, Any]) -> str:
+    """Return Pi tools for a confined-read execution posture.
+
+    Pi is intentionally limited to its read tool until Hermes GPT has a real
+    filesystem confinement boundary for absolute paths, ``..`` traversal, and
+    shell ``cd`` escape cases. CWD is not a sandbox.
+    """
     options = ((contract.get("execution") or {}).get("options") or {})
     auth_class = _authorization_class(contract)
+    if auth_class not in {"none", "read_only"}:
+        raise PermissionError("pi_rpc is read-only until filesystem confinement is available")
     requested = options.get("tools")
     if requested is None or requested == "":
-        return "read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"
+        return "read"
     if not isinstance(requested, str):
         raise TypeError("pi_rpc execution.options.tools must be a comma-delimited string")
     tools = [item.strip() for item in requested.split(",") if item.strip()]
     if not tools:
         raise ValueError("pi_rpc execution.options.tools must not be empty")
-    if auth_class in {"none", "read_only"} and set(tools) - {"read"}:
-        raise PermissionError("read-only authorization may only enable Pi's read tool")
-    return ",".join(tools)
+    if set(tools) != {"read"}:
+        raise PermissionError("pi_rpc may only enable Pi's read tool until filesystem confinement is available")
+    return "read"
 
 
 def _pi_agent_dir() -> Path:
@@ -242,15 +343,13 @@ def _unquote_env_value(value: str) -> str:
 
 
 def _pi_child_env(contract: dict[str, Any], hermes_root: Path | None, provider: str) -> dict[str, str]:
-    """Build the Pi child environment with only the selected provider's env-ref credential.
+    """Build a minimal child environment with only the selected provider credential.
 
-    Pi supports custom providers whose ``apiKey`` is an environment reference such
-    as ``$PROVIDER_KEY``. hermes-gpt profiles keep those values in the profile
-    ``.env`` file, but detached local-runner children do not automatically inherit
-    them. Resolve only the single referenced key for the selected provider; never
-    log or persist its value.
+    This intentionally does not inherit ``os.environ`` wholesale. The child gets
+    a small non-secret baseline plus, when configured, exactly the single env-ref
+    credential referenced by the selected Pi provider.
     """
-    child_env = dict(os.environ)
+    child_env = _minimal_child_env()
     if not provider:
         return child_env
 
@@ -264,17 +363,18 @@ def _pi_child_env(contract: dict[str, Any], hermes_root: Path | None, provider: 
     if not match:
         return child_env
     key_name = match.group(1)
-    if child_env.get(key_name):
-        return child_env
 
     profile = str(contract.get("assigned_profile") or "default")
     allowed_profiles = contract.get("allowed_scope", {}).get("profiles") or []
     if allowed_profiles and profile not in allowed_profiles:
         raise PermissionError("Pi runner profile is outside the contract allowed_scope")
-    profile_home = op.resolve_profile_home(profile, hermes_root)
-    import operator_config as op_config
 
-    value = op_config._read_env_value(profile_home / ".env", key_name)
+    value = os.environ.get(key_name)
+    if not value:
+        profile_home = op.resolve_profile_home(profile, hermes_root)
+        import operator_config as op_config
+
+        value = op_config._read_env_value(profile_home / ".env", key_name)
     if value:
         child_env[key_name] = _unquote_env_value(value)
     return child_env
@@ -360,6 +460,9 @@ def load_entrypoint_backends() -> list[str]:
             name = str(getattr(backend, "name", "") or "").strip().lower()
             if name in builtin_names:
                 raise ValueError(f"external runner may not shadow built-in backend {name!r}")
+            allowed_plugins = _split_allowlist(os.environ.get(RUNNER_PLUGIN_ALLOWLIST_ENV))
+            if not allowed_plugins or (name not in allowed_plugins and getattr(ep, "name", "") not in allowed_plugins):
+                raise PermissionError(f"external runner {name!r} is not allowlisted by {RUNNER_PLUGIN_ALLOWLIST_ENV}")
             register_backend(backend, replace=False)
             loaded.append(str(getattr(backend, "name", ep.name)))
         except Exception as exc:
@@ -369,6 +472,7 @@ def load_entrypoint_backends() -> list[str]:
 
 
 def list_backends(*, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+    _cleanup_stale_request_envelopes(hermes_root=hermes_root)
     with _REGISTRY_LOCK:
         items = list(_BACKENDS.values())
     out: list[dict[str, Any]] = []
@@ -384,8 +488,12 @@ def list_backends(*, hermes_root: Path | None = None) -> list[dict[str, Any]]:
 def selected_backend(contract: dict[str, Any]) -> str:
     execution = contract.get("execution")
     if isinstance(execution, dict) and execution.get("backend"):
-        return str(execution["backend"])
-    return "fleet"
+        backend = str(execution["backend"])
+    else:
+        backend = "fleet"
+    if not _runner_allowed(backend):
+        raise PermissionError(f"runner backend {backend!r} is not allowed by {RUNNER_BACKEND_ALLOWLIST_ENV}")
+    return backend
 
 
 def dispatch_contract(
@@ -397,8 +505,8 @@ def dispatch_contract(
     hermes_root: Path | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
-    backend_name = selected_backend(contract)
     try:
+        backend_name = selected_backend(contract)
         backend = get_backend(backend_name)
     except LookupError as exc:
         return {
@@ -407,7 +515,16 @@ def dispatch_contract(
             "code": "RUNNER_BACKEND_UNKNOWN",
             "safe_message": str(exc),
             "suggested_action": "Select a registered execution.backend.",
-            "backend": backend_name,
+            "backend": str((contract.get("execution") or {}).get("backend") or "fleet"),
+        }
+    except PermissionError as exc:
+        return {
+            "success": False,
+            "ok": False,
+            "code": "RUNNER_BACKEND_NOT_ALLOWED",
+            "safe_message": _bounded_text(exc, 300),
+            "suggested_action": "Update runner backend allowlist or select an allowed backend.",
+            "backend": str((contract.get("execution") or {}).get("backend") or "fleet"),
         }
     try:
         result = backend.dispatch(
@@ -665,6 +782,10 @@ class PiRpcBackend(_LocalProcessBackend):
     def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
         tools = _pi_tools(contract)
         provider, model = _pi_selection(contract)
+        if provider and not _allowed_by_env(provider, RUNNER_PROVIDER_ALLOWLIST_ENV):
+            raise PermissionError(f"Pi provider {provider!r} is not allowed by {RUNNER_PROVIDER_ALLOWLIST_ENV}")
+        if model and not _allowed_by_env(model, RUNNER_MODEL_ALLOWLIST_ENV):
+            raise PermissionError(f"Pi model {model!r} is not allowed by {RUNNER_MODEL_ALLOWLIST_ENV}")
         return {"protocol": "jsonl-rpc", "mode": "rpc", "tools": tools, "model": model or None, "provider": provider or None}
 
 
@@ -683,7 +804,10 @@ class OmxBackend(_LocalProcessBackend):
     def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
         options = ((contract.get("execution") or {}).get("options") or {})
         sandbox = _sandbox_for(contract, backend="omx")
-        return {"mode": "exec", "json": True, "sandbox": sandbox, "model": options.get("model"), "profile": options.get("profile")}
+        model = options.get("model")
+        if model and not _allowed_by_env(str(model), RUNNER_MODEL_ALLOWLIST_ENV):
+            raise PermissionError(f"OMX model {model!r} is not allowed by {RUNNER_MODEL_ALLOWLIST_ENV}")
+        return {"mode": "exec", "json": True, "sandbox": sandbox, "model": model, "profile": options.get("profile")}
 
 
 @dataclass
@@ -705,11 +829,14 @@ class CodexBackend:
         options = ((contract.get("execution") or {}).get("options") or {})
         workspace = contract["allowed_scope"]["workspaces"][0]
         sandbox = _sandbox_for(contract, backend="codex")
+        model = options.get("model")
+        if model and not _allowed_by_env(str(model), RUNNER_MODEL_ALLOWLIST_ENV):
+            raise PermissionError(f"Codex model {model!r} is not allowed by {RUNNER_MODEL_ALLOWLIST_ENV}")
         result = op_codex.hermes_codex_start(
             prompt=contract["objective"],
             workdir=workspace,
             sandbox=sandbox,
-            model=options.get("model"),
+            model=model,
             ignore_user_config=bool(options.get("ignore_user_config", False)),
             timeout=max(10, min(int(timeout), 3600)),
             confirm=confirm,
@@ -776,6 +903,10 @@ def _worker_pi(
     options = ((contract.get("execution") or {}).get("options") or {})
     tools = _pi_tools(contract)
     provider, model = _pi_selection(contract)
+    if provider and not _allowed_by_env(provider, RUNNER_PROVIDER_ALLOWLIST_ENV):
+        raise PermissionError(f"Pi provider {provider!r} is not allowed by {RUNNER_PROVIDER_ALLOWLIST_ENV}")
+    if model and not _allowed_by_env(model, RUNNER_MODEL_ALLOWLIST_ENV):
+        raise PermissionError(f"Pi model {model!r} is not allowed by {RUNNER_MODEL_ALLOWLIST_ENV}")
     argv = [exe, "--mode", "rpc", "--no-session", "--tools", tools]
     if _authorization_class(contract) in {"none", "read_only"}:
         # Pi extensions execute arbitrary startup code outside the built-in tool
@@ -866,7 +997,10 @@ def _worker_omx(exe: str, contract: dict[str, Any], timeout: int, log_path: Path
     workspace = contract["allowed_scope"]["workspaces"][0]
     argv = [exe, "exec", "--json", "-C", workspace, "--sandbox", sandbox]
     if options.get("model"):
-        argv += ["--model", str(options["model"])]
+        model = str(options["model"])
+        if not _allowed_by_env(model, RUNNER_MODEL_ALLOWLIST_ENV):
+            raise PermissionError(f"OMX model {model!r} is not allowed by {RUNNER_MODEL_ALLOWLIST_ENV}")
+        argv += ["--model", model]
     if options.get("profile"):
         argv += ["--profile", str(options["profile"])]
     argv.append("-")
@@ -1003,6 +1137,7 @@ def hermes_runner_status(task_id: str, hermes_root: Path | None = None) -> str:
     try:
         policy = op.OperatorPolicy()
         policy.require_level("read_only")
+        _cleanup_stale_request_envelopes(hermes_root=hermes_root)
         if not _TASK_ID_RE.fullmatch(task_id or ""):
             raise ValueError("task_id has an invalid format")
         runs = observed_runs(task_id, hermes_root=hermes_root)

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -1,0 +1,811 @@
+"""Pluggable execution backends for hermes-gpt work contracts.
+
+A runner backend is responsible only for executing a canonical work contract and
+reporting bounded observed state. Contract policy, authorization, completion
+criteria, artifact checks, and review remain owned by ``operator_contract``.
+
+Built-ins:
+- ``fleet``: existing Hermes A2A fleet work-order transport (compatibility default)
+- ``pi_rpc``: Pi coding agent JSONL RPC mode
+- ``omx``: Oh My Codex non-interactive ``omx exec``
+- ``codex``: existing hermes-gpt Codex operator job runner
+
+Third-party backends can implement ``RunnerBackend`` and call
+``register_backend()``. No contract/schema changes are required for additional
+backend names; contracts select them with ``execution.backend``.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import logging
+import os
+import re
+import selectors
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+import operator_fleet as op_fleet
+import operator_policy as op
+
+SCHEMA_VERSION = "0.6-runner.1"
+_BACKEND_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_TASK_ID_RE = op_fleet._TASK_ID_RE
+_MAX_OPTIONS_BYTES = 8_000
+_MAX_RESULT_CHARS = 8_000
+_TERMINAL_STATES = frozenset({"completed", "failed", "cancelled"})
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _root(hermes_root: Path | None = None) -> Path:
+    base = op.normalize_hermes_data_root(hermes_root or Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")))
+    return Path(base or Path.home() / ".hermes") / "runner-jobs"
+
+
+def _job_paths(task_id: str, hermes_root: Path | None = None) -> tuple[Path, Path, Path]:
+    root = _root(hermes_root)
+    return root / f"{task_id}.json", root / f"{task_id}.request.json", root / f"{task_id}.jsonl"
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+    try:
+        tmp.chmod(0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+
+
+def _load_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _append_event(path: Path, event: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def _bounded_text(value: Any, maximum: int = _MAX_RESULT_CHARS) -> str:
+    text = op.redact_output(str(value or ""))
+    return text if len(text) <= maximum else text[: maximum - 3] + "..."
+
+
+def normalize_execution(value: Any) -> dict[str, Any] | None:
+    """Validate an optional contract ``execution`` selector.
+
+    The block is deliberately backend-agnostic. ``options`` must be a bounded
+    JSON object; individual backends validate the options they understand.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise TypeError("execution must be an object")
+    backend = str(value.get("backend") or "").strip().lower()
+    if not _BACKEND_RE.fullmatch(backend):
+        raise ValueError("execution.backend is invalid")
+    options = value.get("options") or {}
+    if not isinstance(options, dict):
+        raise TypeError("execution.options must be an object")
+    secretish = re.compile(r"(?:secret|token|password|api[_-]?key|credential|private[_-]?key)", re.IGNORECASE)
+    bad_keys = [str(key) for key in options if secretish.search(str(key))]
+    if bad_keys:
+        raise ValueError("execution.options must not carry secrets; use runner environment/config instead")
+    try:
+        encoded = json.dumps(options, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("execution.options must contain JSON values") from exc
+    if len(encoded.encode("utf-8")) > _MAX_OPTIONS_BYTES:
+        raise ValueError(f"execution.options exceeds {_MAX_OPTIONS_BYTES} bytes")
+    return {"backend": backend, "options": options}
+
+
+class RunnerBackend(Protocol):
+    name: str
+
+    def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]: ...
+
+    def dispatch(
+        self,
+        contract: dict[str, Any],
+        *,
+        confirm: bool,
+        dry_run: bool,
+        timeout: int,
+        hermes_root: Path | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]: ...
+
+    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]: ...
+
+    def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]: ...
+
+
+_BACKENDS: dict[str, RunnerBackend] = {}
+_REGISTRY_LOCK = threading.RLock()
+
+
+def register_backend(backend: RunnerBackend, *, replace: bool = False) -> None:
+    name = str(getattr(backend, "name", "") or "").strip().lower()
+    if not _BACKEND_RE.fullmatch(name):
+        raise ValueError("runner backend name is invalid")
+    with _REGISTRY_LOCK:
+        if name in _BACKENDS and not replace:
+            raise ValueError(f"runner backend {name!r} is already registered")
+        _BACKENDS[name] = backend
+
+
+def get_backend(name: str) -> RunnerBackend:
+    key = str(name or "").strip().lower()
+    with _REGISTRY_LOCK:
+        backend = _BACKENDS.get(key)
+    if backend is None:
+        raise LookupError(f"runner backend {key!r} is not registered")
+    return backend
+
+
+def load_entrypoint_backends() -> list[str]:
+    """Load external runner plugins from the ``hermes_gpt.runners`` group.
+
+    Each entry point may expose either a backend instance or a zero-argument
+    factory/class returning one. Broken plugins are isolated and skipped.
+    """
+    loaded: list[str] = []
+    try:
+        eps = importlib.metadata.entry_points()
+        selected = eps.select(group="hermes_gpt.runners") if hasattr(eps, "select") else eps.get("hermes_gpt.runners", [])
+    except Exception as exc:
+        logger.debug("runner entry-point discovery failed", exc_info=exc)
+        return loaded
+    for ep in selected:
+        try:
+            candidate = ep.load()
+            backend = candidate() if callable(candidate) and not hasattr(candidate, "name") else candidate
+            register_backend(backend, replace=True)
+            loaded.append(str(getattr(backend, "name", ep.name)))
+        except Exception as exc:
+            logger.debug("runner entry point %s failed to load", getattr(ep, "name", "unknown"), exc_info=exc)
+            continue
+    return loaded
+
+
+def list_backends(*, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+    with _REGISTRY_LOCK:
+        items = list(_BACKENDS.values())
+    out: list[dict[str, Any]] = []
+    for backend in items:
+        try:
+            info = backend.availability(hermes_root=hermes_root)
+        except Exception as exc:  # noqa: BLE001
+            info = {"available": False, "reason": exc.__class__.__name__}
+        out.append({"name": backend.name, **info})
+    return sorted(out, key=lambda item: item["name"])
+
+
+def selected_backend(contract: dict[str, Any]) -> str:
+    execution = contract.get("execution")
+    if isinstance(execution, dict) and execution.get("backend"):
+        return str(execution["backend"])
+    return "fleet"
+
+
+def dispatch_contract(
+    contract: dict[str, Any],
+    *,
+    confirm: bool,
+    dry_run: bool,
+    timeout: int,
+    hermes_root: Path | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    backend_name = selected_backend(contract)
+    try:
+        backend = get_backend(backend_name)
+    except LookupError as exc:
+        return {
+            "success": False,
+            "ok": False,
+            "code": "RUNNER_BACKEND_UNKNOWN",
+            "safe_message": str(exc),
+            "suggested_action": "Select a registered execution.backend.",
+            "backend": backend_name,
+        }
+    try:
+        result = backend.dispatch(
+            contract,
+            confirm=confirm,
+            dry_run=dry_run,
+            timeout=timeout,
+            hermes_root=hermes_root,
+            **kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "success": False,
+            "ok": False,
+            "code": "RUNNER_DISPATCH_ERROR",
+            "safe_message": _bounded_text(exc, 300),
+            "suggested_action": f"Check the {backend_name} runner backend and retry.",
+            "backend": backend_name,
+        }
+    result.setdefault("backend", backend_name)
+    return result
+
+
+def observed_runs(task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with _REGISTRY_LOCK:
+        items = list(_BACKENDS.values())
+    for backend in items:
+        try:
+            out.extend(backend.observed_runs(task_id, hermes_root=hermes_root))
+        except Exception as exc:
+            logger.debug("runner backend %s observation failed", getattr(backend, "name", "unknown"), exc_info=exc)
+            continue
+    return out
+
+
+@dataclass
+class FleetBackend:
+    name: str = "fleet"
+
+    def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        try:
+            payload = json.loads(op_fleet.hermes_fleet_list())
+            return {"available": bool(payload.get("success")), "reason": payload.get("safe_message") if not payload.get("success") else None}
+        except Exception as exc:  # noqa: BLE001
+            return {"available": False, "reason": _bounded_text(exc, 200)}
+
+    def dispatch(self, contract: dict[str, Any], *, confirm: bool, dry_run: bool, timeout: int, hermes_root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+        workspaces = contract["allowed_scope"]["workspaces"]
+        acceptance_checks = [
+            f"run_state outcome_ok={contract['completion_criteria']['run_state']['outcome_ok']}",
+            f"artifacts_present={contract['completion_criteria']['artifacts_present']}",
+            f"tests_pass={contract['completion_criteria']['tests_pass']}",
+            f"review_satisfied={contract['completion_criteria']['review_satisfied']}",
+            f"no_forbidden_actions={contract['completion_criteria']['no_forbidden_actions']}",
+        ]
+        deliverables = [a["path"] for a in contract["expected_artifacts"]]
+        text = op_fleet.hermes_fleet_dispatch_work_order(
+            agent=contract["assigned_agent"],
+            task_id=contract["task_id"],
+            target_profile=contract["assigned_profile"],
+            objective=contract["objective"],
+            workspace=workspaces[0] if workspaces else "",
+            inputs=contract["inputs"],
+            constraints=contract["constraints"],
+            acceptance_checks=acceptance_checks,
+            deliverables=deliverables,
+            authorization=contract["authorization"],
+            confirm=confirm,
+            dry_run=dry_run,
+            timeout=timeout,
+            runner=kwargs.get("runner"),
+            hermes_bin=kwargs.get("hermes_bin"),
+            authority_manifest=kwargs.get("authority_manifest"),
+        )
+        payload = json.loads(text)
+        payload["backend"] = self.name
+        return payload
+
+    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+        return []  # Fleet observations remain sourced from Mission Control.
+
+    def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        return {"success": False, "code": "RUNNER_CANCEL_UNSUPPORTED", "backend": self.name}
+
+
+class _LocalProcessBackend:
+    name = "local"
+
+    def executable(self) -> str | None:
+        raise NotImplementedError
+
+    def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        exe = self.executable()
+        return {"available": bool(exe), "executable": exe}
+
+    def _policy_workspace(self, contract: dict[str, Any]) -> Path:
+        workspaces = contract.get("allowed_scope", {}).get("workspaces") or []
+        if not workspaces:
+            raise ValueError("local runner requires at least one allowed workspace")
+        workspace = Path(workspaces[0]).expanduser().resolve()
+        policy = op.OperatorPolicy()
+        policy.require_level("workspace")
+        policy.require_workspace_path(str(workspace))
+        return workspace
+
+    def dispatch(self, contract: dict[str, Any], *, confirm: bool, dry_run: bool, timeout: int, hermes_root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+        policy = op.OperatorPolicy()
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        effective = policy.effective_dry_run(dry_run)
+        workspace = self._policy_workspace(contract)
+        exe = self.executable()
+        if not exe:
+            return {"success": False, "code": "RUNNER_UNAVAILABLE", "backend": self.name, "safe_message": f"{self.name} executable not found"}
+        plan = self.build_plan(contract)
+        plan.update({"backend": self.name, "workspace": str(workspace), "task_id": contract["task_id"]})
+        if effective:
+            return {"success": True, "dry_run": True, "changed": False, "backend": self.name, "plan": plan}
+        if not confirm:
+            return {"success": False, "code": "CONFIRMATION_REQUIRED", "backend": self.name, "safe_message": "local runner dispatch requires confirm=true"}
+
+        task_id = contract["task_id"]
+        meta_path, request_path, _ = _job_paths(task_id, hermes_root)
+        if meta_path.exists():
+            return {"success": False, "code": "RUNNER_JOB_EXISTS", "backend": self.name, "safe_message": f"runner job {task_id!r} already exists"}
+        request = {
+            "backend": self.name,
+            "contract": contract,
+            "timeout": max(10, min(int(timeout), 3600)),
+            "hermes_root": str((hermes_root or Path.home() / ".hermes").expanduser()),
+        }
+        _atomic_json(request_path, request)
+        meta = {
+            "schema_version": SCHEMA_VERSION,
+            "task_id": task_id,
+            "backend": self.name,
+            "state": "queued",
+            "outcome": "",
+            "workspace": str(workspace),
+            "created_at": _now(),
+            "started_at": None,
+            "ended_at": None,
+            "pid": None,
+            "returncode": None,
+            "error": "",
+        }
+        _atomic_json(meta_path, meta)
+        proc = subprocess.Popen(
+            [sys.executable, str(Path(__file__).resolve()), "--worker", task_id, "--root", str(_root(hermes_root))],
+            cwd=str(workspace),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        meta["pid"] = proc.pid
+        meta["state"] = "running"
+        meta["started_at"] = _now()
+        _atomic_json(meta_path, meta)
+        return {"success": True, "changed": True, "dry_run": False, "backend": self.name, "task_id": task_id, "state": "running", "pid": proc.pid}
+
+    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+        if not _TASK_ID_RE.fullmatch(task_id or ""):
+            return []
+        meta_path, _, _ = _job_paths(task_id, hermes_root)
+        meta = _load_json(meta_path)
+        if not meta or meta.get("backend") != self.name:
+            return []
+        return [{
+            "task_id": task_id,
+            "status": meta.get("state"),
+            "outcome": meta.get("outcome") or meta.get("state"),
+            "error": meta.get("error") or None,
+            "started_at": meta.get("started_at") or meta.get("created_at"),
+            "ended_at": meta.get("ended_at"),
+            "scope": f"runner:{self.name}",
+        }]
+
+    def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        meta_path, _, _ = _job_paths(task_id, hermes_root)
+        meta = _load_json(meta_path)
+        if not meta or meta.get("backend") != self.name:
+            return {"success": False, "code": "RUNNER_JOB_NOT_FOUND", "backend": self.name}
+        if meta.get("state") in _TERMINAL_STATES:
+            return {"success": True, "changed": False, "backend": self.name, "state": meta.get("state")}
+        pid = meta.get("pid")
+        if isinstance(pid, int) and pid > 1:
+            try:
+                os.killpg(pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        meta["state"] = "cancelled"
+        meta["outcome"] = "cancelled"
+        meta["ended_at"] = _now()
+        _atomic_json(meta_path, meta)
+        return {"success": True, "changed": True, "backend": self.name, "state": "cancelled"}
+
+
+@dataclass
+class PiRpcBackend(_LocalProcessBackend):
+    name: str = "pi_rpc"
+
+    def executable(self) -> str | None:
+        configured = os.environ.get("HERMES_GPT_PI_EXE")
+        candidates = [configured, shutil.which("pi"), str(Path.home() / ".local" / "bin" / "pi")]
+        package_cli = Path.home() / ".local" / "lib" / "node_modules" / "@earendil-works" / "pi-coding-agent" / "dist" / "cli.js"
+        candidates.append(str(package_cli))
+        for candidate in candidates:
+            if candidate and Path(candidate).is_file():
+                return str(Path(candidate).resolve())
+        return None
+
+    def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
+        options = ((contract.get("execution") or {}).get("options") or {})
+        auth_class = str(contract.get("authorization", {}).get("class") or "none")
+        tools = options.get("tools")
+        if not tools:
+            tools = "read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"
+        return {"protocol": "jsonl-rpc", "mode": "rpc", "tools": tools, "model": options.get("model"), "provider": options.get("provider")}
+
+
+@dataclass
+class OmxBackend(_LocalProcessBackend):
+    name: str = "omx"
+
+    def executable(self) -> str | None:
+        configured = os.environ.get("HERMES_GPT_OMX_EXE")
+        candidates = [configured, shutil.which("omx"), "/usr/bin/omx", str(Path.home() / ".local" / "bin" / "omx")]
+        for candidate in candidates:
+            if candidate and Path(candidate).is_file():
+                return str(Path(candidate).resolve())
+        return None
+
+    def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
+        options = ((contract.get("execution") or {}).get("options") or {})
+        auth_class = str(contract.get("authorization", {}).get("class") or "none")
+        sandbox = options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write")
+        if sandbox not in {"read-only", "workspace-write"}:
+            raise ValueError("omx execution.options.sandbox must be read-only or workspace-write")
+        return {"mode": "exec", "json": True, "sandbox": sandbox, "model": options.get("model"), "profile": options.get("profile")}
+
+
+@dataclass
+class CodexBackend:
+    name: str = "codex"
+
+    def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        try:
+            import operator_codex as op_codex
+            status = op_codex.hermes_codex_status()
+            if isinstance(status, str):
+                status = json.loads(status)
+            return {"available": bool(status.get("codex_available")), "enabled": bool(status.get("enabled")), "write_enabled": bool(status.get("write_enabled"))}
+        except Exception as exc:  # noqa: BLE001
+            return {"available": False, "reason": _bounded_text(exc, 200)}
+
+    def dispatch(self, contract: dict[str, Any], *, confirm: bool, dry_run: bool, timeout: int, hermes_root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+        import operator_codex as op_codex
+        options = ((contract.get("execution") or {}).get("options") or {})
+        workspace = contract["allowed_scope"]["workspaces"][0]
+        auth_class = str(contract.get("authorization", {}).get("class") or "none")
+        sandbox = options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write")
+        result = op_codex.hermes_codex_start(
+            prompt=contract["objective"],
+            workdir=workspace,
+            sandbox=sandbox,
+            model=options.get("model"),
+            ignore_user_config=bool(options.get("ignore_user_config", False)),
+            timeout=max(10, min(int(timeout), 3600)),
+            confirm=confirm,
+            dry_run=dry_run,
+        )
+        if isinstance(result, str):
+            result = json.loads(result)
+        job_id = result.get("job_id") if isinstance(result, dict) else None
+        if isinstance(job_id, str) and result.get("success"):
+            try:
+                meta = op_codex._load(job_id, hermes_root)
+                if isinstance(meta, dict):
+                    meta["task_id"] = contract["task_id"]
+                    op_codex._save(meta, hermes_root)
+            except Exception as exc:
+                logger.debug("failed to persist Codex task linkage for %s", job_id, exc_info=exc)
+        result["backend"] = self.name
+        result.setdefault("task_id", contract["task_id"])
+        return result
+
+    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
+        # Codex jobs use their own opaque job ids, so contract linkage is only
+        # available when the operator metadata recorded task_id (newer stores).
+        root = (hermes_root or Path.home() / ".hermes") / "codex-jobs"
+        if not root.is_dir():
+            return []
+        out: list[dict[str, Any]] = []
+        for path in list(root.glob("*.json"))[:500]:
+            meta = _load_json(path)
+            if not meta or meta.get("task_id") != task_id:
+                continue
+            state = str(meta.get("state") or meta.get("status") or "unknown")
+            out.append({"task_id": task_id, "status": state, "outcome": meta.get("outcome") or state, "error": meta.get("error") or None, "started_at": meta.get("started_at") or meta.get("created_at"), "ended_at": meta.get("ended_at") or meta.get("completed_at"), "scope": "runner:codex"})
+        return out
+
+    def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        return {"success": False, "code": "RUNNER_CANCEL_REQUIRES_JOB_ID", "backend": self.name}
+
+
+def _extract_pi_text(message: Any) -> str:
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "\n".join(parts)
+    return ""
+
+
+def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path) -> tuple[int, str]:
+    options = ((contract.get("execution") or {}).get("options") or {})
+    auth_class = str(contract.get("authorization", {}).get("class") or "none")
+    tools = str(options.get("tools") or ("read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"))
+    argv = [exe, "--mode", "rpc", "--no-session", "--tools", tools]
+    if options.get("provider"):
+        argv += ["--provider", str(options["provider"])]
+    if options.get("model"):
+        argv += ["--model", str(options["model"])]
+    if options.get("thinking"):
+        argv += ["--thinking", str(options["thinking"])]
+    proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+    assert proc.stdin is not None and proc.stdout is not None
+    proc.stdin.write(json.dumps({"id": "dispatch", "type": "prompt", "message": contract["objective"]}, ensure_ascii=False) + "\n")
+    proc.stdin.flush()
+    final_text = ""
+    settled = False
+    deadline = datetime.now(timezone.utc).timestamp() + timeout
+    selector = selectors.DefaultSelector()
+    selector.register(proc.stdout, selectors.EVENT_READ)
+    while datetime.now(timezone.utc).timestamp() < deadline:
+        remaining = max(0.0, deadline - datetime.now(timezone.utc).timestamp())
+        ready = selector.select(timeout=min(0.5, remaining))
+        if not ready:
+            if proc.poll() is not None:
+                break
+            continue
+        line = proc.stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                break
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        etype = event.get("type")
+        if etype in {"response", "agent_start", "agent_end", "agent_settled", "turn_end", "message_end", "extension_error", "auto_retry_start", "auto_retry_end"}:
+            _append_event(log_path, {"type": etype, "at": _now(), "success": event.get("success"), "command": event.get("command")})
+        if etype == "message_end":
+            text = _extract_pi_text(event.get("message"))
+            if text:
+                final_text = text
+        if etype == "agent_settled":
+            settled = True
+            break
+    selector.close()
+    if not settled and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        return 124, final_text
+    try:
+        proc.stdin.close()
+    except OSError:
+        pass
+    try:
+        rc = proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.terminate()
+        rc = proc.wait(timeout=5)
+    return rc, final_text
+
+
+def _worker_omx(exe: str, contract: dict[str, Any], timeout: int, log_path: Path) -> tuple[int, str]:
+    options = ((contract.get("execution") or {}).get("options") or {})
+    auth_class = str(contract.get("authorization", {}).get("class") or "none")
+    sandbox = str(options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write"))
+    workspace = contract["allowed_scope"]["workspaces"][0]
+    argv = [exe, "exec", "--json", "-C", workspace, "--sandbox", sandbox]
+    if options.get("model"):
+        argv += ["--model", str(options["model"])]
+    if options.get("profile"):
+        argv += ["--profile", str(options["profile"])]
+    argv.append("-")
+    proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    try:
+        stdout, stderr = proc.communicate(input=contract["objective"], timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        _append_event(log_path, {"type": "timeout", "at": _now()})
+        return 124, ""
+    final_text = ""
+    for raw in stdout.splitlines():
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        etype = event.get("type")
+        _append_event(log_path, {"type": etype or "event", "at": _now()})
+        item = event.get("item") if isinstance(event.get("item"), dict) else {}
+        text = item.get("text") or event.get("text")
+        if isinstance(text, str) and text:
+            final_text = text
+    if proc.returncode and stderr:
+        _append_event(log_path, {"type": "stderr", "at": _now(), "summary": _bounded_text(stderr, 500)})
+    return int(proc.returncode or 0), final_text
+
+
+def _worker(task_id: str, jobs_root: Path) -> int:
+    meta_path = jobs_root / f"{task_id}.json"
+    request_path = jobs_root / f"{task_id}.request.json"
+    log_path = jobs_root / f"{task_id}.jsonl"
+    meta = _load_json(meta_path) or {}
+    request = _load_json(request_path)
+    if not request or not isinstance(request.get("contract"), dict):
+        meta.update({"state": "failed", "outcome": "failed", "ended_at": _now(), "error": "runner request missing"})
+        _atomic_json(meta_path, meta)
+        return 2
+    contract = request["contract"]
+    backend_name = str(request.get("backend") or "")
+    timeout = max(10, min(int(request.get("timeout") or 900), 3600))
+    try:
+        backend = get_backend(backend_name)
+        exe = backend.executable() if isinstance(backend, _LocalProcessBackend) else None
+        if not exe:
+            raise RuntimeError(f"{backend_name} executable not found")
+        meta.update({"state": "running", "started_at": meta.get("started_at") or _now(), "pid": os.getpid()})
+        _atomic_json(meta_path, meta)
+        if backend_name == "pi_rpc":
+            rc, final_text = _worker_pi(exe, contract, timeout, log_path)
+        elif backend_name == "omx":
+            rc, final_text = _worker_omx(exe, contract, timeout, log_path)
+        else:
+            raise RuntimeError(f"local worker does not support backend {backend_name}")
+        meta["returncode"] = rc
+        meta["ended_at"] = _now()
+        if rc == 0:
+            meta["state"] = "completed"
+            meta["outcome"] = "completed"
+            meta["error"] = ""
+        else:
+            meta["state"] = "failed"
+            meta["outcome"] = "failed"
+            meta["error"] = "runner timed out" if rc == 124 else f"runner exited with code {rc}"
+        if final_text:
+            meta["result_summary"] = _bounded_text(final_text)
+        _atomic_json(meta_path, meta)
+        return rc
+    except Exception as exc:  # noqa: BLE001
+        meta.update({"state": "failed", "outcome": "failed", "ended_at": _now(), "error": _bounded_text(exc, 500)})
+        _atomic_json(meta_path, meta)
+        return 1
+
+
+def hermes_runner_list(hermes_root: Path | None = None) -> str:
+    """List registered runner backends and bounded availability metadata."""
+    try:
+        op.OperatorPolicy().require_level("read_only")
+        payload = {
+            "success": True,
+            "schema_version": SCHEMA_VERSION,
+            "backends": list_backends(hermes_root=hermes_root),
+        }
+        return json.dumps(payload, ensure_ascii=False, indent=2)
+    except PermissionError as exc:
+        return json.dumps({"success": False, "code": "RUNNER_POLICY_DENIED", "safe_message": _bounded_text(exc, 300)}, indent=2)
+
+
+def hermes_runner_status(task_id: str, hermes_root: Path | None = None) -> str:
+    """Return bounded observed state for a contract task across runner backends."""
+    try:
+        op.OperatorPolicy().require_level("read_only")
+        if not _TASK_ID_RE.fullmatch(task_id or ""):
+            raise ValueError("task_id has an invalid format")
+        runs = observed_runs(task_id, hermes_root=hermes_root)
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "task_id": task_id, "runs": runs, "count": len(runs)}, ensure_ascii=False, indent=2)
+    except (PermissionError, ValueError) as exc:
+        return json.dumps({"success": False, "code": "RUNNER_STATUS_ERROR", "safe_message": _bounded_text(exc, 300)}, indent=2)
+
+
+def hermes_runner_cancel(task_id: str, backend: str = "", confirm: bool = False, dry_run: bool = True, hermes_root: Path | None = None) -> str:
+    """Cancel a runner job when the selected backend supports cancellation."""
+    try:
+        policy = op.OperatorPolicy()
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        effective = policy.effective_dry_run(dry_run)
+        if not _TASK_ID_RE.fullmatch(task_id or ""):
+            raise ValueError("task_id has an invalid format")
+        selected = str(backend or "").strip().lower()
+        if not selected:
+            meta_path, _, _ = _job_paths(task_id, hermes_root)
+            meta = _load_json(meta_path) or {}
+            selected = str(meta.get("backend") or "")
+        if not selected:
+            return json.dumps({"success": False, "code": "RUNNER_BACKEND_REQUIRED", "safe_message": "backend could not be inferred for task"}, indent=2)
+        target = get_backend(selected)
+        if effective:
+            return json.dumps({"success": True, "dry_run": True, "changed": False, "backend": selected, "task_id": task_id, "plan": "cancel"}, indent=2)
+        if not confirm:
+            return json.dumps({"success": False, "code": "CONFIRMATION_REQUIRED", "backend": selected, "safe_message": "runner cancellation requires confirm=true"}, indent=2)
+        result = target.cancel(task_id, hermes_root=hermes_root)
+        result.setdefault("backend", selected)
+        result.setdefault("task_id", task_id)
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    except (PermissionError, ValueError, LookupError) as exc:
+        return json.dumps({"success": False, "code": "RUNNER_CANCEL_ERROR", "safe_message": _bounded_text(exc, 300)}, indent=2)
+
+
+def _register_builtins() -> None:
+    for backend in (FleetBackend(), PiRpcBackend(), OmxBackend(), CodexBackend()):
+        register_backend(backend, replace=True)
+
+
+_register_builtins()
+load_entrypoint_backends()
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) >= 3 and argv[1] == "--worker":
+        task_id = argv[2]
+        if not _TASK_ID_RE.fullmatch(task_id):
+            return 2
+        jobs_root = None
+        if len(argv) >= 5 and argv[3] == "--root":
+            jobs_root = Path(argv[4]).expanduser().resolve()
+        if jobs_root is None:
+            jobs_root = _root()
+        return _worker(task_id, jobs_root)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))
+
+
+__all__ = [
+    "CodexBackend",
+    "FleetBackend",
+    "OmxBackend",
+    "PiRpcBackend",
+    "RunnerBackend",
+    "dispatch_contract",
+    "get_backend",
+    "hermes_runner_cancel",
+    "hermes_runner_list",
+    "hermes_runner_status",
+    "list_backends",
+    "load_entrypoint_backends",
+    "normalize_execution",
+    "observed_runs",
+    "register_backend",
+    "selected_backend",
+]

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -37,6 +37,7 @@ import operator_fleet as op_fleet
 import operator_policy as op
 
 SCHEMA_VERSION = "0.6-runner.1"
+RUNNER_PLUGINS_ENV = "HERMES_GPT_ENABLE_RUNNER_PLUGINS"
 _BACKEND_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 _TASK_ID_RE = op_fleet._TASK_ID_RE
 _MAX_OPTIONS_BYTES = 8_000
@@ -57,6 +58,10 @@ def _root(hermes_root: Path | None = None) -> Path:
 def _job_paths(task_id: str, hermes_root: Path | None = None) -> tuple[Path, Path, Path]:
     root = _root(hermes_root)
     return root / f"{task_id}.json", root / f"{task_id}.request.json", root / f"{task_id}.jsonl"
+
+
+def _cancel_path(task_id: str, hermes_root: Path | None = None) -> Path:
+    return _root(hermes_root) / f"{task_id}.cancel.json"
 
 
 def _atomic_json(path: Path, value: dict[str, Any]) -> None:
@@ -97,6 +102,32 @@ def _bounded_text(value: Any, maximum: int = _MAX_RESULT_CHARS) -> str:
     return text if len(text) <= maximum else text[: maximum - 3] + "..."
 
 
+def _audit_runner(
+    *,
+    tool: str,
+    policy: op.OperatorPolicy,
+    dry_run: bool,
+    success: bool,
+    changed: bool = False,
+    summary: str = "",
+    task_id: str = "",
+    backend: str = "",
+) -> None:
+    try:
+        op.audit_record(
+            tool=tool,
+            level=policy.level,
+            apply_mode=policy.apply_mode,
+            dry_run=dry_run,
+            success=success,
+            changed=changed,
+            summary=summary,
+            extra={"task_id": task_id, "backend": backend},
+        )
+    except Exception as exc:
+        logger.debug("runner audit failed", exc_info=exc)
+
+
 def normalize_execution(value: Any) -> dict[str, Any] | None:
     """Validate an optional contract ``execution`` selector.
 
@@ -124,6 +155,38 @@ def normalize_execution(value: Any) -> dict[str, Any] | None:
     if len(encoded.encode("utf-8")) > _MAX_OPTIONS_BYTES:
         raise ValueError(f"execution.options exceeds {_MAX_OPTIONS_BYTES} bytes")
     return {"backend": backend, "options": options}
+
+
+def _authorization_class(contract: dict[str, Any]) -> str:
+    return str(contract.get("authorization", {}).get("class") or "none")
+
+
+def _pi_tools(contract: dict[str, Any]) -> str:
+    options = ((contract.get("execution") or {}).get("options") or {})
+    auth_class = _authorization_class(contract)
+    requested = options.get("tools")
+    if requested is None or requested == "":
+        return "read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"
+    if not isinstance(requested, str):
+        raise TypeError("pi_rpc execution.options.tools must be a comma-delimited string")
+    tools = [item.strip() for item in requested.split(",") if item.strip()]
+    if not tools:
+        raise ValueError("pi_rpc execution.options.tools must not be empty")
+    if auth_class in {"none", "read_only"} and set(tools) - {"read"}:
+        raise PermissionError("read-only authorization may only enable Pi's read tool")
+    return ",".join(tools)
+
+
+def _sandbox_for(contract: dict[str, Any], *, backend: str) -> str:
+    options = ((contract.get("execution") or {}).get("options") or {})
+    auth_class = _authorization_class(contract)
+    requested = options.get("sandbox")
+    sandbox = str(requested or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write"))
+    if sandbox not in {"read-only", "workspace-write"}:
+        raise ValueError(f"{backend} execution.options.sandbox must be read-only or workspace-write")
+    if auth_class in {"none", "read_only"} and sandbox != "read-only":
+        raise PermissionError(f"read-only authorization may not use {backend} workspace-write sandbox")
+    return sandbox
 
 
 class RunnerBackend(Protocol):
@@ -395,11 +458,10 @@ class _LocalProcessBackend:
             start_new_session=True,
             close_fds=True,
         )
-        meta["pid"] = proc.pid
-        meta["state"] = "running"
-        meta["started_at"] = _now()
-        _atomic_json(meta_path, meta)
-        return {"success": True, "changed": True, "dry_run": False, "backend": self.name, "task_id": task_id, "state": "running", "pid": proc.pid}
+        # The worker owns durable state transitions. Avoid a parent-side write
+        # after spawn: a fast worker could otherwise complete and then be
+        # overwritten back to "running" by the parent.
+        return {"success": True, "changed": True, "dry_run": False, "backend": self.name, "task_id": task_id, "state": "queued", "pid": proc.pid}
 
     def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]:
         if not _TASK_ID_RE.fullmatch(task_id or ""):
@@ -425,6 +487,7 @@ class _LocalProcessBackend:
             return {"success": False, "code": "RUNNER_JOB_NOT_FOUND", "backend": self.name}
         if meta.get("state") in _TERMINAL_STATES:
             return {"success": True, "changed": False, "backend": self.name, "state": meta.get("state")}
+        _atomic_json(_cancel_path(task_id, hermes_root), {"task_id": task_id, "requested_at": _now()})
         pid = meta.get("pid")
         if isinstance(pid, int) and pid > 1:
             try:
@@ -454,10 +517,7 @@ class PiRpcBackend(_LocalProcessBackend):
 
     def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
         options = ((contract.get("execution") or {}).get("options") or {})
-        auth_class = str(contract.get("authorization", {}).get("class") or "none")
-        tools = options.get("tools")
-        if not tools:
-            tools = "read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"
+        tools = _pi_tools(contract)
         return {"protocol": "jsonl-rpc", "mode": "rpc", "tools": tools, "model": options.get("model"), "provider": options.get("provider")}
 
 
@@ -475,10 +535,7 @@ class OmxBackend(_LocalProcessBackend):
 
     def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
         options = ((contract.get("execution") or {}).get("options") or {})
-        auth_class = str(contract.get("authorization", {}).get("class") or "none")
-        sandbox = options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write")
-        if sandbox not in {"read-only", "workspace-write"}:
-            raise ValueError("omx execution.options.sandbox must be read-only or workspace-write")
+        sandbox = _sandbox_for(contract, backend="omx")
         return {"mode": "exec", "json": True, "sandbox": sandbox, "model": options.get("model"), "profile": options.get("profile")}
 
 
@@ -500,8 +557,7 @@ class CodexBackend:
         import operator_codex as op_codex
         options = ((contract.get("execution") or {}).get("options") or {})
         workspace = contract["allowed_scope"]["workspaces"][0]
-        auth_class = str(contract.get("authorization", {}).get("class") or "none")
-        sandbox = options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write")
+        sandbox = _sandbox_for(contract, backend="codex")
         result = op_codex.hermes_codex_start(
             prompt=contract["objective"],
             workdir=workspace,
@@ -563,8 +619,7 @@ def _extract_pi_text(message: Any) -> str:
 
 def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path) -> tuple[int, str]:
     options = ((contract.get("execution") or {}).get("options") or {})
-    auth_class = str(contract.get("authorization", {}).get("class") or "none")
-    tools = str(options.get("tools") or ("read" if auth_class in {"none", "read_only"} else "read,bash,edit,write"))
+    tools = _pi_tools(contract)
     argv = [exe, "--mode", "rpc", "--no-session", "--tools", tools]
     if options.get("provider"):
         argv += ["--provider", str(options["provider"])]
@@ -629,8 +684,7 @@ def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path)
 
 def _worker_omx(exe: str, contract: dict[str, Any], timeout: int, log_path: Path) -> tuple[int, str]:
     options = ((contract.get("execution") or {}).get("options") or {})
-    auth_class = str(contract.get("authorization", {}).get("class") or "none")
-    sandbox = str(options.get("sandbox") or ("read-only" if auth_class in {"none", "read_only"} else "workspace-write"))
+    sandbox = _sandbox_for(contract, backend="omx")
     workspace = contract["allowed_scope"]["workspaces"][0]
     argv = [exe, "exec", "--json", "-C", workspace, "--sandbox", sandbox]
     if options.get("model"):
@@ -676,6 +730,13 @@ def _worker(task_id: str, jobs_root: Path) -> int:
     contract = request["contract"]
     backend_name = str(request.get("backend") or "")
     timeout = max(10, min(int(request.get("timeout") or 900), 3600))
+    # The objective is needed only to start the worker. Remove the durable
+    # request envelope as soon as it has been loaded so prompt text is not
+    # retained after dispatch.
+    try:
+        request_path.unlink()
+    except OSError:
+        pass
     try:
         backend = get_backend(backend_name)
         exe = backend.executable() if isinstance(backend, _LocalProcessBackend) else None
@@ -683,10 +744,14 @@ def _worker(task_id: str, jobs_root: Path) -> int:
             raise RuntimeError(f"{backend_name} executable not found")
         meta.update({"state": "running", "started_at": meta.get("started_at") or _now(), "pid": os.getpid()})
         _atomic_json(meta_path, meta)
+        if (jobs_root / f"{task_id}.cancel.json").exists():
+            meta.update({"state": "cancelled", "outcome": "cancelled", "ended_at": _now()})
+            _atomic_json(meta_path, meta)
+            return 0
         if backend_name == "pi_rpc":
-            rc, final_text = _worker_pi(exe, contract, timeout, log_path)
+            rc, _ = _worker_pi(exe, contract, timeout, log_path)
         elif backend_name == "omx":
-            rc, final_text = _worker_omx(exe, contract, timeout, log_path)
+            rc, _ = _worker_omx(exe, contract, timeout, log_path)
         else:
             raise RuntimeError(f"local worker does not support backend {backend_name}")
         meta["returncode"] = rc
@@ -699,8 +764,9 @@ def _worker(task_id: str, jobs_root: Path) -> int:
             meta["state"] = "failed"
             meta["outcome"] = "failed"
             meta["error"] = "runner timed out" if rc == 124 else f"runner exited with code {rc}"
-        if final_text:
-            meta["result_summary"] = _bounded_text(final_text)
+        # Completion evidence is state/exit metadata only. Do not persist the
+        # model's final text in the runner store; contract validation must not
+        # depend on worker self-report or retain prompt-derived output.
         _atomic_json(meta_path, meta)
         return rc
     except Exception as exc:  # noqa: BLE001
@@ -712,12 +778,14 @@ def _worker(task_id: str, jobs_root: Path) -> int:
 def hermes_runner_list(hermes_root: Path | None = None) -> str:
     """List registered runner backends and bounded availability metadata."""
     try:
-        op.OperatorPolicy().require_level("read_only")
+        policy = op.OperatorPolicy()
+        policy.require_level("read_only")
         payload = {
             "success": True,
             "schema_version": SCHEMA_VERSION,
             "backends": list_backends(hermes_root=hermes_root),
         }
+        _audit_runner(tool="hermes_runner_list", policy=policy, dry_run=True, success=True, summary="listed runner backends")
         return json.dumps(payload, ensure_ascii=False, indent=2)
     except PermissionError as exc:
         return json.dumps({"success": False, "code": "RUNNER_POLICY_DENIED", "safe_message": _bounded_text(exc, 300)}, indent=2)
@@ -726,10 +794,12 @@ def hermes_runner_list(hermes_root: Path | None = None) -> str:
 def hermes_runner_status(task_id: str, hermes_root: Path | None = None) -> str:
     """Return bounded observed state for a contract task across runner backends."""
     try:
-        op.OperatorPolicy().require_level("read_only")
+        policy = op.OperatorPolicy()
+        policy.require_level("read_only")
         if not _TASK_ID_RE.fullmatch(task_id or ""):
             raise ValueError("task_id has an invalid format")
         runs = observed_runs(task_id, hermes_root=hermes_root)
+        _audit_runner(tool="hermes_runner_status", policy=policy, dry_run=True, success=True, summary=f"observed {len(runs)} runner record(s)", task_id=task_id)
         return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "task_id": task_id, "runs": runs, "count": len(runs)}, ensure_ascii=False, indent=2)
     except (PermissionError, ValueError) as exc:
         return json.dumps({"success": False, "code": "RUNNER_STATUS_ERROR", "safe_message": _bounded_text(exc, 300)}, indent=2)
@@ -752,13 +822,25 @@ def hermes_runner_cancel(task_id: str, backend: str = "", confirm: bool = False,
         if not selected:
             return json.dumps({"success": False, "code": "RUNNER_BACKEND_REQUIRED", "safe_message": "backend could not be inferred for task"}, indent=2)
         target = get_backend(selected)
+        if isinstance(target, _LocalProcessBackend):
+            meta_path, _, _ = _job_paths(task_id, hermes_root)
+            meta = _load_json(meta_path)
+            if not meta or meta.get("backend") != selected:
+                return json.dumps({"success": False, "code": "RUNNER_JOB_NOT_FOUND", "backend": selected, "task_id": task_id}, indent=2)
+            workspace = meta.get("workspace")
+            if not isinstance(workspace, str) or not workspace:
+                raise PermissionError("runner job has no valid workspace scope")
+            policy.require_workspace_path(workspace)
         if effective:
+            _audit_runner(tool="hermes_runner_cancel", policy=policy, dry_run=True, success=True, changed=False, summary="cancel plan", task_id=task_id, backend=selected)
             return json.dumps({"success": True, "dry_run": True, "changed": False, "backend": selected, "task_id": task_id, "plan": "cancel"}, indent=2)
         if not confirm:
+            _audit_runner(tool="hermes_runner_cancel", policy=policy, dry_run=True, success=False, changed=False, summary="confirmation required", task_id=task_id, backend=selected)
             return json.dumps({"success": False, "code": "CONFIRMATION_REQUIRED", "backend": selected, "safe_message": "runner cancellation requires confirm=true"}, indent=2)
         result = target.cancel(task_id, hermes_root=hermes_root)
         result.setdefault("backend", selected)
         result.setdefault("task_id", task_id)
+        _audit_runner(tool="hermes_runner_cancel", policy=policy, dry_run=False, success=bool(result.get("success")), changed=bool(result.get("changed")), summary="cancelled runner job" if result.get("success") else "runner cancel failed", task_id=task_id, backend=selected)
         return json.dumps(result, ensure_ascii=False, indent=2)
     except (PermissionError, ValueError, LookupError) as exc:
         return json.dumps({"success": False, "code": "RUNNER_CANCEL_ERROR", "safe_message": _bounded_text(exc, 300)}, indent=2)
@@ -770,7 +852,8 @@ def _register_builtins() -> None:
 
 
 _register_builtins()
-load_entrypoint_backends()
+if op.env_truthy(RUNNER_PLUGINS_ENV):
+    load_entrypoint_backends()
 
 
 def _main(argv: list[str]) -> int:

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -177,6 +177,70 @@ def _pi_tools(contract: dict[str, Any]) -> str:
     return ",".join(tools)
 
 
+def _pi_agent_dir() -> Path:
+    configured = os.environ.get("PI_CODING_AGENT_DIR", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".pi" / "agent"
+
+
+def _pi_selection(contract: dict[str, Any]) -> tuple[str, str]:
+    """Return the effective Pi provider/model without exposing credentials."""
+    options = ((contract.get("execution") or {}).get("options") or {})
+    provider = str(options.get("provider") or "").strip()
+    model = str(options.get("model") or "").strip()
+    settings = _load_json(_pi_agent_dir() / "settings.json") or {}
+    if not provider:
+        provider = str(settings.get("defaultProvider") or "").strip()
+    if not model:
+        model = str(settings.get("defaultModel") or "").strip()
+    return provider, model
+
+
+def _unquote_env_value(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _pi_child_env(contract: dict[str, Any], hermes_root: Path | None, provider: str) -> dict[str, str]:
+    """Build the Pi child environment with only the selected provider's env-ref credential.
+
+    Pi supports custom providers whose ``apiKey`` is an environment reference such
+    as ``$PROVIDER_KEY``. hermes-gpt profiles keep those values in the profile
+    ``.env`` file, but detached local-runner children do not automatically inherit
+    them. Resolve only the single referenced key for the selected provider; never
+    log or persist its value.
+    """
+    child_env = dict(os.environ)
+    if not provider:
+        return child_env
+
+    models = _load_json(_pi_agent_dir() / "models.json") or {}
+    providers = models.get("providers") if isinstance(models.get("providers"), dict) else {}
+    config = providers.get(provider) if isinstance(providers, dict) else None
+    raw_key = config.get("apiKey") if isinstance(config, dict) else None
+    if not isinstance(raw_key, str):
+        return child_env
+    match = re.fullmatch(r"\$([A-Za-z_][A-Za-z0-9_]*)", raw_key.strip())
+    if not match:
+        return child_env
+    key_name = match.group(1)
+    if child_env.get(key_name):
+        return child_env
+
+    profile = str(contract.get("assigned_profile") or "default")
+    allowed_profiles = contract.get("allowed_scope", {}).get("profiles") or []
+    if allowed_profiles and profile not in allowed_profiles:
+        raise PermissionError("Pi runner profile is outside the contract allowed_scope")
+    profile_home = op.resolve_profile_home(profile, hermes_root)
+    import operator_config as op_config
+
+    value = op_config._read_env_value(profile_home / ".env", key_name)
+    if value:
+        child_env[key_name] = _unquote_env_value(value)
+    return child_env
+
+
 def _sandbox_for(contract: dict[str, Any], *, backend: str) -> str:
     options = ((contract.get("execution") or {}).get("options") or {})
     auth_class = _authorization_class(contract)
@@ -562,9 +626,9 @@ class PiRpcBackend(_LocalProcessBackend):
         return None
 
     def build_plan(self, contract: dict[str, Any]) -> dict[str, Any]:
-        options = ((contract.get("execution") or {}).get("options") or {})
         tools = _pi_tools(contract)
-        return {"protocol": "jsonl-rpc", "mode": "rpc", "tools": tools, "model": options.get("model"), "provider": options.get("provider")}
+        provider, model = _pi_selection(contract)
+        return {"protocol": "jsonl-rpc", "mode": "rpc", "tools": tools, "model": model or None, "provider": provider or None}
 
 
 @dataclass
@@ -665,22 +729,44 @@ def _extract_pi_text(message: Any) -> str:
     return ""
 
 
-def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path) -> tuple[int, str]:
+def _worker_pi(
+    exe: str,
+    contract: dict[str, Any],
+    timeout: int,
+    log_path: Path,
+    hermes_root: Path | None = None,
+) -> tuple[int, str]:
     options = ((contract.get("execution") or {}).get("options") or {})
     tools = _pi_tools(contract)
+    provider, model = _pi_selection(contract)
     argv = [exe, "--mode", "rpc", "--no-session", "--tools", tools]
-    if options.get("provider"):
-        argv += ["--provider", str(options["provider"])]
-    if options.get("model"):
-        argv += ["--model", str(options["model"])]
+    if _authorization_class(contract) in {"none", "read_only"}:
+        # Pi extensions execute arbitrary startup code outside the built-in tool
+        # allowlist. Disable extension discovery for read-only contracts so an
+        # extension cannot mutate the workspace before the model even runs.
+        argv.append("--no-extensions")
+    if provider:
+        argv += ["--provider", provider]
+    if model:
+        argv += ["--model", model]
     if options.get("thinking"):
         argv += ["--thinking", str(options["thinking"])]
-    proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+    child_env = _pi_child_env(contract, hermes_root, provider)
+    proc = subprocess.Popen(
+        argv,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=child_env,
+    )
     assert proc.stdin is not None and proc.stdout is not None
     proc.stdin.write(json.dumps({"id": "dispatch", "type": "prompt", "message": contract["objective"]}, ensure_ascii=False) + "\n")
     proc.stdin.flush()
     final_text = ""
     settled = False
+    rpc_error = ""
     deadline = datetime.now(timezone.utc).timestamp() + timeout
     selector = selectors.DefaultSelector()
     selector.register(proc.stdout, selectors.EVENT_READ)
@@ -703,6 +789,9 @@ def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path)
         etype = event.get("type")
         if etype in {"response", "agent_start", "agent_end", "agent_settled", "turn_end", "message_end", "extension_error", "auto_retry_start", "auto_retry_end"}:
             _append_event(log_path, {"type": etype, "at": _now(), "success": event.get("success"), "command": event.get("command")})
+        if etype == "response" and event.get("command") == "prompt" and event.get("success") is False:
+            rpc_error = _bounded_text(event.get("error") or "Pi RPC prompt rejected", 500)
+            break
         if etype == "message_end":
             text = _extract_pi_text(event.get("message"))
             if text:
@@ -711,13 +800,24 @@ def _worker_pi(exe: str, contract: dict[str, Any], timeout: int, log_path: Path)
             settled = True
             break
     selector.close()
-    if not settled and proc.poll() is None:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-        return 124, final_text
+    if rpc_error:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        raise RuntimeError(f"Pi RPC prompt failed: {rpc_error}")
+    if not settled:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            return 124, final_text
+        rc = int(proc.returncode or 0)
+        return (rc if rc else 1), final_text
     try:
         proc.stdin.close()
     except OSError:
@@ -778,6 +878,10 @@ def _worker(task_id: str, jobs_root: Path) -> int:
     contract = request["contract"]
     backend_name = str(request.get("backend") or "")
     timeout = max(10, min(int(request.get("timeout") or 900), 3600))
+    request_root_raw = request.get("hermes_root")
+    request_root = Path(str(request_root_raw)).expanduser() if request_root_raw else None
+    normalized_root = op.normalize_hermes_data_root(request_root) if request_root is not None else None
+    worker_hermes_root = Path(normalized_root) if normalized_root is not None else request_root
     # The objective is needed only to start the worker. Remove the durable
     # request envelope as soon as it has been loaded so prompt text is not
     # retained after dispatch.
@@ -826,7 +930,7 @@ def _worker(task_id: str, jobs_root: Path) -> int:
             _terminalize(meta, state="cancelled")
             return 0
         if backend_name == "pi_rpc":
-            rc, _ = _worker_pi(exe, contract, timeout, log_path)
+            rc, _ = _worker_pi(exe, contract, timeout, log_path, worker_hermes_root)
         elif backend_name == "omx":
             rc, _ = _worker_omx(exe, contract, timeout, log_path)
         else:

--- a/operator_runners.py
+++ b/operator_runners.py
@@ -102,6 +102,45 @@ def _bounded_text(value: Any, maximum: int = _MAX_RESULT_CHARS) -> str:
     return text if len(text) <= maximum else text[: maximum - 3] + "..."
 
 
+def _popen_process_group(argv: list[str], **kwargs: Any) -> subprocess.Popen[str]:
+    """Start a child in its own process group/session for bounded cleanup."""
+    kwargs.setdefault("close_fds", True)
+    if os.name == "nt":
+        kwargs.setdefault("creationflags", subprocess.CREATE_NEW_PROCESS_GROUP)
+    else:
+        kwargs.setdefault("start_new_session", True)
+    return subprocess.Popen(argv, **kwargs)
+
+
+def _terminate_process_group(proc: subprocess.Popen[Any], *, timeout: float = 5.0) -> None:
+    """Terminate the child and descendants started by _popen_process_group."""
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "nt":
+            proc.terminate()
+        else:
+            os.killpg(proc.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    try:
+        proc.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if os.name == "nt":
+            proc.kill()
+        else:
+            os.killpg(proc.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def _audit_runner(
     *,
     tool: str,
@@ -534,14 +573,12 @@ class _LocalProcessBackend:
         }
         _atomic_json(meta_path, meta)
         try:
-            proc = subprocess.Popen(
+            proc = _popen_process_group(
                 [sys.executable, str(Path(__file__).resolve()), "--worker", task_id, "--root", str(_root(hermes_root))],
                 cwd=str(workspace),
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
-                start_new_session=True,
-                close_fds=True,
             )
         except Exception as exc:  # noqa: BLE001
             # Spawn failed after the request/meta envelopes were written.
@@ -752,11 +789,13 @@ def _worker_pi(
     if options.get("thinking"):
         argv += ["--thinking", str(options["thinking"])]
     child_env = _pi_child_env(contract, hermes_root, provider)
-    proc = subprocess.Popen(
+    proc = _popen_process_group(
         argv,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        # Route stderr away from PIPE so noisy Pi startup/logging cannot fill an
+        # unconsumed pipe and stall RPC progress before agent_settled.
+        stderr=subprocess.DEVNULL,
         text=True,
         bufsize=1,
         env=child_env,
@@ -801,20 +840,11 @@ def _worker_pi(
             break
     selector.close()
     if rpc_error:
-        if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+        _terminate_process_group(proc)
         raise RuntimeError(f"Pi RPC prompt failed: {rpc_error}")
     if not settled:
         if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+            _terminate_process_group(proc)
             return 124, final_text
         rc = int(proc.returncode or 0)
         return (rc if rc else 1), final_text
@@ -825,8 +855,8 @@ def _worker_pi(
     try:
         rc = proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        proc.terminate()
-        rc = proc.wait(timeout=5)
+        _terminate_process_group(proc)
+        rc = int(proc.returncode or 124)
     return rc, final_text
 
 
@@ -840,12 +870,15 @@ def _worker_omx(exe: str, contract: dict[str, Any], timeout: int, log_path: Path
     if options.get("profile"):
         argv += ["--profile", str(options["profile"])]
     argv.append("-")
-    proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    proc = _popen_process_group(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     try:
         stdout, stderr = proc.communicate(input=contract["objective"], timeout=timeout)
     except subprocess.TimeoutExpired:
-        proc.kill()
-        stdout, stderr = proc.communicate()
+        _terminate_process_group(proc)
+        try:
+            stdout, stderr = proc.communicate(timeout=2)
+        except subprocess.TimeoutExpired:
+            stdout, stderr = "", ""
         _append_event(log_path, {"type": "timeout", "at": _now()})
         return 124, ""
     final_text = ""

--- a/operator_swarm.py
+++ b/operator_swarm.py
@@ -686,7 +686,7 @@ def _stage_contract(workflow: dict[str, Any], stage: dict[str, Any], *, task_id:
         "approval_reference": "G4-swarm",
     }
 
-    return {
+    contract = {
         "schema": CONTRACT_SCHEMA,
         "task_id": task_id,
         "assigned_agent": stage["owner"],
@@ -705,6 +705,9 @@ def _stage_contract(workflow: dict[str, Any], stage: dict[str, Any], *, task_id:
         "constraints": _string_list(stage.get("constraints") or [], field="constraints"),
         "authorization": auth,
     }
+    if stage.get("execution") is not None:
+        contract["execution"] = stage["execution"]
+    return contract
 
 
 def _stage_contract_sha(contract: dict[str, Any]) -> str:
@@ -1307,6 +1310,7 @@ def _workflow_stages_for_dispatch(record: dict[str, Any]) -> list[dict[str, Any]
             "review_requirements": st.get("review_requirements"),
             "completion_criteria": st.get("completion_criteria"),
             "authorization": st.get("authorization"),
+            "execution": st.get("execution"),
             "worktree": st.get("worktree"),
             "inputs": st.get("inputs", []),
             "constraints": st.get("constraints", []),
@@ -1419,7 +1423,7 @@ def hermes_swarm_stage_advance(
 
     # Codex review stage: drive the existing runner, read the bounded verdict.
     review_evidence: dict[str, Any] | None = None
-    if stage.get("kind") == "codex_review" or stage.get("id") == "codex_review":
+    if (stage.get("kind") == "codex_review" or stage.get("id") == "codex_review") and stage.get("execution") is None and stage.get("owner") == "codex":
         reviewer = codex_reviewer or _default_codex_reviewer
         plan = _worktree_plan(workflow, stage, st.get("task_id") or f"{workflow_id}-{stage_id}")
         # Design §8: target = the merged branch (base:<integration-branch>).

--- a/operator_swarm_workflows.py
+++ b/operator_swarm_workflows.py
@@ -126,6 +126,7 @@ def canonical_workflow(
     workflow_id: str | None = None,
     owners: dict[str, str] | None = None,
     objectives: dict[str, str] | None = None,
+    executions: dict[str, dict[str, Any]] | None = None,
     implementation_artifacts: list[dict[str, Any]] | None = None,
     tests_artifacts: list[dict[str, Any]] | None = None,
     docs_artifacts: list[dict[str, Any]] | None = None,
@@ -143,6 +144,7 @@ def canonical_workflow(
     """
     owners = dict(DEFAULT_OWNERS, **(owners or {}))
     objectives = objectives or {}
+    executions = executions or {}
     stages: list[dict[str, Any]] = []
     for stage_id, kind, parents in CANONICAL_STAGE_SPECS:
         owner = owners.get(stage_id, DEFAULT_OWNERS[stage_id])
@@ -157,6 +159,8 @@ def canonical_workflow(
             worktree=worktree,
             objective=objectives.get(stage_id),
         )
+        if stage_id in executions:
+            stage["execution"] = dict(executions[stage_id])
         if stage_id == "implementation" and implementation_artifacts:
             stage["expected_artifacts"] = list(implementation_artifacts)
             if implementation_tests:
@@ -170,8 +174,8 @@ def canonical_workflow(
             # review verdict (P2-1: bounded verdict JSON, no transcripts).
             stage["review_requirements"] = {
                 "required": True,
-                "reviewer": "codex",
-                "evidence": "codex review verdict JSON",
+                "reviewer": owner,
+                "evidence": "review verdict evidence",
                 "approval_required": False,
             }
             stage["completion_criteria"] = {

--- a/operator_workspace.py
+++ b/operator_workspace.py
@@ -313,10 +313,25 @@ def hermes_gateway_status(
         )
 
 
+def _hermes_cli() -> str:
+    """Return the Hermes CLI executable used by fixed-argv gateway commands."""
+    configured = os.environ.get("HERMES_CLI", "").strip()
+    if configured:
+        return str(Path(configured).expanduser())
+    found = shutil.which("hermes")
+    if found:
+        return found
+    local_bin = Path.home() / ".local" / "bin" / "hermes"
+    if local_bin.exists():
+        return str(local_bin)
+    return "hermes"
+
+
 def _hermes_argv(profile: str, sub: list[str]) -> list[str]:
+    hermes_cli = _hermes_cli()
     if profile == "default":
-        return ["hermes", *sub]
-    return ["hermes", "-p", profile, *sub]
+        return [hermes_cli, *sub]
+    return [hermes_cli, "-p", profile, *sub]
 
 
 def _gateway_restart_argv(profile: str) -> list[str]:

--- a/operator_workspace.py
+++ b/operator_workspace.py
@@ -328,10 +328,10 @@ def _hermes_cli() -> str:
 
 
 def _hermes_argv(profile: str, sub: list[str]) -> list[str]:
-    hermes_cli = _hermes_cli()
+    """Return the stable logical Hermes argv used by plans and injected runners."""
     if profile == "default":
-        return [hermes_cli, *sub]
-    return [hermes_cli, "-p", profile, *sub]
+        return ["hermes", *sub]
+    return ["hermes", "-p", profile, *sub]
 
 
 def _gateway_restart_argv(profile: str) -> list[str]:
@@ -346,8 +346,13 @@ def _hermes_gateway_restart_raw(
 
     No policy checks; callers must gate mutation themselves.
     """
-    run_fn = runner or op.run_argv
-    return run_fn(_gateway_restart_argv(profile), timeout=120, workdir=None)
+    argv = _gateway_restart_argv(profile)
+    if runner is None:
+        argv = [_hermes_cli(), *argv[1:]]
+        run_fn = op.run_argv
+    else:
+        run_fn = runner
+    return run_fn(argv, timeout=120, workdir=None)
 
 
 def hermes_gateway_restart(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ py-modules = [
   "operator_session",
   "operator_mission",
   "operator_contract",
+  "operator_runners",
   "operator_review",
   "operator_events",
   "operator_oauth",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "ruff",
   "build",
   "twine",
   "pyyaml",

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ import operator_fleet as op_fleet
 import operator_session as op_session
 import operator_mission as op_mission
 import operator_contract as op_contract
+import operator_runners as op_runners
 import operator_review as op_review
 import operator_events as op_events
 import operator_oauth as op_oauth
@@ -1394,6 +1395,9 @@ def hermes_operator_status() -> str:
             "hermes_contract_dispatch",
             "hermes_contract_validate",
             "hermes_contract_status",
+            "hermes_runner_list",
+            "hermes_runner_status",
+            "hermes_runner_cancel",
         ]
         result = {
             "success": True,
@@ -1994,6 +1998,32 @@ def hermes_contract_status(contract_json: str) -> str:
     return op_contract.hermes_contract_status(contract_json=contract_json, hermes_root=_default_hermes_root())
 
 
+# --- Pluggable Runner Backends ---------------------------------------------
+
+
+def hermes_runner_list() -> str:
+    return op_runners.hermes_runner_list(hermes_root=_default_hermes_root())
+
+
+def hermes_runner_status(task_id: str) -> str:
+    return op_runners.hermes_runner_status(task_id=task_id, hermes_root=_default_hermes_root())
+
+
+def hermes_runner_cancel(
+    task_id: str,
+    backend: str = "",
+    confirm: bool = False,
+    dry_run: bool = True,
+) -> str:
+    return op_runners.hermes_runner_cancel(
+        task_id=task_id,
+        backend=backend,
+        confirm=confirm,
+        dry_run=dry_run,
+        hermes_root=_default_hermes_root(),
+    )
+
+
 def hermes_review_accept(
     contract_sha256: str,
     task_id: str,
@@ -2412,6 +2442,15 @@ def register_tools(server: FastMCP) -> None:
         hermes_contract_status,
     ):
         server.add_tool(_contract_tool, meta=tool_meta())
+
+    # Pluggable execution backends: list/status are read-only; cancellation is
+    # workspace/direct gated internally and dry-run-first.
+    for _runner_tool in (
+        hermes_runner_list,
+        hermes_runner_status,
+        hermes_runner_cancel,
+    ):
+        server.add_tool(_runner_tool, meta=tool_meta())
 
     # Review-evidence writer (v0.7 S3): owner-gated, distinct reviewer.
     server.add_tool(

--- a/test_operator_contract.py
+++ b/test_operator_contract.py
@@ -1031,5 +1031,8 @@ def test_server_registers_contract_tools(monkeypatch):
         "hermes_contract_dispatch",
         "hermes_contract_validate",
         "hermes_contract_status",
+        "hermes_runner_list",
+        "hermes_runner_status",
+        "hermes_runner_cancel",
     ):
         assert tool in names

--- a/test_operator_fleet_cli_resolution.py
+++ b/test_operator_fleet_cli_resolution.py
@@ -1,0 +1,23 @@
+import operator_fleet as fleet
+
+
+def test_hermes_bin_prefers_explicit_cli_env(monkeypatch, tmp_path):
+    fake_cli = tmp_path / "hermes"
+    fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_CLI", str(fake_cli))
+
+    assert fleet._hermes_bin() == str(fake_cli)
+
+
+def test_hermes_bin_uses_local_bin_fallback(monkeypatch, tmp_path):
+    fake_home = tmp_path
+    fake_cli = fake_home / ".local" / "bin" / "hermes"
+    fake_cli.parent.mkdir(parents=True)
+    fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("HERMES_CLI", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(fleet.shutil, "which", lambda name: None)
+    monkeypatch.setattr(fleet.op, "normalize_hermes_data_root", lambda value: None)
+
+    assert fleet._hermes_bin() == str(fake_cli)

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -224,3 +224,281 @@ def test_runner_cancel_enforces_job_workspace_scope(tmp_path: Path, monkeypatch:
     payload = json.loads(runners.hermes_runner_cancel(task_id, backend="pi_rpc", dry_run=True, hermes_root=root))
     assert payload["success"] is False
     assert payload["code"] == "RUNNER_CANCEL_ERROR"
+
+
+# ---------------------------------------------------------------------------
+# PR #18 correctness regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_popen_failure_deletes_request_envelope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Spawn failure after envelope writes must delete the request (raw
+    objective) and leave only bounded failed metadata."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("pi_rpc")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("spawn refused")
+
+    monkeypatch.setattr(runners.subprocess, "Popen", _boom)
+    raw = _contract(ws, backend="pi_rpc")
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=False, confirm=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_SPAWN_FAILED"
+    meta_path, request_path, _ = runners._job_paths(raw["task_id"], root)
+    assert not request_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["state"] == "failed"
+    assert meta["outcome"] == "failed"
+    assert raw["objective"] not in json.dumps(meta)
+
+
+def test_fleet_exception_keeps_legacy_contract_dispatch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    fleet = runners.get_backend("fleet")
+    monkeypatch.setattr(fleet, "dispatch", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("fleet peer unreachable")))
+    raw = _contract(ws)  # no execution selector -> implicit fleet
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "CONTRACT_DISPATCH_ERROR"
+    assert payload["suggested_action"] == "Check fleet authority manifest, registry, and peer service."
+
+
+def test_explicit_fleet_selector_uses_runner_dispatch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    fleet = runners.get_backend("fleet")
+    monkeypatch.setattr(fleet, "dispatch", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    raw = _contract(ws, backend="fleet")
+    payload = runners.dispatch_contract(raw, confirm=False, dry_run=True, timeout=30, hermes_root=root)
+    assert payload["code"] == "RUNNER_DISPATCH_ERROR"
+
+
+def test_non_fleet_backend_exception_uses_runner_dispatch_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    codex = runners.get_backend("codex")
+    monkeypatch.setattr(codex, "dispatch", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("codex backend exploded")))
+    raw = _contract(ws, backend="codex")
+    payload = runners.dispatch_contract(raw, confirm=False, dry_run=True, timeout=30, hermes_root=root)
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_DISPATCH_ERROR"
+    assert payload["backend"] == "codex"
+
+
+def test_codex_observed_runs_uses_normalized_data_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import operator_codex as op_codex
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "env-hermes"))
+    backend = runners.CodexBackend()
+    # With hermes_root given, observed_runs must use the normalized root
+    # (op_codex._root), not hermes_root/'codex-jobs' or ~/.hermes directly.
+    normalized = op_codex._root(root)
+    normalized.mkdir(parents=True, exist_ok=True)
+    normalized.joinpath("job-1.json").write_text(json.dumps({
+        "job_id": "job-1", "state": "completed", "outcome": "completed", "task_id": "codex-link-001",
+    }), encoding="utf-8")
+    runs = backend.observed_runs("codex-link-001", hermes_root=root)
+    assert len(runs) == 1
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["scope"] == "runner:codex"
+    # And normalization applies without an explicit hermes_root too.
+    env_root = op_codex._root(None)
+    if env_root != normalized:
+        assert backend.observed_runs("codex-link-001") == []
+
+
+def _fake_backend(monkeypatch):
+    backend = runners.PiRpcBackend()
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    return backend
+
+
+def _make_job(root: Path, task_id: str, *, backend: str = "pi_rpc", state: str = "running") -> Path:
+    meta_path = root / f"{task_id}.json"
+    request_path = root / f"{task_id}.request.json"
+    runners._atomic_json(meta_path, {
+        "schema_version": runners.SCHEMA_VERSION,
+        "task_id": task_id,
+        "backend": backend,
+        "state": state,
+        "outcome": state,
+        "workspace": "/tmp",
+        "created_at": runners._now(),
+        "started_at": runners._now(),
+        "ended_at": None,
+        "pid": None,
+        "returncode": None,
+        "error": "",
+    })
+    runners._atomic_json(request_path, {"backend": backend, "contract": _contract(Path("/tmp"), backend=backend), "timeout": 30})
+    return meta_path
+
+
+def test_cancel_marker_wins_over_completed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    task_id = "race-completed-001"
+    meta_path, _, _ = runners._job_paths(task_id, tmp_path)
+    root = meta_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    _make_job(root, task_id)
+    cancel_path = root / f"{task_id}.cancel.json"
+    runners._atomic_json(cancel_path, {"task_id": task_id})
+    monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    rc = runners._worker(task_id, root)
+    meta = json.loads(meta_path.read_text())
+    assert rc == 0, meta.get("error")
+    assert meta["state"] == "cancelled"
+    assert meta["outcome"] == "cancelled"
+    assert not (root / f"{task_id}.cancel.json").exists()
+
+
+def test_cancel_marker_wins_over_failed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    task_id = "race-failed-001"
+    meta_path, _, _ = runners._job_paths(task_id, tmp_path)
+    root = meta_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    _make_job(root, task_id)
+    cancel_path = root / f"{task_id}.cancel.json"
+    runners._atomic_json(cancel_path, {"task_id": task_id})
+    monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
+    monkeypatch.setattr(runners, "_worker_omx", lambda exe, contract, timeout, log_path: (3, ""))
+    runners._worker(task_id, root)
+    meta = json.loads(meta_path.read_text())
+    assert meta["state"] == "cancelled"
+
+
+def test_cancel_marker_wins_on_exception_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    task_id = "race-exc-001"
+    meta_path, _, _ = runners._job_paths(task_id, tmp_path)
+    root = meta_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    _make_job(root, task_id)
+    cancel_path = root / f"{task_id}.cancel.json"
+    runners._atomic_json(cancel_path, {"task_id": task_id})
+
+    def _raise(name):
+        raise LookupError("backend vanished")
+
+    monkeypatch.setattr(runners, "get_backend", _raise)
+    assert runners._worker(task_id, root) == 1
+    meta = json.loads(meta_path.read_text())
+    assert meta["state"] == "cancelled"
+    assert not (root / f"{task_id}.cancel.json").exists()
+
+
+def test_worker_without_cancel_marker_reports_completed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    task_id = "race-ok-001"
+    meta_path, _, _ = runners._job_paths(task_id, tmp_path)
+    root = meta_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    _make_job(root, task_id)
+    monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    rc = runners._worker(task_id, root)
+    meta = json.loads(meta_path.read_text())
+    assert rc == 0, meta.get("error")
+    assert meta["state"] == "completed"
+    assert not (root / f"{task_id}.cancel.json").exists()
+
+
+def test_cancel_arriving_during_terminal_write_still_wins(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    task_id = "race-terminal-write-001"
+    meta_path, _, _ = runners._job_paths(task_id, tmp_path)
+    root = meta_path.parent
+    root.mkdir(parents=True, exist_ok=True)
+    _make_job(root, task_id)
+    cancel_path = root / f"{task_id}.cancel.json"
+    monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    real_atomic = runners._atomic_json
+    injected = {"done": False}
+
+    def _atomic_with_cancel(path, value):
+        real_atomic(path, value)
+        if path == meta_path and value.get("state") == "completed" and not injected["done"]:
+            injected["done"] = True
+            real_atomic(cancel_path, {"task_id": task_id, "requested_at": runners._now()})
+
+    monkeypatch.setattr(runners, "_atomic_json", _atomic_with_cancel)
+    rc = runners._worker(task_id, root)
+    meta = json.loads(meta_path.read_text())
+    assert rc == 0
+    assert injected["done"] is True
+    assert meta["state"] == "cancelled"
+    assert meta["outcome"] == "cancelled"
+    assert not cancel_path.exists()
+
+
+class _ExternalBackend:
+    name = "external_probe"
+
+    def availability(self, *, hermes_root=None):
+        return {"available": True}
+
+    def dispatch(self, *a, **k):
+        return {"success": True}
+
+    def observed_runs(self, task_id, *, hermes_root=None):
+        return []
+
+    def cancel(self, task_id, *, hermes_root=None):
+        return {"success": True}
+
+
+class _ShadowFleetBackend(_ExternalBackend):
+    name = "fleet"
+
+
+def _fake_entry_points(monkeypatch, candidates):
+    class _EP:
+        def __init__(self, name, loader):
+            self.name = name
+            self._loader = loader
+
+        def load(self):
+            return self._loader
+
+    class _EPS(dict):
+        def select(self, *, group):
+            return [_EP(name, loader) for name, loader in candidates.get(group, [])]
+
+    monkeypatch.setattr(runners.importlib.metadata, "entry_points", lambda: _EPS())
+
+
+def test_plugin_class_entry_point_instantiates(monkeypatch: pytest.MonkeyPatch):
+    _fake_entry_points(monkeypatch, {"hermes_gpt.runners": [("external_probe", _ExternalBackend)]})
+    loaded = runners.load_entrypoint_backends()
+    assert "external_probe" in loaded
+    try:
+        assert runners.get_backend("external_probe").availability() == {"available": True}
+    finally:
+        with runners._REGISTRY_LOCK:
+            runners._BACKENDS.pop("external_probe", None)
+
+
+def test_plugin_cannot_shadow_builtin_backend_name(monkeypatch: pytest.MonkeyPatch):
+    _fake_entry_points(monkeypatch, {"hermes_gpt.runners": [("fleet", _ShadowFleetBackend)]})
+    loaded = runners.load_entrypoint_backends()
+    assert loaded == []
+    with pytest.raises(LookupError):
+        runners.get_backend("__never__")  # registry sanity helper
+    # The built-in fleet backend must still be the registered one.
+    assert runners.get_backend("fleet").__class__ is runners.FleetBackend

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -346,6 +346,99 @@ def test_runner_cancel_enforces_job_workspace_scope(tmp_path: Path, monkeypatch:
     assert payload["code"] == "RUNNER_CANCEL_ERROR"
 
 
+def test_runner_cancel_routes_pid_to_tree_cleanup_and_terminalizes_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    root = tmp_path / "hermes"
+    ws.mkdir()
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    task_id = "runner-cancel-tree"
+    meta_path, _, _ = runners._job_paths(task_id, root)
+    runners._atomic_json(meta_path, {
+        "schema_version": runners.SCHEMA_VERSION,
+        "task_id": task_id,
+        "backend": "pi_rpc",
+        "state": "running",
+        "outcome": "running",
+        "workspace": str(ws),
+        "pid": 4242,
+        "ended_at": None,
+    })
+    terminated = []
+    monkeypatch.setattr(
+        runners,
+        "_terminate_process_tree",
+        lambda target, timeout=5.0: terminated.append((target, timeout)),
+    )
+
+    payload = json.loads(
+        runners.hermes_runner_cancel(
+            task_id,
+            backend="pi_rpc",
+            confirm=True,
+            dry_run=False,
+            hermes_root=root,
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["state"] == "cancelled"
+    assert terminated == [(4242, 5.0)]
+    stored = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert stored["state"] == "cancelled"
+    assert stored["outcome"] == "cancelled"
+    assert stored["ended_at"]
+
+
+def test_windows_backend_cancel_uses_taskkill_tree_and_marks_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    task_id = "runner-cancel-windows"
+    meta_path = tmp_path / "job.json"
+    request_path = tmp_path / "request.json"
+    log_path = tmp_path / "events.jsonl"
+    cancel_path = tmp_path / "cancel.json"
+    runners._atomic_json(meta_path, {
+        "schema_version": runners.SCHEMA_VERSION,
+        "task_id": task_id,
+        "backend": "pi_rpc",
+        "state": "running",
+        "outcome": "running",
+        "workspace": str(tmp_path),
+        "pid": 4343,
+        "ended_at": None,
+    })
+    taskkill_calls = []
+
+    def _run(argv, **kwargs):
+        taskkill_calls.append(argv)
+        return runners.subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(
+        runners,
+        "_job_paths",
+        lambda task_id, hermes_root=None: (meta_path, request_path, log_path),
+    )
+    monkeypatch.setattr(
+        runners,
+        "_cancel_path",
+        lambda task_id, hermes_root=None: cancel_path,
+    )
+    monkeypatch.setattr(runners.os, "name", "nt")
+    monkeypatch.setattr(runners.subprocess, "run", _run)
+
+    result = runners.PiRpcBackend().cancel(task_id, hermes_root=tmp_path)
+
+    assert result["success"] is True
+    assert result["state"] == "cancelled"
+    assert taskkill_calls == [["taskkill", "/PID", "4343", "/T", "/F"]]
+    stored = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert stored["state"] == "cancelled"
+    assert stored["outcome"] == "cancelled"
+    assert stored["ended_at"]
+
+
 # ---------------------------------------------------------------------------
 # PR #18 correctness regression tests
 # ---------------------------------------------------------------------------
@@ -680,11 +773,35 @@ def test_windows_process_tree_cleanup_uses_taskkill(monkeypatch: pytest.MonkeyPa
 
     def _run(argv, **kwargs):
         calls.append(argv)
+        return runners.subprocess.CompletedProcess(argv, 0)
 
     monkeypatch.setattr(runners.os, "name", "nt")
     monkeypatch.setattr(runners.subprocess, "run", _run)
     runners._terminate_process_tree(_Proc(), timeout=1)
     assert ["taskkill", "/PID", "4242", "/T", "/F"] in calls
+    assert ["terminate"] not in calls
+    assert ["kill"] not in calls
+
+
+@pytest.mark.parametrize("failure", ["missing", "nonzero"])
+def test_windows_detached_pid_cleanup_falls_back_when_taskkill_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+):
+    direct_kills = []
+
+    def _run(argv, **kwargs):
+        if failure == "missing":
+            raise FileNotFoundError("taskkill unavailable")
+        return runners.subprocess.CompletedProcess(argv, 1)
+
+    monkeypatch.setattr(runners.os, "name", "nt")
+    monkeypatch.setattr(runners.subprocess, "run", _run)
+    monkeypatch.setattr(runners.os, "kill", lambda pid, sig: direct_kills.append((pid, sig)))
+
+    runners._terminate_process_tree(5252, timeout=1)
+
+    assert direct_kills == [(5252, runners.signal.SIGTERM)]
 
 
 def test_posix_process_tree_cleanup_uses_process_group(monkeypatch: pytest.MonkeyPatch):

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -100,6 +100,62 @@ def test_pi_rpc_dry_run_uses_rpc_plan(tmp_path: Path, monkeypatch: pytest.Monkey
     assert payload["plan"]["model"] == "x/y"
 
 
+def test_pi_defaults_and_profile_credential_reference_are_applied(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pi_dir = tmp_path / "pi-agent"
+    pi_dir.mkdir()
+    (pi_dir / "settings.json").write_text(
+        json.dumps({"defaultProvider": "test-provider", "defaultModel": "test-model"}),
+        encoding="utf-8",
+    )
+    (pi_dir / "models.json").write_text(
+        json.dumps({"providers": {"test-provider": {"apiKey": "$PI_TEST_PROVIDER_KEY", "models": [{"id": "test-model"}]}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+    monkeypatch.delenv("PI_TEST_PROVIDER_KEY", raising=False)
+    monkeypatch.delenv("PI_TEST_UNRELATED", raising=False)
+
+    hermes_root = tmp_path / "hermes"
+    hermes_root.mkdir()
+    (hermes_root / ".env").write_text(
+        "PI_TEST_PROVIDER_KEY=test-credential\nPI_TEST_UNRELATED=do-not-copy\n",
+        encoding="utf-8",
+    )
+    contract = _contract(tmp_path, backend="pi_rpc")
+
+    assert runners._pi_selection(contract) == ("test-provider", "test-model")
+    child_env = runners._pi_child_env(contract, hermes_root, "test-provider")
+    assert child_env["PI_TEST_PROVIDER_KEY"] == "test-credential"
+    assert "PI_TEST_UNRELATED" not in child_env
+
+
+def test_pi_rpc_prompt_rejection_fails_immediately(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pi_dir = tmp_path / "pi-agent"
+    pi_dir.mkdir()
+    (pi_dir / "settings.json").write_text(
+        json.dumps({"defaultProvider": "test-provider", "defaultModel": "test-model"}),
+        encoding="utf-8",
+    )
+    (pi_dir / "models.json").write_text(json.dumps({"providers": {}}), encoding="utf-8")
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+
+    fake_pi = tmp_path / "fake-pi"
+    fake_pi.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys\n"
+        "assert '--no-extensions' in sys.argv\n"
+        "json.loads(sys.stdin.readline())\n"
+        "print(json.dumps({'id':'dispatch','type':'response','command':'prompt','success':False,'error':'provider unavailable'}), flush=True)\n",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+    contract = _contract(tmp_path, backend="pi_rpc")
+    contract["authorization"] = {"class": "read_only", "approved": True}
+
+    with pytest.raises(RuntimeError, match="Pi RPC prompt failed: provider unavailable"):
+        runners._worker_pi(str(fake_pi), contract, 5, tmp_path / "events.jsonl", tmp_path / "hermes")
+
+
 def test_omx_dry_run_uses_native_exec_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     ws = tmp_path / "ws"
     ws.mkdir()
@@ -361,7 +417,7 @@ def test_cancel_marker_wins_over_completed(tmp_path: Path, monkeypatch: pytest.M
     cancel_path = root / f"{task_id}.cancel.json"
     runners._atomic_json(cancel_path, {"task_id": task_id})
     monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
-    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path, hermes_root=None: (0, "done"))
     rc = runners._worker(task_id, root)
     meta = json.loads(meta_path.read_text())
     assert rc == 0, meta.get("error")
@@ -411,7 +467,7 @@ def test_worker_without_cancel_marker_reports_completed(tmp_path: Path, monkeypa
     root.mkdir(parents=True, exist_ok=True)
     _make_job(root, task_id)
     monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
-    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path, hermes_root=None: (0, "done"))
     rc = runners._worker(task_id, root)
     meta = json.loads(meta_path.read_text())
     assert rc == 0, meta.get("error")
@@ -427,7 +483,7 @@ def test_cancel_arriving_during_terminal_write_still_wins(tmp_path: Path, monkey
     _make_job(root, task_id)
     cancel_path = root / f"{task_id}.cancel.json"
     monkeypatch.setattr(runners, "get_backend", lambda name: _fake_backend(monkeypatch))
-    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path: (0, "done"))
+    monkeypatch.setattr(runners, "_worker_pi", lambda exe, contract, timeout, log_path, hermes_root=None: (0, "done"))
     real_atomic = runners._atomic_json
     injected = {"done": False}
 

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -154,6 +155,52 @@ def test_pi_rpc_prompt_rejection_fails_immediately(tmp_path: Path, monkeypatch: 
 
     with pytest.raises(RuntimeError, match="Pi RPC prompt failed: provider unavailable"):
         runners._worker_pi(str(fake_pi), contract, 5, tmp_path / "events.jsonl", tmp_path / "hermes")
+
+
+def test_pi_stderr_burst_cannot_stall_worker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pi_dir = tmp_path / "pi-agent"
+    pi_dir.mkdir()
+    (pi_dir / "settings.json").write_text(json.dumps({}), encoding="utf-8")
+    (pi_dir / "models.json").write_text(json.dumps({"providers": {}}), encoding="utf-8")
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+
+    fake_pi = tmp_path / "fake-pi-noisy-stderr"
+    fake_pi.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, sys\n"
+        "json.loads(sys.stdin.readline())\n"
+        "os.write(sys.stderr.fileno(), b'x' * (2 * 1024 * 1024))\n"
+        "print(json.dumps({'type':'message_end','message':{'role':'assistant','content':'done'}}), flush=True)\n"
+        "print(json.dumps({'type':'agent_settled','success':True}), flush=True)\n",
+        encoding="utf-8",
+    )
+    fake_pi.chmod(0o755)
+    contract = _contract(tmp_path, backend="pi_rpc")
+    started = time.monotonic()
+    rc, final_text = runners._worker_pi(str(fake_pi), contract, 5, tmp_path / "events.jsonl", tmp_path / "hermes")
+    assert rc == 0
+    assert final_text == "done"
+    assert time.monotonic() - started < 5
+
+
+def test_omx_timeout_kills_descendant_holding_inherited_pipes(tmp_path: Path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    fake_omx = tmp_path / "fake-omx-descendant"
+    fake_omx.write_text(
+        "#!/usr/bin/env python3\n"
+        "import subprocess, sys, time\n"
+        "subprocess.Popen([sys.executable, '-c', \"import sys,time; sys.stdout.write('held'); sys.stdout.flush(); time.sleep(60)\"])\n"
+        "time.sleep(60)\n",
+        encoding="utf-8",
+    )
+    fake_omx.chmod(0o755)
+    contract = _contract(ws, backend="omx")
+    started = time.monotonic()
+    rc, final_text = runners._worker_omx(str(fake_omx), contract, 1, tmp_path / "events.jsonl")
+    assert rc == 124
+    assert final_text == ""
+    assert time.monotonic() - started < 8
 
 
 def test_omx_dry_run_uses_native_exec_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -92,6 +92,7 @@ def test_pi_rpc_dry_run_uses_rpc_plan(tmp_path: Path, monkeypatch: pytest.Monkey
     backend = runners.get_backend("pi_rpc")
     monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
     raw = _contract(ws, backend="pi_rpc", options={"model": "x/y"})
+    raw["authorization"] = {"class": "read_only", "approved": True}
     payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
     assert payload["success"] is True
     assert payload["dry_run"] is True
@@ -114,7 +115,7 @@ def test_pi_defaults_and_profile_credential_reference_are_applied(tmp_path: Path
     )
     monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
     monkeypatch.delenv("PI_TEST_PROVIDER_KEY", raising=False)
-    monkeypatch.delenv("PI_TEST_UNRELATED", raising=False)
+    monkeypatch.setenv("PI_TEST_UNRELATED", "parent-secret-must-not-copy")
 
     hermes_root = tmp_path / "hermes"
     hermes_root.mkdir()
@@ -176,6 +177,7 @@ def test_pi_stderr_burst_cannot_stall_worker(tmp_path: Path, monkeypatch: pytest
     )
     fake_pi.chmod(0o755)
     contract = _contract(tmp_path, backend="pi_rpc")
+    contract["authorization"] = {"class": "read_only", "approved": True}
     started = time.monotonic()
     rc, final_text = runners._worker_pi(str(fake_pi), contract, 5, tmp_path / "events.jsonl", tmp_path / "hermes")
     assert rc == 0
@@ -287,7 +289,22 @@ def test_read_only_pi_cannot_enable_write_tools(tmp_path: Path, monkeypatch: pyt
     payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
     assert payload["success"] is False
     assert payload["code"] == "RUNNER_DISPATCH_ERROR"
-    assert "read-only authorization" in payload["safe_message"]
+    assert "read tool" in payload["safe_message"]
+
+
+def test_pi_writable_contract_rejected_until_filesystem_confinement_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("pi_rpc")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    raw = _contract(ws, backend="pi_rpc")
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_DISPATCH_ERROR"
+    assert "filesystem confinement" in payload["safe_message"]
 
 
 def test_read_only_omx_cannot_request_workspace_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -350,6 +367,7 @@ def test_popen_failure_deletes_request_envelope(tmp_path: Path, monkeypatch: pyt
 
     monkeypatch.setattr(runners.subprocess, "Popen", _boom)
     raw = _contract(ws, backend="pi_rpc")
+    raw["authorization"] = {"class": "read_only", "approved": True}
     payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=False, confirm=True, hermes_root=root))
     assert payload["success"] is False
     assert payload["code"] == "RUNNER_SPAWN_FAILED"
@@ -587,6 +605,7 @@ def _fake_entry_points(monkeypatch, candidates):
 
 
 def test_plugin_class_entry_point_instantiates(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(runners.RUNNER_PLUGIN_ALLOWLIST_ENV, "external_probe")
     _fake_entry_points(monkeypatch, {"hermes_gpt.runners": [("external_probe", _ExternalBackend)]})
     loaded = runners.load_entrypoint_backends()
     assert "external_probe" in loaded
@@ -605,3 +624,96 @@ def test_plugin_cannot_shadow_builtin_backend_name(monkeypatch: pytest.MonkeyPat
         runners.get_backend("__never__")  # registry sanity helper
     # The built-in fleet backend must still be the registered one.
     assert runners.get_backend("fleet").__class__ is runners.FleetBackend
+
+
+
+def test_plugin_entry_point_requires_explicit_allowlist(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(runners.RUNNER_PLUGIN_ALLOWLIST_ENV, raising=False)
+    _fake_entry_points(monkeypatch, {"hermes_gpt.runners": [("external_probe", _ExternalBackend)]})
+    loaded = runners.load_entrypoint_backends()
+    assert loaded == []
+    with pytest.raises(LookupError):
+        runners.get_backend("external_probe")
+
+
+def test_runner_backend_allowlist_blocks_unexpected_backend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(runners.RUNNER_BACKEND_ALLOWLIST_ENV, "fleet")
+    raw = _contract(tmp_path, backend="pi_rpc")
+    payload = runners.dispatch_contract(raw, confirm=False, dry_run=True, timeout=30, hermes_root=tmp_path / "hermes")
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_BACKEND_NOT_ALLOWED"
+
+
+def test_runner_provider_model_allowlists_are_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    pi_dir = tmp_path / "pi-agent"
+    pi_dir.mkdir()
+    (pi_dir / "settings.json").write_text(json.dumps({"defaultProvider": "expensive-provider", "defaultModel": "expensive-model"}), encoding="utf-8")
+    (pi_dir / "models.json").write_text(json.dumps({"providers": {}}), encoding="utf-8")
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(pi_dir))
+    monkeypatch.setenv(runners.RUNNER_PROVIDER_ALLOWLIST_ENV, "safe-provider")
+    raw = _contract(tmp_path, backend="pi_rpc")
+    raw["authorization"] = {"class": "read_only", "approved": True}
+    backend = runners.PiRpcBackend()
+    with pytest.raises(PermissionError, match="not allowed"):
+        backend.build_plan(raw)
+
+
+def test_windows_process_tree_cleanup_uses_taskkill(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+
+    class _Proc:
+        pid = 4242
+        waits = 0
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.waits += 1
+            return 0
+
+        def terminate(self):
+            calls.append(["terminate"])
+
+        def kill(self):
+            calls.append(["kill"])
+
+    def _run(argv, **kwargs):
+        calls.append(argv)
+
+    monkeypatch.setattr(runners.os, "name", "nt")
+    monkeypatch.setattr(runners.subprocess, "run", _run)
+    runners._terminate_process_tree(_Proc(), timeout=1)
+    assert ["taskkill", "/PID", "4242", "/T", "/F"] in calls
+
+
+def test_posix_process_tree_cleanup_uses_process_group(monkeypatch: pytest.MonkeyPatch):
+    calls = []
+
+    class _Proc:
+        pid = 4343
+        waits = 0
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            self.waits += 1
+            return 0
+
+    monkeypatch.setattr(runners.os, "name", "posix")
+    monkeypatch.setattr(runners.os, "killpg", lambda pid, sig: calls.append((pid, sig)))
+    runners._terminate_process_tree(_Proc(), timeout=1)
+    assert calls == [(4343, runners.signal.SIGTERM)]
+
+
+def test_stale_request_envelope_cleanup_removes_old_prompt(tmp_path: Path):
+    task_id = "stale-request-001"
+    _, request_path, _ = runners._job_paths(task_id, tmp_path)
+    runners._atomic_json(request_path, {"contract": {"objective": "stale raw prompt"}})
+    old = time.time() - 7200
+    request_path.touch()
+    import os as _os
+    _os.utime(request_path, (old, old))
+    assert runners._cleanup_stale_request_envelopes(hermes_root=tmp_path, ttl_seconds=3600) == 1
+    assert not request_path.exists()

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import operator_contract as contract_mod
+import operator_policy as op
+import operator_runners as runners
+
+
+def _contract(ws: Path, *, backend: str | None = None, options: dict | None = None) -> dict:
+    value = {
+        "schema": "hermes.work-contract/v1",
+        "task_id": "runner-test-001",
+        "assigned_agent": "coder",
+        "assigned_profile": "default",
+        "objective": "Inspect the workspace and make the requested bounded change.",
+        "allowed_scope": {"workspaces": [str(ws)], "profiles": ["default"]},
+        "forbidden_actions": [],
+        "expected_artifacts": [],
+        "tests": [],
+        "review_requirements": {},
+        "completion_criteria": {
+            "run_state": {"terminal": True, "outcome_ok": ["completed"]},
+            "artifacts_present": False,
+            "tests_pass": False,
+            "review_satisfied": False,
+            "no_forbidden_actions": True,
+        },
+        "inputs": [],
+        "constraints": [],
+        "authorization": {
+            "class": "reversible_write",
+            "approved": True,
+            "approved_by": "owner",
+            "approval_reference": "test",
+        },
+    }
+    if backend:
+        value["execution"] = {"backend": backend, "options": options or {}}
+    return value
+
+
+def _enable_workspace(monkeypatch: pytest.MonkeyPatch, ws: Path) -> None:
+    monkeypatch.setenv(op.OPERATOR_ENABLED_ENV, "1")
+    monkeypatch.setenv(op.OPERATOR_LEVEL_ENV, "workspace")
+    monkeypatch.setenv(op.OPERATOR_APPLY_MODE_ENV, "direct")
+    monkeypatch.setenv(op.OPERATOR_ALLOWED_PATHS_ENV, str(ws))
+
+
+def test_builtin_backends_registered():
+    names = {item["name"] for item in runners.list_backends()}
+    assert {"fleet", "pi_rpc", "omx", "codex"}.issubset(names)
+
+
+def test_legacy_contract_hash_shape_unchanged_without_execution(tmp_path: Path):
+    raw = _contract(tmp_path)
+    canonical, parsed, sha = contract_mod._parse_contract(json.dumps(raw))
+    assert "execution" not in parsed
+    assert "execution" not in json.loads(canonical)
+    assert len(sha) == 64
+    assert runners.selected_backend(parsed) == "fleet"
+
+
+def test_execution_is_canonical_and_surface_redacts_option_values(tmp_path: Path):
+    raw = _contract(tmp_path, backend="pi_rpc", options={"model": "test/model", "provider": "test-provider"})
+    _, parsed, _ = contract_mod._parse_contract(json.dumps(raw))
+    assert parsed["execution"]["backend"] == "pi_rpc"
+    surface = contract_mod._surface_contract(parsed)
+    assert surface["execution"] == {"backend": "pi_rpc", "option_keys": ["model", "provider"]}
+    assert "test/model" not in json.dumps(surface)
+
+
+def test_unknown_backend_returns_structured_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _enable_workspace(monkeypatch, tmp_path)
+    raw = _contract(tmp_path, backend="does_not_exist")
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=tmp_path / "hermes"))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_BACKEND_UNKNOWN"
+    assert payload["backend"] == "does_not_exist"
+
+
+def test_pi_rpc_dry_run_uses_rpc_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("pi_rpc")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    raw = _contract(ws, backend="pi_rpc", options={"model": "x/y"})
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is True
+    assert payload["dry_run"] is True
+    assert payload["backend"] == "pi_rpc"
+    assert payload["plan"]["protocol"] == "jsonl-rpc"
+    assert payload["plan"]["mode"] == "rpc"
+    assert payload["plan"]["model"] == "x/y"
+
+
+def test_omx_dry_run_uses_native_exec_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("omx")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    raw = _contract(ws, backend="omx")
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is True
+    assert payload["backend"] == "omx"
+    assert payload["plan"]["mode"] == "exec"
+    assert payload["plan"]["sandbox"] == "workspace-write"
+
+
+def test_runner_job_is_observed_by_contract_validator(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    op.set_audit_log_override(tmp_path / "audit.jsonl")
+    raw = _contract(ws, backend="pi_rpc")
+    _, parsed, _ = contract_mod._parse_contract(json.dumps(raw))
+    meta_path, _, _ = runners._job_paths(parsed["task_id"], root)
+    runners._atomic_json(meta_path, {
+        "schema_version": runners.SCHEMA_VERSION,
+        "task_id": parsed["task_id"],
+        "backend": "pi_rpc",
+        "state": "completed",
+        "outcome": "completed",
+        "created_at": "2026-08-17T00:00:00+00:00",
+        "started_at": "2026-08-17T00:00:01+00:00",
+        "ended_at": "2026-08-17T00:00:02+00:00",
+        "error": "",
+    })
+    check = contract_mod._check_run_state(parsed, root)
+    assert check["status"] == "PASS"
+    assert "runner:pi_rpc" in check["detail"]
+
+
+def test_execution_options_reject_secret_like_keys(tmp_path: Path):
+    raw = _contract(tmp_path, backend="pi_rpc", options={"api_key": "do-not-inline"})
+    with pytest.raises(ValueError, match="must not carry secrets"):
+        contract_mod._parse_contract(json.dumps(raw))
+
+
+def test_canonical_swarm_accepts_per_stage_execution(tmp_path: Path):
+    import operator_swarm as swarm
+    import operator_swarm_workflows as workflows
+
+    wf = workflows.canonical_workflow(
+        title="Runner workflow",
+        workspace=str(tmp_path),
+        owners={"implementation": "coder", "codex_review": "reviewer"},
+        executions={
+            "implementation": {"backend": "pi_rpc", "options": {}},
+            "codex_review": {"backend": "omx", "options": {"sandbox": "read-only"}},
+        },
+    )
+    impl = next(stage for stage in wf["stages"] if stage["id"] == "implementation")
+    review = next(stage for stage in wf["stages"] if stage["id"] == "codex_review")
+    assert impl["execution"]["backend"] == "pi_rpc"
+    assert review["execution"]["backend"] == "omx"
+    assert review["review_requirements"]["reviewer"] == "reviewer"
+
+    contract = swarm._stage_contract(wf, impl, task_id="runner-stage-001")
+    _, parsed, _ = contract_mod._parse_contract(json.dumps(contract))
+    assert parsed["execution"]["backend"] == "pi_rpc"

--- a/test_operator_runners.py
+++ b/test_operator_runners.py
@@ -169,3 +169,58 @@ def test_canonical_swarm_accepts_per_stage_execution(tmp_path: Path):
     contract = swarm._stage_contract(wf, impl, task_id="runner-stage-001")
     _, parsed, _ = contract_mod._parse_contract(json.dumps(contract))
     assert parsed["execution"]["backend"] == "pi_rpc"
+
+
+def test_read_only_pi_cannot_enable_write_tools(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("pi_rpc")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    raw = _contract(ws, backend="pi_rpc", options={"tools": "read,bash,edit,write"})
+    raw["authorization"] = {"class": "read_only", "approved": True}
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_DISPATCH_ERROR"
+    assert "read-only authorization" in payload["safe_message"]
+
+
+def test_read_only_omx_cannot_request_workspace_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    root = tmp_path / "hermes"
+    root.mkdir()
+    _enable_workspace(monkeypatch, ws)
+    backend = runners.get_backend("omx")
+    monkeypatch.setattr(backend, "executable", lambda: "/bin/true")
+    raw = _contract(ws, backend="omx", options={"sandbox": "workspace-write"})
+    raw["authorization"] = {"class": "read_only", "approved": True}
+    payload = json.loads(contract_mod.hermes_contract_dispatch(json.dumps(raw), dry_run=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_DISPATCH_ERROR"
+    assert "read-only authorization" in payload["safe_message"]
+
+
+def test_runner_cancel_enforces_job_workspace_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    allowed = tmp_path / "allowed"
+    other = tmp_path / "other"
+    root = tmp_path / "hermes"
+    allowed.mkdir()
+    other.mkdir()
+    root.mkdir()
+    _enable_workspace(monkeypatch, allowed)
+    task_id = "runner-cancel-scope"
+    meta_path, _, _ = runners._job_paths(task_id, root)
+    runners._atomic_json(meta_path, {
+        "schema_version": runners.SCHEMA_VERSION,
+        "task_id": task_id,
+        "backend": "pi_rpc",
+        "state": "running",
+        "workspace": str(other),
+        "pid": None,
+    })
+    payload = json.loads(runners.hermes_runner_cancel(task_id, backend="pi_rpc", dry_run=True, hermes_root=root))
+    assert payload["success"] is False
+    assert payload["code"] == "RUNNER_CANCEL_ERROR"

--- a/test_operator_workspace_hermes_cli.py
+++ b/test_operator_workspace_hermes_cli.py
@@ -1,7 +1,7 @@
 import operator_workspace as ow
 
 
-def test_hermes_argv_uses_local_bin_fallback_when_path_missing(monkeypatch, tmp_path):
+def test_hermes_cli_uses_local_bin_fallback_when_path_missing(monkeypatch, tmp_path):
     fake_home = tmp_path
     fake_cli = fake_home / ".local" / "bin" / "hermes"
     fake_cli.parent.mkdir(parents=True)
@@ -11,14 +11,16 @@ def test_hermes_argv_uses_local_bin_fallback_when_path_missing(monkeypatch, tmp_
     monkeypatch.setenv("PATH", "")
     monkeypatch.setattr(ow.shutil, "which", lambda name: None)
 
-    assert ow._hermes_argv("default", ["gateway", "restart"]) == [str(fake_cli), "gateway", "restart"]
+    assert ow._hermes_cli() == str(fake_cli)
+    assert ow._hermes_argv("default", ["gateway", "restart"]) == ["hermes", "gateway", "restart"]
 
 
-def test_hermes_argv_prefers_explicit_env(monkeypatch):
+def test_hermes_cli_prefers_explicit_env(monkeypatch):
     monkeypatch.setenv("HERMES_CLI", "/opt/hermes/bin/hermes")
 
+    assert ow._hermes_cli() == "/opt/hermes/bin/hermes"
     assert ow._hermes_argv("work", ["gateway", "restart"]) == [
-        "/opt/hermes/bin/hermes",
+        "hermes",
         "-p",
         "work",
         "gateway",

--- a/test_operator_workspace_hermes_cli.py
+++ b/test_operator_workspace_hermes_cli.py
@@ -1,0 +1,26 @@
+import operator_workspace as ow
+
+
+def test_hermes_argv_uses_local_bin_fallback_when_path_missing(monkeypatch, tmp_path):
+    fake_home = tmp_path
+    fake_cli = fake_home / ".local" / "bin" / "hermes"
+    fake_cli.parent.mkdir(parents=True)
+    fake_cli.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("HERMES_CLI", raising=False)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(ow.shutil, "which", lambda name: None)
+
+    assert ow._hermes_argv("default", ["gateway", "restart"]) == [str(fake_cli), "gateway", "restart"]
+
+
+def test_hermes_argv_prefers_explicit_env(monkeypatch):
+    monkeypatch.setenv("HERMES_CLI", "/opt/hermes/bin/hermes")
+
+    assert ow._hermes_argv("work", ["gateway", "restart"]) == [
+        "/opt/hermes/bin/hermes",
+        "-p",
+        "work",
+        "gateway",
+        "restart",
+    ]

--- a/test_ui_security.py
+++ b/test_ui_security.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json
 import re
 import time
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -41,6 +40,8 @@ def ui_root(tmp_path: Path, monkeypatch):
     """
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv(oauth_auth.OAUTH_ENABLE_ENV, raising=False)
+    monkeypatch.delenv(oauth_auth.AUTH_TOKEN_ENV, raising=False)
     op.set_audit_log_override(tmp_path / "audit.jsonl")
     op_mission._cache_clear()
     root = tmp_path / ".hermes"
@@ -405,11 +406,10 @@ def test_property_all_api_get_routes_redacted(ui_root, monkeypatch):
     def walk(route_list):
         for route in route_list:
             path = getattr(route, "path", "")
-            if path.startswith("/api/"):
-                if getattr(route, "methods", None) and "GET" in route.methods:
-                    resp = client.get(path)
-                    if resp.status_code == 200:
-                        assert_no_forbidden(resp.text)
+            if path.startswith("/api/") and getattr(route, "methods", None) and "GET" in route.methods:
+                resp = client.get(path)
+                if resp.status_code == 200:
+                    assert_no_forbidden(resp.text)
             mount = getattr(route, "app", None)
             mount_routes = getattr(mount, "routes", None) if mount is not None else None
             if mount_routes:

--- a/test_ui_static_assets.py
+++ b/test_ui_static_assets.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
+import oauth_auth
 import operator_mission as op_mission
 import operator_policy as op
 import server
@@ -25,6 +26,8 @@ def ui_root(tmp_path: Path, monkeypatch):
     """Hermetic Hermes root; Path.home patched so defaults stay inside tmp."""
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
     monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv(oauth_auth.OAUTH_ENABLE_ENV, raising=False)
+    monkeypatch.delenv(oauth_auth.AUTH_TOKEN_ENV, raising=False)
     op.set_audit_log_override(tmp_path / "audit.jsonl")
     op_mission._cache_clear()
     root = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- Add a pluggable execution backend registry for work-contract dispatch.
- Built-in adapters for Pi JSONL RPC, OMX non-interactive execution, legacy Fleet, and compatibility Codex.
- Add optional, backward-compatible `execution.backend` / `execution.options` contract selection; contracts that omit `execution` preserve the legacy Fleet path and canonical hash shape.
- Propagate execution selection through swarm stages.
- Add `hermes_runner_list`, `hermes_runner_status`, and `hermes_runner_cancel` operator tools.
- Preserve upstream official-A2A Fleet behavior while improving Hermes CLI discovery for bridge/gateway command paths.

## Safety / compatibility hardening
- Runner options cannot escalate a read-only contract to Pi write tools or OMX/Codex workspace-write sandboxes.
- Local runner request envelopes containing the objective are transient and are removed on worker load and spawn failure; model response text is not persisted as completion evidence.
- Cancellation is workspace-scoped, dry-run/confirm gated, audited, and cancellation wins terminal-state races.
- Third-party runner entry points are opt-in (`HERMES_GPT_ENABLE_RUNNER_PLUGINS=1`) and cannot shadow built-in backends.
- Legacy implicit-Fleet dispatch exceptions retain `CONTRACT_DISPATCH_ERROR`; explicitly selected runner backends use the runner error contract.
- Codex observations use the normalized Codex job root.

## Verification
- Rebased onto upstream `master` at `c4d93eb`; GitHub reports the PR mergeable.
- All tests outside the three currently broken upstream UI test files pass in a clean Python 3.11 environment.
- The full suite has 19 failures in `test_ui_chat.py`, `test_ui_security.py`, and `test_ui_static_assets.py`; the same 19 failures reproduce on untouched upstream `c4d93eb` in the same environment.
- Runner/contract/swarm/workspace/fleet regression tests pass after the rebase.
- Ruff passes for the new runner module and its new regression-test files; remaining import-order warnings in older touched modules reproduce on upstream.
- `git diff --check upstream/master...HEAD` passes.
- Wheel build succeeds as `hermes_gpt-0.7.0` and includes `operator_runners.py`.

## External check note
The repository's Vercel check currently fails with deployment authorization required. No GitHub code/test CI check is configured on this PR; the Vercel failure is unrelated to the Python changes above.
