### PR TITLE
docs: add OpenAI Secure MCP Tunnel deployment path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,33 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: python -m ruff check operator_runners.py test_operator_runners.py
 
+  windows-docs:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse Secure MCP Tunnel PowerShell examples
+        shell: powershell
+        run: |
+          $paths = @(
+            'examples/start-openai-secure-mcp-tunnel.example.ps1',
+            'examples/status-hermes-gpt.example.ps1'
+          )
+          foreach ($path in $paths) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile(
+              (Resolve-Path $path),
+              [ref]$tokens,
+              [ref]$errors
+            ) | Out-Null
+            if ($errors.Count -gt 0) {
+              $errors | Format-List | Out-String | Write-Error
+              exit 1
+            }
+          }
+
   build:
-    needs: [test, lint]
+    needs: [test, lint, windows-docs]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +94,8 @@ jobs:
       - run: python -m pip install build twine
       - run: python -m build
       - run: python -m twine check dist/*
+      - name: Check package hygiene
+        run: python tools/check_package_hygiene.py dist/*
       - uses: actions/upload-artifact@v4
         with:
           name: distributions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added a first-class OpenAI Secure MCP Tunnel deployment path for private ChatGPT/Codex/OpenAI access while Hermes GPT stays bound to loopback. Added a canonical guide, supervised Windows launcher, tunnel-aware status example, package wiring, and cross-links from the README, MCP compatibility, Cloudflare, and Windows Codex docs.
+- Documented the tunnel security boundary: no public `HERMES_GPT_ALLOWED_HOSTS` entry is required for the private loopback path, static bearer remains optional defense in depth, and built-in OAuth still requires separately reachable browser-facing authorization-server endpoints.
+
 ## 0.7.0 - 2026-08-15
 
 Flight Deck: durable, interactive, verifiable autonomy.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See the [v0.6.0 release notes](docs/release-notes-v0.6.0.md) and [retention poli
 | --- | --- |
 | Understand the repository and current docs | [Documentation map](docs/README.md) |
 | Run Hermes GPT locally | [Local quickstart](#local-quickstart) |
+| Connect ChatGPT/OpenAI privately without publishing Hermes GPT | [OpenAI Secure MCP Tunnel](docs/openai-secure-mcp-tunnel.md) |
 | Authenticate a remote MCP connector | [OAuth and bearer authentication](docs/oauth.md) |
 | Verify the MCP protocol surface | [MCP compatibility manifest](docs/mcp-compatibility.md) |
 | Use Codex as an MCP client | [Codex guide](docs/codex.md) |
@@ -141,14 +142,18 @@ Endpoint:
 http://127.0.0.1:7677/mcp
 ```
 
-Keep the server on loopback. A remote client such as ChatGPT cannot use your machine's `127.0.0.1` directly, so remote access requires a deliberately configured private/authenticated boundary. Do not publish an unauthenticated Operator endpoint to the internet.
+Keep the server on loopback. A remote client such as ChatGPT cannot use your machine's `127.0.0.1` directly.
+
+For supported OpenAI products, prefer [OpenAI Secure MCP Tunnel](docs/openai-secure-mcp-tunnel.md) when it is available for the target account or workspace. It keeps Hermes GPT on loopback and uses an outbound-only `tunnel-client` connection instead of publishing a public Hermes GPT hostname. Secure MCP Tunnel alone does not require a public `HERMES_GPT_ALLOWED_HOSTS` entry.
+
+For other remote clients, use a deliberately configured private/authenticated HTTPS boundary. The existing [Cloudflare Tunnel deployment](docs/cloudflare-tunnel.md) is a public-proxy path with a different Host/authentication boundary. Do not publish an unauthenticated Operator endpoint to the internet.
 
 Hermes GPT can enforce either a strong static bearer token or a built-in,
 single-confidential-client OAuth authorization-code flow with rotating refresh
-tokens. OAuth credentials are memory-backed and fail closed on missing client
-authentication, unsupported scope/resource, expiry, or replay. See
-[OAuth and bearer authentication](docs/oauth.md) before enabling the `remote`
-profile; authentication does not activate Operator mutation or Owner Mode.
+tokens. With Secure MCP Tunnel, static bearer authentication can be used as an
+optional local-hop defense in depth. Built-in OAuth requires deliberate
+browser-facing authorization-server reachability because the authorization
+server itself is not automatically tunneled. See [OpenAI Secure MCP Tunnel](docs/openai-secure-mcp-tunnel.md) and [OAuth and bearer authentication](docs/oauth.md); authentication does not activate Operator mutation or Owner Mode.
 
 ## Operator Mode
 
@@ -290,6 +295,7 @@ Git checkout updates require a clean checkout on the default branch and use fast
 Current operational documentation:
 
 - [Documentation map and source-of-truth rules](docs/README.md)
+- [OpenAI Secure MCP Tunnel](docs/openai-secure-mcp-tunnel.md)
 - [OAuth and bearer authentication](docs/oauth.md)
 - [Operator Mode](docs/operator-mode.md)
 - [Codex integration](docs/codex.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ The latest published releases are GitHub `v0.6.0` and PyPI `0.6.0`. PyPI is an i
 | [`../README.md`](../README.md) | current | project overview, current release, quickstart, safety invariants, entry-point selection |
 | [`oauth.md`](oauth.md) | current | static bearer and confidential-client OAuth configuration, token lifecycle, refresh rotation, and remote authentication limits |
 | [`mcp-compatibility.md`](mcp-compatibility.md) | current | pinned MCP protocol revisions, transport matrix, trusted-client auth metadata |
+| [`openai-secure-mcp-tunnel.md`](openai-secure-mcp-tunnel.md) | current | outbound-only private access from supported OpenAI products to loopback Hermes GPT |
 | [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, Flight Deck v0.7 surfaces |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |
@@ -48,7 +49,7 @@ The main Hermes GPT server and the curated Codex MCP server overlap but are not 
 Important example:
 
 - main server page extraction: `hermes_web_extract`
-- Codex-focused MCP page extraction: `hermes_extract_page`
+- Codex-focused MCP extraction: `hermes_extract_page`
 
 Before generating a tool call, verify the active server/toolset and exact registered name.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ The latest published releases are GitHub `v0.6.0` and PyPI `0.6.0`. PyPI is an i
 | [`oauth.md`](oauth.md) | current | static bearer and confidential-client OAuth configuration, token lifecycle, refresh rotation, and remote authentication limits |
 | [`mcp-compatibility.md`](mcp-compatibility.md) | current | pinned MCP protocol revisions, transport matrix, trusted-client auth metadata |
 | [`openai-secure-mcp-tunnel.md`](openai-secure-mcp-tunnel.md) | current | outbound-only private access from supported OpenAI products to loopback Hermes GPT |
+| [`cloudflare-tunnel.md`](cloudflare-tunnel.md) | current | public Cloudflare HTTPS proxy deployment and Host allowlist behavior |
 | [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, Flight Deck v0.7 surfaces |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |

--- a/docs/cloudflare-tunnel.md
+++ b/docs/cloudflare-tunnel.md
@@ -1,5 +1,7 @@
 # Cloudflare Tunnel deployment
 
+This guide covers the **public HTTPS proxy** deployment path. If the only remote client is a supported OpenAI product and you want Hermes GPT to remain strictly loopback/private with no public inbound hostname, prefer [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md) when it is available for the target account or workspace.
+
 Hermes GPT keeps MCP DNS-rebinding protection enabled. When exposing the HTTP server through a locally managed Cloudflare Tunnel, configure both the proxy and the MCP server so legitimate public requests cannot be rejected with `421 Invalid Host header`.
 
 ## Cloudflare ingress
@@ -29,6 +31,8 @@ HERMES_GPT_ALLOWED_HOSTS=gpt.example.com
 ```
 
 Multiple hosts may be comma-separated. This extends the existing MCP transport-security allowlist; it does not disable DNS-rebinding protection. Loopback hosts remain allowed automatically.
+
+This public-host allowlist is specific to public proxy traffic. Do not add a public Host entry merely because you use OpenAI Secure MCP Tunnel; the Secure MCP Tunnel path targets the loopback MCP URL locally.
 
 For a systemd user service, add the environment variable to the Hermes GPT server unit, then run:
 

--- a/docs/mcp-compatibility.md
+++ b/docs/mcp-compatibility.md
@@ -42,6 +42,8 @@ fails the suite.
 | Streamable HTTP | `/mcp` | Enabled with `--http`; transport security host/origin allowlist |
 | Legacy SSE | `/sse` (plus `/messages/`) | Retained for older clients |
 
+OpenAI Secure MCP Tunnel is an external private bridge, not a fourth Hermes GPT server transport. For the recommended Hermes setup, `tunnel-client` reaches `http://127.0.0.1:4750/mcp` locally over the existing Streamable HTTP transport and carries those MCP requests through an outbound-only OpenAI tunnel. See [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md).
+
 Server transport security (`TransportSecuritySettings`) enforces an explicit
 host/origin allowlist: loopback by default plus `HERMES_GPT_ALLOWED_HOSTS`
 extensions and the OAuth issuer when configured. Public unauthenticated
@@ -58,6 +60,8 @@ Every tool advertises its security scheme via MCP tool metadata
 | Static bearer (`HERMES_GPT_BEARER_TOKEN`) | `http` / `bearer` |
 | Neither | `noauth` (loopback / trusted-proxy only) |
 
+For Secure MCP Tunnel, the baseline local hop can remain loopback/noauth while OpenAI tunnel identity and Hermes Operator policy protect separate layers. Static bearer can be added as local-hop defense in depth. Built-in OAuth requires separate browser-facing authorization-server reachability because the authorization server itself is not automatically tunneled.
+
 ## Version advertisement
 
 The `initialize` handshake advertises the hermes-gpt app version in
@@ -70,7 +74,7 @@ asserts the handshake reports `versioning.VERSION` and that the pinned floor
 Client notes:
 
 - **ChatGPT (chatgpt.com connector)**: uses the OAuth metadata to drive the
-  ChatGPT connector flow; loopback redirect required.
+  ChatGPT connector flow; loopback redirect required. For private developer-mode access without a public Hermes GPT hostname, see [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md).
 - **Codex CLI**: uses stdio or streamable HTTP with the configured scheme;
   curated tool names (`hermes_extract_page` vs `hermes_web_extract`) are
   documented in `docs/codex.md`.

--- a/docs/openai-secure-mcp-tunnel.md
+++ b/docs/openai-secure-mcp-tunnel.md
@@ -1,0 +1,249 @@
+# OpenAI Secure MCP Tunnel
+
+Status: current operational guide.
+
+OpenAI Secure MCP Tunnel is the preferred private connection path for using a loopback-bound Hermes GPT server from supported OpenAI products when Secure MCP Tunnel is available for the target account or workspace.
+
+It keeps Hermes GPT off the public internet. `tunnel-client` runs on the same trusted machine or network as Hermes GPT, opens an outbound HTTPS connection to OpenAI, forwards queued MCP requests to the local Streamable HTTP endpoint, and returns responses through the same tunnel.
+
+Official OpenAI documentation:
+
+- https://developers.openai.com/api/docs/guides/secure-mcp-tunnels
+- https://github.com/openai/tunnel-client
+
+## Architecture
+
+```text
+ChatGPT / Codex / supported OpenAI surface
+                  |
+                  v
+       OpenAI-hosted tunnel endpoint
+                  ^
+                  | outbound HTTPS
+                  |
+            tunnel-client
+                  |
+                  | local Streamable HTTP
+                  v
+         Hermes GPT on loopback
+       http://127.0.0.1:4750/mcp
+```
+
+Hermes GPT remains bound to `127.0.0.1`. You do not need to publish a public hostname, open an inbound firewall port, or add a public hostname to `HERMES_GPT_ALLOWED_HOSTS` for this path.
+
+Secure MCP Tunnel is a transport path. It does not change Hermes GPT Operator or Owner authorization. Tool visibility, mutation gates, allowed paths, direct mode, confirmation, and Owner Mode remain independent.
+
+Secure MCP Tunnel is for private connections and developer-mode testing. It is not a public plugin distribution endpoint.
+
+## Prerequisites
+
+You need:
+
+- Hermes GPT installed or checked out locally;
+- Streamable HTTP available on loopback;
+- a tunnel created in OpenAI Platform tunnel settings;
+- a tunnel runtime API key for `tunnel-client`;
+- Tunnels Read + Use permission to run the client or select the tunnel;
+- Tunnels Read + Manage permission only when creating or editing tunnel metadata;
+- the target ChatGPT workspace or Platform organization associated with the tunnel when that OpenAI surface needs to discover it;
+- ChatGPT developer-mode access when connecting the tunnel as a ChatGPT developer-mode app.
+
+OpenAI tunnel permissions and ChatGPT developer-mode permissions are separate. Do not assume access to one grants access to the other.
+
+## 1. Keep Hermes GPT on loopback
+
+Start Hermes GPT with Streamable HTTP on a loopback address:
+
+```powershell
+python server.py --http --host 127.0.0.1 --port 4750
+```
+
+The local MCP endpoint is:
+
+```text
+http://127.0.0.1:4750/mcp
+```
+
+Do not switch Hermes GPT to a wildcard or public bind merely to use Secure MCP Tunnel.
+
+If Operator Mode is enabled, keep its authority as narrow as the deployment requires. In particular, leave Owner Mode off for an always-on connector unless there is a deliberate break-glass reason to activate it.
+
+## 2. Create the tunnel and associate the right contexts
+
+Create or manage the tunnel in OpenAI Platform tunnel settings. Record the `tunnel_id` without committing it into this repository.
+
+Associate every OpenAI context that should be able to find or use the tunnel:
+
+- the Platform organization that owns or manages it;
+- the ChatGPT workspace that should list it when creating an app;
+- any additional Platform organization that will use it from Codex, the Responses API, or another supported surface.
+
+A tunnel associated only with one Platform organization does not automatically appear in an unrelated ChatGPT workspace.
+
+## 3. Install tunnel-client
+
+Use the download supplied by OpenAI Platform tunnel settings or the latest public release from the official `openai/tunnel-client` repository.
+
+Do not pin documentation or automation to a historical release URL. Start by inspecting the installed binary:
+
+```powershell
+tunnel-client.exe help quickstart
+```
+
+## 4. Configure the runtime API key outside the repository
+
+`tunnel-client` uses a tunnel runtime API key for its long-lived connection to the OpenAI tunnel control plane. This is separate from an OpenAI admin key and separate from Hermes GPT credentials.
+
+For an interactive PowerShell session:
+
+```powershell
+$env:CONTROL_PLANE_API_KEY = '<runtime-api-key>'
+```
+
+For an always-on deployment, load the value from the service or scheduled-task secret environment. Do not place it in Git, a launcher script, a command-line argument, a prompt, or logs.
+
+Use an OpenAI admin key only for administrative tunnel CRUD workflows that explicitly require one. Do not use an admin key as the long-lived tunnel daemon credential.
+
+## 5. Create a named Hermes GPT profile
+
+Discover the built-in samples before creating a profile:
+
+```powershell
+tunnel-client.exe profiles samples list
+```
+
+For the normal loopback/no-auth local hop, create a named HTTP profile with the current no-auth HTTP sample:
+
+```powershell
+tunnel-client.exe init `
+  --sample sample_mcp_remote_no_auth `
+  --profile hermes-gpt `
+  --tunnel-id tunnel_0123456789abcdef0123456789abcdef `
+  --mcp-server-url http://127.0.0.1:4750/mcp
+```
+
+Use your real tunnel ID. The example value is intentionally fake.
+
+Named profiles keep runtime configuration out of repeated command lines and can be inspected or edited with `tunnel-client` profile commands. Keep secret values as environment or file references instead of literal YAML values.
+
+## 6. Validate before starting the long-lived client
+
+With Hermes GPT already listening on `127.0.0.1:4750`, run:
+
+```powershell
+tunnel-client.exe doctor --profile hermes-gpt --explain
+```
+
+Do not continue until `doctor` succeeds. It is the canonical first diagnostic for profile, control-plane, and local MCP reachability problems.
+
+Then start the long-lived tunnel client:
+
+```powershell
+tunnel-client.exe run --profile hermes-gpt
+```
+
+Keep this process running. App discovery and MCP tool calls depend on the client being connected and polling.
+
+`tunnel-client` exposes local health and operator surfaces including `/healthz`, `/readyz`, `/metrics`, and `/ui`. The admin UI is loopback-only by default and should stay that way unless an operator network is intentionally allowed to reach it.
+
+## 7. Connect from ChatGPT
+
+In ChatGPT developer mode, create a developer-mode app and choose **Tunnel** as the connection type. Select the associated tunnel when it appears, or provide the valid tunnel ID where the product surface allows it.
+
+If the tunnel does not appear:
+
+1. verify the tunnel is associated with the target ChatGPT workspace;
+2. verify the app creator has Tunnels Read + Use;
+3. verify ChatGPT developer-mode access is enabled for that workspace/user;
+4. confirm `tunnel-client run --profile hermes-gpt` is still running;
+5. rerun `tunnel-client doctor --profile hermes-gpt --explain`.
+
+## Optional local-hop bearer defense in depth
+
+For many private developer deployments, the OpenAI tunnel identity plus Hermes GPT's own Operator policy is the intended baseline and Hermes GPT can remain no-auth on the loopback hop.
+
+If you want a second credential on the local MCP hop, Hermes GPT already supports a static bearer token. Configure Hermes GPT with a strong secret:
+
+```powershell
+$env:HERMES_GPT_BEARER_TOKEN = '<strong-random-token>'
+```
+
+Then derive an Authorization header value for the tunnel process without writing the token into the profile:
+
+```powershell
+$env:HERMES_GPT_TUNNEL_AUTHORIZATION = "Bearer $env:HERMES_GPT_BEARER_TOKEN"
+```
+
+Edit the named tunnel profile and add an MCP runtime header that references the environment variable:
+
+```yaml
+mcp:
+  extra_headers:
+    Authorization: env:HERMES_GPT_TUNNEL_AUTHORIZATION
+```
+
+`tunnel-client` supports `env:` and `file:` references for secret-bearing MCP header values. Prefer those references over literal secrets in YAML.
+
+The bearer token authenticates the local MCP request. It does not activate Hermes GPT mutation, direct mode, or Owner Mode.
+
+## OAuth caveat
+
+Hermes GPT also ships a built-in confidential-client OAuth authorization-code flow. Do not make that the default Secure MCP Tunnel recipe.
+
+OpenAI Secure MCP Tunnel can carry OAuth discovery metadata for the MCP server, but the browser-facing authorization server itself is not automatically tunneled. Hermes GPT's OAuth issuer and authorization/token endpoints therefore still need to be reachable by the parties participating in the OAuth flow.
+
+Use Hermes GPT OAuth with Secure MCP Tunnel only when you deliberately provide that authorization-server reachability and understand the additional trust boundary. For a tunnel-only private deployment, use the baseline loopback path or the optional static bearer defense in depth described above.
+
+See [OAuth and bearer authentication](oauth.md) for the Hermes GPT OAuth contract.
+
+## Windows supervised launcher
+
+The repository ships [`../examples/start-openai-secure-mcp-tunnel.example.ps1`](../examples/start-openai-secure-mcp-tunnel.example.ps1).
+
+The example:
+
+- starts only the configured Hermes GPT process;
+- verifies that the new process owns the expected loopback listener;
+- runs `tunnel-client doctor --profile ... --explain` before the daemon;
+- starts `tunnel-client run --profile ...`;
+- watches both child processes;
+- stops only the child process it owns if the other side exits;
+- never searches for or kills arbitrary `python.exe` processes;
+- never embeds tunnel or Hermes credentials.
+
+Copy the example to a private local path before customizing machine-specific executable paths.
+
+For Task Scheduler, point the task at your private copy of the supervised launcher. Store credentials in the scheduled task's service environment or another appropriate secret source, not in the checked-in example.
+
+## Cloudflare Tunnel vs OpenAI Secure MCP Tunnel
+
+Use OpenAI Secure MCP Tunnel when a supported OpenAI product needs private access and you want Hermes GPT to remain strictly loopback-bound with no public inbound hostname.
+
+Use the existing [Cloudflare Tunnel guide](cloudflare-tunnel.md) when you intentionally need a public HTTPS proxy hostname in front of Hermes GPT. That path has a different Host-header and authentication boundary and may require `HERMES_GPT_ALLOWED_HOSTS`.
+
+Do not combine the two merely because both are called tunnels. Pick the boundary that matches the client and deployment.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+| --- | --- | --- |
+| `doctor` cannot reach Hermes GPT | Hermes GPT is not listening on the configured local URL | Verify the `127.0.0.1:4750` listener and the profile MCP URL. |
+| Tunnel is not visible in ChatGPT | Missing workspace association or permission | Check the target ChatGPT workspace association and Tunnels Read + Use. |
+| Tool discovery worked, then calls fail | `tunnel-client` stopped or lost readiness | Keep `run` alive, inspect `/readyz` or `/ui`, and rerun `doctor --explain`. |
+| Control-plane requests fail | Runtime key, egress, proxy, CA, or mTLS problem | Verify `CONTROL_PLANE_API_KEY`, outbound HTTPS, and any enterprise proxy/CA/mTLS configuration. |
+| Local MCP returns unauthorized | Optional bearer header is missing/mismatched | Verify Hermes GPT's bearer token and the profile's secret-backed `Authorization` header. |
+| OAuth discovery works but browser auth fails | Authorization server is not reachable | Provide deliberate authorization-server reachability or use the tunnel baseline/static bearer path instead. |
+| Public hostname returns `421` | You are using the public-proxy path, not the private tunnel path | Follow [Cloudflare Tunnel deployment](cloudflare-tunnel.md) and configure the public Host boundary there. |
+
+## Security checklist
+
+- Keep Hermes GPT on `127.0.0.1`.
+- Do not add a public Host allowlist entry for Secure MCP Tunnel alone.
+- Keep the tunnel runtime API key out of Git, argv, prompts, and logs.
+- Keep tunnel profile secrets as `env:` or `file:` references.
+- Keep Operator Mode authority narrow.
+- Keep Owner Mode off for normal always-on access.
+- Remember that tunnel transport authentication and Hermes authorization are separate layers.
+- Keep `tunnel-client` health/admin surfaces loopback-only unless there is a deliberate operator-network requirement.
+- Use `doctor --explain` before treating the connection as healthy.
+- Use the latest OpenAI tunnel documentation as the source of truth when the external client changes.

--- a/docs/windows-chatgpt-codex.md
+++ b/docs/windows-chatgpt-codex.md
@@ -4,7 +4,7 @@ This guide covers one specific deployment path:
 
 ```text
 ChatGPT
-  -> authenticated/private boundary
+  -> OpenAI Secure MCP Tunnel or another authenticated/private boundary
   -> normal Hermes GPT Operator MCP on 127.0.0.1:4750/mcp
   -> Hermes Operator policy
   -> standalone Codex CLI
@@ -20,7 +20,8 @@ For documentation authority rules, see [docs/README.md](README.md).
 This is an advanced local setup.
 
 - Keep Hermes GPT bound to loopback.
-- Put a private or authenticated boundary in front of it for ChatGPT access.
+- For supported OpenAI products, prefer [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md) when available so Hermes GPT does not need a public inbound hostname.
+- If Secure MCP Tunnel is unavailable for the target client, put another deliberately configured private/authenticated boundary in front of Hermes GPT.
 - Restrict allowed workspaces narrowly.
 - Start with `sandbox=read-only`.
 - Do not enable Owner Mode for an always-on connector.
@@ -33,7 +34,7 @@ This is an advanced local setup.
 - Python 3.10+
 - Hermes GPT installed or checked out locally
 - Hermes Agent available to the Hermes GPT runtime
-- A private/authenticated HTTPS boundary that forwards to `http://127.0.0.1:4750`
+- OpenAI Secure MCP Tunnel or another private/authenticated boundary that can carry the loopback MCP endpoint to ChatGPT
 - The standalone Codex CLI
 - A dedicated Git repository to use as the approved work directory
 
@@ -127,7 +128,15 @@ Do not initialize Git in a broad personal directory merely to satisfy the CLI.
 
 ChatGPT cannot directly reach the computer's loopback address.
 
-Forward the local MCP endpoint through your private/authenticated boundary, then configure the connector with the resulting HTTPS endpoint:
+### Preferred OpenAI path: Secure MCP Tunnel
+
+When Secure MCP Tunnel is available for the target account/workspace, follow [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md). Keep Hermes GPT on `127.0.0.1:4750`, point `tunnel-client` at `http://127.0.0.1:4750/mcp`, validate the named profile with `doctor --explain`, and select the associated tunnel in ChatGPT developer mode.
+
+This path does not require a public Hermes GPT hostname or a public `HERMES_GPT_ALLOWED_HOSTS` entry. The repository also ships [`../examples/start-openai-secure-mcp-tunnel.example.ps1`](../examples/start-openai-secure-mcp-tunnel.example.ps1) for supervised Windows startup.
+
+### Other private/authenticated boundaries
+
+If Secure MCP Tunnel is not the chosen transport, forward the local MCP endpoint through a deliberately configured private/authenticated HTTPS boundary, then configure the connector with that boundary's HTTPS endpoint:
 
 ```text
 Protocol: Streaming HTTP
@@ -205,7 +214,9 @@ In Swarm Orchestration, Codex can provide a review verdict but is never an imple
 
 ## 8. Start automatically without visible consoles
 
-Task Scheduler can start both Hermes GPT and the private tunnel/boundary at logon.
+For Secure MCP Tunnel, prefer a single supervised launcher so Hermes GPT and `tunnel-client` fail together instead of leaving a stale half-running bridge. Copy and customize [`../examples/start-openai-secure-mcp-tunnel.example.ps1`](../examples/start-openai-secure-mcp-tunnel.example.ps1) in a private local path.
+
+For another boundary, Task Scheduler can start Hermes GPT and the boundary at logon using separate supervised tasks.
 
 Launching `powershell.exe` directly can flash a console even with `-WindowStyle Hidden`. A small Windows Script Host wrapper can hide the launcher while letting Task Scheduler monitor the process.
 
@@ -231,7 +242,7 @@ Arguments: "C:\path\to\run-powershell-hidden.vbs" "C:\path\to\launcher.ps1"
 Start in: the launcher's working directory
 ```
 
-Use separate tasks for Hermes GPT and the tunnel/boundary. Configure restart-on-failure as appropriate and keep logs free of credentials.
+Configure restart-on-failure as appropriate and keep logs free of credentials.
 
 ## 9. Restart safely
 
@@ -256,12 +267,14 @@ After stopping the verified stale process, restart Hermes GPT and confirm exactl
 | Job returns runner disabled | `HERMES_GPT_ENABLE_CODEX_RUNNER=1` is missing in the running process | Set it in the actual launch environment and restart Hermes GPT. |
 | Job previews but does not execute | Server/call is still dry-run | For an approved real job, use direct mode plus `confirm=true` and `dry_run=false`. |
 | New server cannot bind port 4750 | Stale server still owns the listener | Identify and verify the listener PID before ending that specific process. |
+| Secure tunnel is not visible in ChatGPT | Missing workspace association, Tunnels Use, or developer-mode access | Follow the association/permission checks in [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md). |
 | ChatGPT shows old tools/gates | Stale server or cached connector schema | Verify the listener, restart Hermes GPT, then reconnect/recreate the connector. |
 
 ## Security checklist
 
 - Keep Hermes GPT on `127.0.0.1`.
-- Require a private/authenticated remote boundary.
+- Prefer Secure MCP Tunnel for supported OpenAI private access when available.
+- Require a deliberate private/authenticated boundary for every other remote path.
 - Restrict `HERMES_GPT_OPERATOR_ALLOWED_PATHS` to specific workspaces.
 - Leave `HERMES_GPT_ALLOW_CODEX_WRITE` unset until a write job is deliberately required.
 - Keep Owner Mode off for always-on access.
@@ -272,6 +285,7 @@ After stopping the verified stale process, restart Hermes GPT and confirm exactl
 ## Related docs
 
 - [Documentation map](README.md)
+- [OpenAI Secure MCP Tunnel](openai-secure-mcp-tunnel.md)
 - [Hermes GPT and Codex](codex.md)
 - [Operator Mode](operator-mode.md)
 - [Updating](updating.md)

--- a/examples/start-openai-secure-mcp-tunnel.example.ps1
+++ b/examples/start-openai-secure-mcp-tunnel.example.ps1
@@ -77,10 +77,21 @@ function Stop-OwnedProcess {
 
     try {
         $Process.Refresh()
-        if (-not $Process.HasExited) {
-            Stop-Process -Id $Process.Id -ErrorAction Stop
-            Wait-Process -Id $Process.Id -Timeout 10 -ErrorAction SilentlyContinue
+        if ($Process.HasExited) {
+            return
         }
+
+        Stop-Process -Id $Process.Id -ErrorAction Stop
+        $deadline = (Get-Date).AddSeconds(10)
+        while ((Get-Date) -lt $deadline) {
+            Start-Sleep -Milliseconds 100
+            $Process.Refresh()
+            if ($Process.HasExited) {
+                return
+            }
+        }
+
+        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
     }
     catch {
         Write-Warning "Could not stop owned PID $($Process.Id): $($_.Exception.Message)"

--- a/examples/start-openai-secure-mcp-tunnel.example.ps1
+++ b/examples/start-openai-secure-mcp-tunnel.example.ps1
@@ -1,0 +1,160 @@
+<#
+.SYNOPSIS
+    Example supervised launcher for Hermes GPT plus OpenAI Secure MCP Tunnel.
+.DESCRIPTION
+    Copy this file to a private local path before customizing machine-specific
+    executable paths. Keep all credentials out of this file.
+
+    Required environment:
+      CONTROL_PLANE_API_KEY  Tunnel runtime API key used by tunnel-client.
+
+    Optional Hermes GPT environment such as Operator policy or a static bearer
+    token should also be supplied by the service/scheduled-task environment,
+    not committed into this example.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$WorkingDir = 'C:\Users\<YOU>\hermes-gpt'
+$PythonExe = 'C:\Users\<YOU>\AppData\Local\Programs\Python\Python311\python.exe'
+$TunnelClientExe = 'C:\Tools\tunnel-client\tunnel-client.exe'
+$TunnelProfile = 'hermes-gpt'
+$ListenHost = '127.0.0.1'
+$ListenPort = 4750
+$ReadyTimeoutSeconds = 30
+$PollSeconds = 1
+
+function Assert-FileExists {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "$Label was not found: $Path"
+    }
+}
+
+function Wait-ForOwnedListener {
+    param(
+        [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory = $true)][string]$HostAddress,
+        [Parameter(Mandatory = $true)][int]$Port,
+        [Parameter(Mandatory = $true)][int]$TimeoutSeconds
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $Process.Refresh()
+        if ($Process.HasExited) {
+            throw "Hermes GPT exited before the MCP listener became ready (exit $($Process.ExitCode))."
+        }
+
+        $listener = Get-NetTCPConnection `
+            -LocalAddress $HostAddress `
+            -LocalPort $Port `
+            -State Listen `
+            -ErrorAction SilentlyContinue |
+            Where-Object { $_.OwningProcess -eq $Process.Id } |
+            Select-Object -First 1
+
+        if ($null -ne $listener) {
+            return
+        }
+
+        Start-Sleep -Milliseconds 250
+    }
+
+    throw "Timed out waiting for Hermes GPT PID $($Process.Id) to own $HostAddress`:$Port."
+}
+
+function Stop-OwnedProcess {
+    param([System.Diagnostics.Process]$Process)
+
+    if ($null -eq $Process) {
+        return
+    }
+
+    try {
+        $Process.Refresh()
+        if (-not $Process.HasExited) {
+            Stop-Process -Id $Process.Id -ErrorAction Stop
+            Wait-Process -Id $Process.Id -Timeout 10 -ErrorAction SilentlyContinue
+        }
+    }
+    catch {
+        Write-Warning "Could not stop owned PID $($Process.Id): $($_.Exception.Message)"
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($env:CONTROL_PLANE_API_KEY)) {
+    throw 'CONTROL_PLANE_API_KEY is required. Load the tunnel runtime key from a private service environment before starting this launcher.'
+}
+
+Assert-FileExists -Path $PythonExe -Label 'Python executable'
+Assert-FileExists -Path $TunnelClientExe -Label 'tunnel-client executable'
+Assert-FileExists -Path (Join-Path $WorkingDir 'server.py') -Label 'Hermes GPT server.py'
+
+$hermesProcess = $null
+$tunnelProcess = $null
+$exitCode = 1
+
+try {
+    $hermesProcess = Start-Process `
+        -FilePath $PythonExe `
+        -ArgumentList @('server.py', '--http', '--host', $ListenHost, '--port', [string]$ListenPort) `
+        -WorkingDirectory $WorkingDir `
+        -PassThru `
+        -NoNewWindow
+
+    Wait-ForOwnedListener `
+        -Process $hermesProcess `
+        -HostAddress $ListenHost `
+        -Port $ListenPort `
+        -TimeoutSeconds $ReadyTimeoutSeconds
+
+    Write-Host "Hermes GPT ready on http://$ListenHost`:$ListenPort/mcp (PID $($hermesProcess.Id))."
+
+    $doctorProcess = Start-Process `
+        -FilePath $TunnelClientExe `
+        -ArgumentList @('doctor', '--profile', $TunnelProfile, '--explain') `
+        -PassThru `
+        -Wait `
+        -NoNewWindow
+
+    if ($doctorProcess.ExitCode -ne 0) {
+        throw "tunnel-client doctor failed with exit code $($doctorProcess.ExitCode)."
+    }
+
+    $tunnelProcess = Start-Process `
+        -FilePath $TunnelClientExe `
+        -ArgumentList @('run', '--profile', $TunnelProfile) `
+        -PassThru `
+        -NoNewWindow
+
+    Write-Host "OpenAI Secure MCP Tunnel running with profile '$TunnelProfile' (PID $($tunnelProcess.Id))."
+
+    while ($true) {
+        Start-Sleep -Seconds $PollSeconds
+        $hermesProcess.Refresh()
+        $tunnelProcess.Refresh()
+
+        if ($hermesProcess.HasExited) {
+            $exitCode = $hermesProcess.ExitCode
+            Write-Warning "Hermes GPT exited with code $exitCode. Stopping the owned tunnel-client process."
+            break
+        }
+
+        if ($tunnelProcess.HasExited) {
+            $exitCode = $tunnelProcess.ExitCode
+            Write-Warning "tunnel-client exited with code $exitCode. Stopping the owned Hermes GPT process."
+            break
+        }
+    }
+}
+finally {
+    Stop-OwnedProcess -Process $tunnelProcess
+    Stop-OwnedProcess -Process $hermesProcess
+}
+
+exit $exitCode

--- a/examples/status-hermes-gpt.example.ps1
+++ b/examples/status-hermes-gpt.example.ps1
@@ -1,17 +1,52 @@
 <#
 .SYNOPSIS
-    Example status script for hermes-gpt and its MCP tunnel.
+    Example status script for a loopback Hermes GPT deployment.
 .DESCRIPTION
-    Reports the local listener, the tunnel URL, and the MCP tool surface.
-    Safe to adapt for your own machine.
+    Reports the local MCP listener and can optionally run tunnel-client doctor
+    for a named OpenAI Secure MCP Tunnel profile.
+
+    This script intentionally does not assume a public tunnel URL. Secure MCP
+    Tunnel keeps Hermes GPT on loopback and uses a separately managed tunnel ID.
 #>
 
-$ListenHost = '127.0.0.1'
-$ListenPort = 4750
-$TunnelUrl = 'https://your-domain.example/mcp'
-$McpUrl = "http://127.0.0.1:$ListenPort/mcp"
+param(
+    [int]$ListenPort = 4750,
+    [string]$TunnelProfile = 'hermes-gpt',
+    [string]$TunnelClientExe = 'tunnel-client.exe',
+    [switch]$RunDoctor
+)
 
-Write-Host "Local MCP URL : $McpUrl"
-Write-Host "Tunnel URL    : $TunnelUrl"
-Write-Host "Port listening: $ListenHost`:$ListenPort"
-Write-Host 'Probe the MCP endpoint with an MCP client, not a browser GET.'
+$ListenHost = '127.0.0.1'
+$McpUrl = "http://$ListenHost`:$ListenPort/mcp"
+
+Write-Host "Local MCP URL  : $McpUrl"
+
+$listener = Get-NetTCPConnection `
+    -LocalAddress $ListenHost `
+    -LocalPort $ListenPort `
+    -State Listen `
+    -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+
+if ($null -eq $listener) {
+    Write-Host "Listener       : not listening on $ListenHost`:$ListenPort"
+}
+else {
+    Write-Host "Listener       : listening (PID $($listener.OwningProcess))"
+}
+
+Write-Host "Tunnel profile : $TunnelProfile"
+Write-Host 'Tunnel URL     : not public; select the associated tunnel in the supported OpenAI product'
+Write-Host 'MCP probe      : use an MCP client or tunnel-client doctor, not a browser GET'
+
+if (-not $RunDoctor) {
+    Write-Host "Doctor         : skipped (rerun with -RunDoctor to execute tunnel-client doctor --explain)"
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($env:CONTROL_PLANE_API_KEY)) {
+    throw 'CONTROL_PLANE_API_KEY is required to run tunnel-client doctor.'
+}
+
+& $TunnelClientExe doctor --profile $TunnelProfile --explain
+exit $LASTEXITCODE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ py-modules = [
   "docs/operator-mode.md",
   "docs/mcp-compatibility.md",
   "docs/openai-secure-mcp-tunnel.md",
+  "docs/cloudflare-tunnel.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",
   "docs/release-notes-v0.4.0.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ py-modules = [
   "docs/oauth.md",
   "docs/operator-mode.md",
   "docs/mcp-compatibility.md",
+  "docs/openai-secure-mcp-tunnel.md",
   "docs/release-notes-v0.2.0.md",
   "docs/release-notes-v0.3.0.md",
   "docs/release-notes-v0.4.0.md",
@@ -100,6 +101,7 @@ py-modules = [
 ]
 "share/hermes-gpt/examples" = [
   "examples/start-hermes-gpt.example.ps1",
+  "examples/start-openai-secure-mcp-tunnel.example.ps1",
   "examples/status-hermes-gpt.example.ps1",
   "examples/install-task.example.ps1",
   "examples/fleet-authority.example.json",

--- a/test_secure_mcp_tunnel_docs.py
+++ b/test_secure_mcp_tunnel_docs.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parent
+GUIDE = ROOT / "docs" / "openai-secure-mcp-tunnel.md"
+LAUNCHER = ROOT / "examples" / "start-openai-secure-mcp-tunnel.example.ps1"
+STATUS = ROOT / "examples" / "status-hermes-gpt.example.ps1"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_secure_tunnel_guide_preserves_loopback_and_security_boundaries() -> None:
+    text = _read(GUIDE)
+
+    assert "https://developers.openai.com/api/docs/guides/secure-mcp-tunnels" in text
+    assert "http://127.0.0.1:4750/mcp" in text
+    assert "tunnel-client.exe doctor --profile hermes-gpt --explain" in text
+    assert "tunnel-client.exe run --profile hermes-gpt" in text
+    assert "HERMES_GPT_ALLOWED_HOSTS" in text
+    assert "authorization server itself is not automatically tunneled" in text
+    assert "Operator or Owner authorization" in text
+    assert "public plugin distribution endpoint" in text
+
+
+def test_secure_tunnel_launcher_supervises_only_owned_children() -> None:
+    text = _read(LAUNCHER)
+
+    assert "$ListenHost = '127.0.0.1'" in text
+    assert "CONTROL_PLANE_API_KEY" in text
+    assert "doctor', '--profile', $TunnelProfile, '--explain'" in text
+    assert "run', '--profile', $TunnelProfile" in text
+    assert "Where-Object { $_.OwningProcess -eq $Process.Id }" in text
+    assert "Stop-Process -Id $Process.Id" in text
+    assert "Get-Process python" not in text
+    assert "taskkill" not in text.lower()
+    assert "sk-" not in text
+
+
+def test_status_example_does_not_assume_a_public_tunnel_hostname() -> None:
+    text = _read(STATUS)
+
+    assert "https://your-domain.example/mcp" not in text
+    assert "not public" in text
+    assert "--profile $TunnelProfile --explain" in text
+
+
+def test_secure_tunnel_docs_are_wired_into_current_entry_points() -> None:
+    root_readme = _read(ROOT / "README.md")
+    docs_readme = _read(ROOT / "docs" / "README.md")
+    windows_guide = _read(ROOT / "docs" / "windows-chatgpt-codex.md")
+    cloudflare_guide = _read(ROOT / "docs" / "cloudflare-tunnel.md")
+    compatibility = _read(ROOT / "docs" / "mcp-compatibility.md")
+
+    for text in (root_readme, docs_readme, windows_guide, cloudflare_guide, compatibility):
+        assert "openai-secure-mcp-tunnel.md" in text
+
+
+def test_secure_tunnel_docs_and_launcher_ship_in_package_data() -> None:
+    data = tomllib.loads(_read(ROOT / "pyproject.toml"))
+    package_data = data["tool"]["setuptools"]["data-files"]
+
+    assert "docs/openai-secure-mcp-tunnel.md" in package_data["share/hermes-gpt/docs"]
+    assert (
+        "examples/start-openai-secure-mcp-tunnel.example.ps1"
+        in package_data["share/hermes-gpt/examples"]
+    )

--- a/test_secure_mcp_tunnel_docs.py
+++ b/test_secure_mcp_tunnel_docs.py
@@ -67,9 +67,9 @@ def test_secure_tunnel_docs_are_wired_into_current_entry_points() -> None:
 def test_secure_tunnel_docs_and_launcher_ship_in_package_data() -> None:
     data = tomllib.loads(_read(ROOT / "pyproject.toml"))
     package_data = data["tool"]["setuptools"]["data-files"]
+    shipped_docs = package_data["share/hermes-gpt/docs"]
+    shipped_examples = package_data["share/hermes-gpt/examples"]
 
-    assert "docs/openai-secure-mcp-tunnel.md" in package_data["share/hermes-gpt/docs"]
-    assert (
-        "examples/start-openai-secure-mcp-tunnel.example.ps1"
-        in package_data["share/hermes-gpt/examples"]
-    )
+    assert "docs/openai-secure-mcp-tunnel.md" in shipped_docs
+    assert "docs/cloudflare-tunnel.md" in shipped_docs
+    assert "examples/start-openai-secure-mcp-tunnel.example.ps1" in shipped_examples


### PR DESCRIPTION
Closes #16.

## What this implements

- Adds a canonical `docs/openai-secure-mcp-tunnel.md` guide for outbound-only private access from supported OpenAI products while Hermes GPT stays on loopback.
- Makes Secure MCP Tunnel the preferred OpenAI/ChatGPT private path in the root README when available, while keeping Cloudflare as the distinct public-proxy option.
- Documents tunnel permissions/workspace associations, runtime-key handling, named-profile setup, `doctor --explain`, long-lived `run`, health/readiness surfaces, ChatGPT developer-mode connection, optional static-bearer defense in depth, and the OAuth authorization-server reachability caveat.
- Adds a supervised Windows launcher that verifies the newly started Hermes GPT PID owns the loopback listener, validates tunnel-client before starting it, watches both owned children, and shuts down only the owned peer when one side exits.
- Updates the existing status example so it no longer assumes every tunnel has a public URL.
- Updates Windows ChatGPT -> Codex, MCP compatibility, Cloudflare, docs map, and CHANGELOG cross-links.
- Ships the new guide/launcher and the previously linked Cloudflare guide through `pyproject.toml` package data.
- Adds regression tests for documentation/package wiring and security-boundary claims.
- Adds a `windows-latest` PowerShell parse gate for the two tunnel examples and runs package hygiene after build/twine validation.

## Security posture

- No Hermes GPT server/protocol behavior changes.
- No OpenAI SDK dependency or vendored tunnel binary.
- Hermes GPT remains on `127.0.0.1` for the Secure MCP Tunnel path.
- No public `HERMES_GPT_ALLOWED_HOSTS` entry is required for the private tunnel path.
- No credentials are embedded in examples; tunnel-client secret-bearing values are documented as environment/file references.
- Operator/Owner gates remain independent from tunnel transport authentication.
- Built-in OAuth is not presented as the default tunnel recipe because browser-facing authorization-server endpoints are not automatically tunneled.

## Validation

CI on this PR is the source of truth for the exact head. The workflow runs:
- full pytest on Python 3.10, 3.11, 3.12;
- runner regressions, compile checks, whitespace, and lint;
- Windows PowerShell AST parsing of the new/updated tunnel examples;
- wheel/sdist build and `twine check`;
- package-hygiene scanning of the built artifacts.
