### PR TITLE
docs(v0.8): Hermes Fabric G1 research package

### DIFF
--- a/docs/releases/v0.8-fabric-research-package.md
+++ b/docs/releases/v0.8-fabric-research-package.md
@@ -1,254 +1,1017 @@
-# Hermes GPT v0.8 — Fabric Research Package
+# Hermes GPT v0.8 Fabric Research Package
 
-- Status: IN PROGRESS — G1 research only
+- Status: COMPLETE, G1 research gate package
 - Program: #27
 - Gate: #28
-- Frozen baseline: `4bb85d1eb7abf0974077b63c131013613793bb72`
-- Started: 2026-08-19
-- Rule: implementation and current tests outrank historical design artifacts.
+- Hermes GPT frozen baseline: `4bb85d1eb7abf0974077b63c131013613793bb72`
+- Upstream Hermes Agent pin inspected: `ad889540f20ba49157976487a29becb762ce7933`
+- Research date: 2026-08-19
+- Rule: implementation and tests at the pinned revisions outrank historical design artifacts.
+- Scope rule: this document makes architecture recommendations only. It does not authorize production implementation, remote mutation, release, or trust-boundary widening.
 
-## 1. Research question
+## 1. Executive conclusion
 
-What is the smallest safe architecture that lets an existing Hermes GPT Work Contract / Swarm stage execute on another authenticated Hermes machine, return bounded observed evidence and artifacts, and remain subject to the coordinator's existing authority and fail-closed completion model?
+Hermes GPT can safely become a distributed execution fabric without replacing Hermes A2A and without weakening the current Work Contract model.
 
-The second question is placement: once remote execution exists, what facts can Hermes GPT safely use to choose a local/remote node and execution backend automatically without turning capability advertising into authorization?
+The smallest safe shape is:
 
-## 2. Product thesis under test
+1. keep **Hermes A2A v1.0 as the cross-machine transport and task-lifecycle substrate**;
+2. keep the **Hermes GPT coordinator as the authority, policy owner, placement authority, validator, and final approval gate**;
+3. require a **compatible deterministic Fabric acceptor/executor on a remote node** for a stage to count as a verified Fabric execution target;
+4. introduce a **durable coordinator dispatch/attempt journal** because transport task state alone is not durable enough for restart-safe distributed mutation;
+5. make the remote node return a **bounded evidence envelope plus bounded artifact manifests**, never a completion verdict that the coordinator blindly accepts;
+6. add a **two-phase placement router** where hard identity, authority, sandbox, freshness, runner, tool, model, hardware, and compatibility exclusions happen before any load, locality, cost, or latency scoring;
+7. preserve existing fail-closed behavior: ambiguity, missing evidence, lost task state, stale capabilities, and authority drift become blocked/inconclusive states, never success.
 
-Fabric should scale **where work runs**, not **what is trusted**.
+The architectural thesis survives the research pass:
 
-The coordinator remains responsible for policy, authorization, Work Contract identity, completion validation, review requirements, audit/event lineage, and final human approval. A remote peer is an execution host. Its self-report is transport data, never sufficient proof that a contract is satisfied.
+> Fabric scales where work runs, not what is trusted.
 
-## 3. Verified baseline facts
+A remote worker may execute. A remote peer may report bounded observations. Only the coordinator decides whether the declared Work Contract is satisfied.
 
-### 3.1 v0.7 ships cross-machine seams, not remote Swarm execution
+There is one especially important consequence of the implementation review. Current Hermes A2A inbound tasks are ultimately routed into the peer's live agent session. That is correct for agent-to-agent delegation, but a verified Fabric stage cannot rely on an LLM interpreting a serialized authority envelope as the security boundary. A Fabric-capable remote node therefore needs a deterministic Hermes GPT acceptance surface that validates dispatch identity, authority, workspace scope, runner posture, and version compatibility before the worker is allowed to execute.
 
-`seams.py` explicitly states that v0.7 ships interfaces only. The current `WorkOrder` contains:
+Arbitrary A2A peers can remain useful for ordinary delegation. They should not automatically qualify as verified Fabric nodes.
 
-- `task_id`
-- `objective_sha256`
-- `assigned_agent`
-- `authority_class`
-- `allowed_workspaces`
-- `forbidden_actions`
-- `contract_sha256`
-- `parent_ref`
-- bounded metadata
+## 2. Research question and answered scope
 
-`DispatchAdapter` exposes `dispatch(work_order) -> ref`, `poll(ref)`, and `collect(ref)`. `EvidenceProvider` exposes `collect(contract_sha256, task_id, host)`.
+Primary question:
 
-Immediate gap: the seam itself does not yet define cancellation, idempotency, capability snapshots, remote artifact envelopes, transport ambiguity states, restart reconciliation, or proof lineage sufficient for a real multi-host implementation.
+> What is the smallest safe architecture that lets an existing Hermes GPT Work Contract or Swarm stage execute on another authenticated Hermes machine, return bounded observed evidence and artifacts, and remain subject to the coordinator's existing authority and fail-closed completion model?
 
-### 3.2 Hermes GPT already uses official Hermes A2A v1.0 for fleet routing
+Secondary question:
 
-`operator_fleet.py` no longer depends on the legacy bridge for normal dispatch. It reads known peers from Hermes `config.yaml` `a2a_agents`, discovers Agent Cards, resolves configured bearer authentication, and sends tasks using A2A JSON-RPC.
+> What facts can Hermes GPT safely use to choose a local or remote node and execution backend automatically without turning capability advertising into authorization?
 
-This is strategically important: v0.8 should not invent a second remote transport when the official Hermes platform already provides the cross-machine execution channel.
+The research answer is now concrete enough for architecture design. G2 does not need another discovery pass before it can make the required ADRs.
 
-### 3.3 Dispatch-timeout ambiguity already has a useful recovery primitive
+## 3. Verified current-state architecture
 
-Current fleet dispatch creates a unique A2A `contextId`. If `SendMessage` times out, Hermes GPT performs a bounded `ListTasks` lookup for that context and, when exactly one valid task is found, raises `FleetDispatchTimeout` carrying the peer-assigned task ID.
+### 3.1 Work Contracts already own completion truth
 
-This means the code already recognizes the critical distributed-systems fact that a timeout does not mean submission failed. Fabric should generalize this identity/recovery pattern and must never blindly resubmit write-capable work after an ambiguous timeout.
+`operator_contract.py` is the most important existing boundary for Fabric.
 
-### 3.4 Current upstream Hermes A2A already exposes the lifecycle primitives Fabric needs
+Current behavior at the frozen baseline:
 
-Current upstream Hermes documentation describes A2A v1.0 support for:
+- schema: `hermes.work-contract/v1`;
+- contract definition is canonicalized and hashed;
+- dispatch reuses fleet/runner authority and mutation gates;
+- validation produces deterministic `SATISFIED`, `NOT_SATISFIED`, `INCONCLUSIVE`, or `INVALID_CONTRACT` verdicts;
+- validation reads observed sources such as kanban task runs, async delegations, on-disk artifacts, audit data, and allowlisted test execution;
+- a worker-supplied result or completion bundle is not accepted as proof;
+- missing observed run state is `INCONCLUSIVE`, never `SATISFIED`;
+- artifact paths must remain inside allowed workspaces and outside denied secret paths;
+- tests are allowlisted, bounded, `shell=False`, and workspace-gated;
+- contracts are declarative documents, not a separate persistent contract database.
 
-- Agent Card discovery;
-- Hermes-to-Hermes cross-machine calls;
-- `SendMessage` / `SendStreamingMessage`;
+**Fabric implication:** do not invent a second completion engine. Remote execution must feed admissible observed evidence into this model or an explicitly versioned extension of it.
+
+### 3.2 Swarm already has the correct ownership and final-approval model
+
+`operator_swarm.py` already composes Work Contracts into a bounded DAG.
+
+Verified behavior:
+
+- every stage is an M1 Work Contract;
+- stage completion is checked by the Work Contract validator against observed state;
+- false `done` claims return work for rework rather than advancing;
+- each stage has exactly one owner;
+- concurrency is bounded;
+- handoffs carry bounded artifact references and contract verdicts;
+- mutations are dry-run-first and audited;
+- workflow operational state is durable under `swarm-workflows/`;
+- Codex remains a review path, not an implementation owner;
+- final approval is a real Owner/direct gate and never auto-advances.
+
+**Fabric implication:** placement changes where a stage executes. It must not change stage ownership, contract semantics, review independence, or final human approval.
+
+### 3.3 v0.7 cross-machine seams are intentionally incomplete
+
+`seams.py` and `test_seams.py` explicitly describe v0.7 as interfaces only. The test uses a two-process-one-host loopback fake and makes no remote implementation claim.
+
+Current `WorkOrder` carries:
+
+- `task_id`;
+- `objective_sha256`;
+- `assigned_agent`;
+- `authority_class`;
+- `allowed_workspaces`;
+- `forbidden_actions`;
+- `contract_sha256`;
+- `parent_ref`;
+- bounded metadata.
+
+Current `DispatchAdapter` has only:
+
+- `dispatch(work_order) -> ref`;
+- `poll(ref)`;
+- `collect(ref)`.
+
+Current `EvidenceProvider` has only:
+
+- `collect(contract_sha256, task_id, host)`.
+
+Missing from the seam itself:
+
+- cancel;
+- idempotent submission identity;
+- explicit attempt lineage;
+- capability snapshots;
+- remote artifact contract;
+- ambiguous-submission states;
+- peer/coordinator restart reconciliation;
+- compatibility/version negotiation;
+- evidence trust classification.
+
+**Fabric implication:** G2 should prefer a versioned Fabric v2 interface or additive wrapper rather than overloading the tiny v0.7 protocol until its semantics become implicit.
+
+### 3.4 Runner architecture is already closer to what Fabric needs
+
+`operator_runners.py` separates execution ownership from contract policy.
+
+Built-in runners are:
+
+- `fleet`;
+- `pi_rpc`;
+- `omx`;
+- `codex`.
+
+The current `RunnerBackend` protocol already exposes:
+
+- `availability()`;
+- `dispatch()`;
+- `observed_runs()`;
+- `cancel()`.
+
+Other verified behavior:
+
+- `execution.backend` is explicit today, defaulting to `fleet` when omitted;
+- backend, provider, and model allowlists can fail closed;
+- execution options are bounded and secret-looking option keys are rejected;
+- external runner plugins are opt-in and allowlisted and may not shadow built-ins;
+- `list_backends()` already returns bounded availability data;
+- local runner jobs persist bounded state under `runner-jobs/`;
+- local duplicate task IDs are rejected instead of silently creating a second job;
+- local cancellation is idempotent for terminal jobs and terminates the process tree for active jobs;
+- Pi write tools require write-capable Work Contract authorization plus `workspace-write` sandbox;
+- read-only authorization cannot be upgraded into Pi write tools;
+- Pi execution fails closed without a usable OS confinement posture.
+
+The fleet backend is the notable exception:
+
+- `FleetBackend.observed_runs()` returns no runner observations because fleet observation remains sourced elsewhere;
+- `FleetBackend.cancel()` currently reports unsupported.
+
+**Fabric implication:** the runner protocol is a useful model for the new distributed seam. `execution.backend=auto` should become a placement request, not an authorization override.
+
+### 3.5 Fleet already provides a strong A2A transport and authority base
+
+`operator_fleet.py` already uses Hermes' official A2A v1.0 JSON-RPC path for normal fleet work.
+
+Verified behavior:
+
+- peers are selected by registered name, not arbitrary caller-supplied URL on the Hermes GPT fleet surface;
+- configured peer URLs and bearer credentials come from local Hermes configuration;
+- Agent Cards are probed;
+- remote responses are bounded;
+- a local fleet authority manifest defines expected peer identity, allowed profiles, maximum authorization, and public-action posture;
+- live peer identity is checked before work-order dispatch;
+- the canonical work order is SHA-256 hashed;
+- high-impact authorization requires explicit approval metadata;
+- dispatch is workspace-level, dry-run-first, and confirm-gated;
+- remote task IDs are validated and recorded;
+- authority-drift inspection compares registry and manifest identity state.
+
+A current limitation is important for G2: the fleet authority manifest only accepts the built-in peer set represented in the current code. Fabric needs a safe onboarding model for additional managed nodes without making the caller the authority for peer URL, credential, identity, or authorization ceiling.
+
+### 3.6 Dispatch-timeout recovery is already correctly conservative
+
+Current fleet dispatch recognizes that a timeout after `SendMessage` does not prove submission failed.
+
+The implementation:
+
+1. creates a unique A2A `contextId`;
+2. on timeout, performs a bounded `ListTasks(contextId=...)` lookup;
+3. accepts recovery only when exactly one valid remote task ID is found;
+4. raises `FleetDispatchTimeout(task_id)` carrying that recovered ID;
+5. reports `submission_may_have_succeeded: true` and tells the caller to inspect that task before retrying.
+
+**Fabric implication:** preserve this principle and make it durable. A write-capable stage must never be blindly resubmitted just because an RPC timed out.
+
+### 3.7 Current fleet result bundles are transport data, not proof
+
+`hermes_fleet_task` exposes bounded remote task state and artifact count. `hermes_fleet_result` parses remote task/status/artifact text into a bounded completion payload containing fields such as:
+
+- status;
+- node;
+- profile;
+- summary;
+- changed paths;
+- artifacts;
+- verification;
+- residual risk;
+- recommended next action;
+- authorization metadata.
+
+This is useful handoff data. It does not become Work Contract proof merely because it is structured. `operator_contract.py` explicitly rejects worker-supplied completion bundles as proof.
+
+**Fabric implication:** do not rename the existing completion bundle to `evidence` and call the problem solved. Fabric needs an evidence admission contract with provenance and coordinator-side validation.
+
+### 3.8 Current Mission Control and Event History are local read models
+
+`operator_mission.py` is read-only by construction and aggregates bounded/redacted local Hermes state such as profiles, fleet, Codex, cron, delegations, failures, approvals, vault status, usage, and audit.
+
+`operator_events.py` normalizes existing durable local stores at query time:
+
+- operator audit JSONL;
+- swarm workflow JSON;
+- Codex jobs;
+- cron execution DB;
+- kanban task events.
+
+Both surfaces deliberately exclude raw messages, memory bodies, transcripts, request dumps, credentials, and profile-secret bodies.
+
+**Fabric implication:** do not pretend the existing local Mission Control readers can directly verify another host's filesystem or process state. Distributed evidence must be admitted through a new bounded provider and then represented in local coordinator state/events.
+
+### 3.9 Restart recovery already establishes the right fail-closed precedent
+
+`operator_recovery.py` marks local Swarm stages found `running` after a restart as `blocked` with `interrupted_by_restart`. It never auto-advances them. Re-advance is explicit through the existing gated Swarm path.
+
+The same recovery operation checks the durable token envelope and returns a bounded reconciliation summary.
+
+**Fabric implication:** distributed reconciliation must preserve this posture. A restarted coordinator or peer does not earn permission to infer success.
+
+### 3.10 Existing binary export provides the artifact-safety precedent
+
+`operator_export.py` is intentionally stricter than ordinary reads.
+
+Verified behavior:
+
+- workspace Operator level required;
+- non-empty allowed-path configuration required;
+- resolved file must remain under an allowed root and outside denied secret paths;
+- optional extension allowlisting;
+- size checked before and during read;
+- default cap 4 MiB, hard cap 16 MiB;
+- SHA-256 computed over bytes;
+- absolute local path is not returned to the client;
+- binary bytes travel only through the MCP resource payload while metadata stays bounded and safe.
+
+**Fabric implication:** remote artifact admission should reuse these ideas: logical names, size, media type, digest, bounded transfer, path/secret policy, and no leakage of remote absolute paths.
+
+### 3.11 OAuth/token persistence must remain separate from Fabric envelopes
+
+`token_store.py` stores OAuth credentials in an AES-256-GCM encrypted envelope and exposes presence/expiry status without token material. Token material is not placed in audit records or MCP responses.
+
+**Fabric implication:** Work Contracts, capability manifests, dispatch envelopes, evidence envelopes, artifacts, and Flight Deck payloads must never transport peer bearer tokens, OAuth tokens, provider API keys, or other credentials. Fabric consumes server-controlled local configuration. It does not become a credential distribution system.
+
+### 3.12 Flight Deck already has the correct browser authority boundary
+
+`docs/flight-deck-coverage.md` and `ui_ops.py` establish that:
+
+- browser views consume existing bounded/redacted operator read models;
+- Event History is poll-driven because there is no generic backend push event stream;
+- every mutation goes through the existing `POST /api/ops/action` adapter with strict tool/argument allowlisting;
+- dry-run and explicit confirmation remain separate gestures;
+- Operator level, direct mode, secret-path policy, and audit remain authoritative;
+- no independent contract registry or generic approve/reject writer exists.
+
+**Fabric implication:** v0.8 can add nodes, placement explanations, remote states, and evidence summaries to existing read models without inventing a second browser authority path. Generic live push streaming can remain deferred unless G2 proves it is required for correctness.
+
+## 4. Current upstream Hermes A2A findings
+
+The upstream implementation was inspected at:
+
+`NousResearch/hermes-agent@ad889540f20ba49157976487a29becb762ce7933`
+
+### 4.1 Transport and identity primitives are sufficient
+
+The current A2A platform exposes:
+
+- v1.0 Agent Cards;
+- `SendMessage`;
+- `SendStreamingMessage`;
 - `GetTask`;
 - `ListTasks`;
 - `CancelTask`;
 - `SubscribeToTask`;
+- push-notification configuration;
+- SSE status/artifact updates;
+- per-peer bearer identity;
+- trusted-peer filtering;
+- per-identity rate limiting;
+- inbound prompt-injection framing;
+- outbound redaction;
+- audit logging.
+
+The inbound adapter derives identity from the presented credential or local socket context, never from a claimed identity in the request body.
+
+The server caps request bodies at 1 MiB.
+
+**Conclusion:** Fabric does not need a second network protocol.
+
+### 4.2 A2A tasks and parts can carry structured transport data
+
+Current protocol helpers support:
+
+- text parts;
+- file parts by URL or raw base64;
+- structured data parts;
+- task status transitions;
+- artifact updates;
+- task lookup/list/subscribe.
+
+This gives Fabric enough wire vocabulary to carry a versioned envelope and bounded artifact metadata.
+
+However, the current Hermes inbound adapter ultimately injects the task into a live Hermes gateway session. A generic A2A task therefore remains agent input unless a deterministic application boundary is added.
+
+**Conclusion:** use A2A as transport, but require a Fabric-specific acceptance path on managed Fabric nodes.
+
+### 4.3 Current upstream A2A task state is not restart-durable
+
+The current `TaskStore` is in-memory. It keeps active and terminal task records in an ordered in-process store and trims older terminal tasks. Completion is idempotent inside that process, watchers are supported, and orphaned tasks can be failed by watchdog logic.
+
+A separate A2A conversation log is persisted to disk, but that is message history, not a durable task execution journal.
+
+**Conclusion:** `GetTask` cannot be the sole source of truth across a remote peer restart. Fabric requires durable attempt state outside the ephemeral A2A task store.
+
+### 4.4 Upstream capability routing is discovery, not safe scheduling
+
+Current `a2a_orchestrate` matches configured peers by declared capability and supports `all`, `first`, and `best` modes.
+
+The current `best` mode selects the longest successful reply as a coarse detail heuristic.
+
+That is perfectly reasonable for conversational fan-out. It is not an execution scheduler and must not become Fabric placement policy.
+
+**Conclusion:** reuse capability names where useful, but build a separate deterministic eligibility-and-placement layer in Hermes GPT.
+
+### 4.5 Upstream tests verify the primitives Fabric wants to reuse
+
+Current upstream A2A tests cover, among other things:
+
+- peer-token identity;
+- trusted-peer filtering;
+- prompt-injection filtering;
+- slash-command framing;
+- outbound secret/contact redaction;
+- A2A audit records;
+- v1.0 Agent Card/task/part shapes;
 - SSE streaming;
-- signed push notifications;
-- configured peer capabilities;
-- per-peer authenticated identities;
-- A2A audit logging;
-- prompt-injection framing of inbound peer text as untrusted input.
+- task subscription;
+- push HMAC signing;
+- anti-loop protection;
+- rate limiting;
+- TaskStore idempotent completion/watchers/orphan handling;
+- dynamic Agent Cards from live toolsets;
+- capability-based fan-out;
+- push callback SSRF protection.
 
-The first architecture bias is therefore: use A2A task identity/lifecycle as transport, keep Hermes GPT Work Contracts as the authority/verification layer.
+These are transport/security primitives to inherit, not a replacement for Hermes GPT's Work Contract authorization and validation.
 
-### 3.5 Upstream capability advertising is useful but is not authorization
+## 5. Evidence and source matrix
 
-Hermes peers can advertise capabilities/skills and upstream exposes `a2a_orchestrate(capability, ..., mode=all|first|best)`. Configured `a2a_agents` entries can also carry capability hints.
+| Area | Pinned implementation evidence | Test evidence | Fabric-relevant conclusion |
+|---|---|---|---|
+| Work Contract truth | `operator_contract.py` | `test_operator_contract.py` | Observed-state validation remains authoritative; worker result is not proof. |
+| Swarm lifecycle | `operator_swarm.py` | `test_operator_swarm.py` | Placement must not alter owners, validation, rework, caps, review, or human approval. |
+| Cross-machine seams | `seams.py` | `test_seams.py` | v0.7 is explicitly interface-only; real remote semantics are still missing. |
+| Fleet A2A transport | `operator_fleet.py` | `test_operator_fleet.py` | Official A2A, registered peers, authority manifest, live identity check, bounded responses, timeout task recovery already exist. |
+| Runner abstraction | `operator_runners.py` | `test_operator_runners.py` | Availability/dispatch/observed_runs/cancel already form a stronger lifecycle interface than `seams.py`. |
+| Runner confinement | `runner_confinement.py` | `test_runner_confinement.py`, `test_runner_confinement_policy.py` | Writable execution must remain a separate authorization plus OS-confinement decision. |
+| Restart recovery | `operator_recovery.py` | `test_operator_recovery.py` | Existing recovery blocks interrupted stages and never auto-advances. |
+| Mission Control | `operator_mission.py` | existing Mission Control tests in the v0.6/v0.7 suite | Current observed state is coordinator-local and bounded/redacted. |
+| Event history | `operator_events.py` | `test_operator_events.py` | Existing read model can represent Fabric events if coordinator writes bounded lineage locally. |
+| Binary export | `operator_export.py` | `test_operator_export.py`, `test_server_export.py`, `test_export_docs.py` | Hash/size/path/secret controls are the precedent for remote artifact admission. |
+| OAuth tokens | `token_store.py`, `operator_oauth.py` | `test_token_store.py` | Credentials stay in local encrypted/configured stores and never enter Fabric payloads. |
+| Flight Deck | `ui_ops.py`, `docs/flight-deck-coverage.md` | `test_ui_ops.py`, web Vitest/build | Distributed visibility can extend current read models without a new authority path. |
+| Upstream A2A server | `plugins/platforms/a2a/adapter.py` at upstream pin | `tests/plugins/test_a2a_plugin.py` | A2A has authenticated identity, task lifecycle, cancel, subscribe, push, rate limit, and bounded inbound body. |
+| Upstream A2A protocol | `plugins/platforms/a2a/protocol.py` at upstream pin | `tests/plugins/test_a2a_plugin.py`, `tests/plugins/test_a2a_phase23.py` | Data/file parts and task/artifact updates exist, but task store is in-memory. |
+| Upstream A2A routing | `plugins/platforms/a2a/tools.py` at upstream pin | `tests/plugins/test_a2a_phase23.py` | Capability fan-out is conversational routing, not authority-aware placement. |
 
-Fabric can potentially reuse those concepts for discovery, but a reported `coding`, `browser`, `gpu`, or similar capability must not imply:
+## 6. Gap analysis
 
-- write authorization;
-- workspace access;
-- runner confinement availability;
-- model/provider availability at dispatch time;
-- acceptable load/health;
-- evidence quality;
-- permission to perform a public/high-impact action.
+### G1. No deterministic remote Fabric acceptance boundary
 
-Any automatic router therefore needs a strict split between **capability** and **authority**. Hard authority/safety constraints must filter candidates before any capability/load/cost scoring occurs.
+Today Hermes GPT can send a canonical work-order payload over A2A, but generic inbound Hermes A2A work enters the live agent session.
 
-## 4. Candidate architecture shape to investigate, not yet approved
+For verified Fabric execution, the remote host needs a deterministic Hermes GPT surface that:
+
+- recognizes a versioned Fabric envelope;
+- authenticates/binds the coordinator peer identity;
+- validates dispatch and attempt IDs;
+- verifies contract hash and envelope bounds;
+- enforces local authorization ceiling;
+- enforces workspace and runner posture;
+- rejects unsupported versions/capabilities;
+- writes durable attempt state before write-capable execution;
+- invokes the selected runner without trusting the remote LLM to reinterpret authority.
+
+### G2. v0.7 seam lifecycle is too small
+
+The current seam cannot express cancel, recovery, idempotency, capability snapshots, artifact manifests, or restart state.
+
+### G3. No durable distributed dispatch journal
+
+The coordinator has durable Swarm and local runner state, but the remote fleet path does not yet expose a durable Fabric dispatch object binding:
+
+- local stage/task;
+- contract hash;
+- dispatch ID;
+- attempt ID;
+- peer;
+- remote A2A task ID;
+- authority snapshot;
+- capability snapshot;
+- timestamps/state;
+- recovery/cancel lineage.
+
+Without this, coordinator restart recovery cannot safely distinguish `never submitted` from `submitted but reply lost` from `running remotely` from `peer forgot task after restart`.
+
+### G4. Upstream A2A task state is ephemeral across peer restart
+
+The pinned upstream `TaskStore` is in-memory. Fabric therefore needs peer-side durable execution state, or a durable mapping from Fabric dispatch ID to an already-durable runner/job record.
+
+### G5. Existing authority manifest is not yet a general Fabric node registry
+
+The current fleet manifest has strong local authority semantics but is intentionally constrained to the existing built-in peer model. Fabric needs safe extensibility without allowing a request caller to inject a peer URL, token, identity, allowed profile, or authorization ceiling.
+
+### G6. Capability advertisement lacks enough trust semantics
+
+Agent Card skills and configured peer capabilities do not prove:
+
+- current runner availability;
+- model/provider availability;
+- OS confinement posture;
+- writable authority;
+- workspace compatibility;
+- browser/vision/GPU state;
+- health freshness;
+- load/concurrency;
+- version/protocol compatibility;
+- artifact transfer limits.
+
+### G7. Fleet cancellation is not implemented as a runner lifecycle operation
+
+A2A itself supports `CancelTask`, but the current `FleetBackend.cancel()` is unsupported. Fabric needs cancellation to be explicit, idempotent, peer-bound, attempt-bound, and race-safe.
+
+### G8. Remote completion bundles lack proof provenance
+
+Current fleet result parsing is useful but can only be treated as transport/handoff data. Fabric needs an evidence schema that separates facts observed by the coordinator from facts attested by the managed peer and from coordinator-verified artifact/test results.
+
+### G9. Remote artifacts need a safe admission layer
+
+A2A can carry file/data parts, but Fabric needs stricter semantics around logical path, size, digest, content type, secret exclusions, symlink/special-file handling, transfer limits, and producer lineage.
+
+### G10. Existing Event History has no Fabric-specific distributed lineage
+
+The read model is sufficient, but new coordinator-side durable records/events are needed so one can reconstruct dispatch, placement, recovery, cancellation, evidence admission, validation, and approval without reading remote raw logs.
+
+### G11. Flight Deck has no node/placement/evidence model yet
+
+The UI boundary is correct. The missing work is a bounded read model for Fabric nodes and remote stage state, not a new browser control plane.
+
+## 7. Candidate Fabric node capability manifest
+
+This is a research candidate for G2, not an approved schema.
+
+Recommended shape: `hermes.fabric-capability/v1`.
+
+### 7.1 Identity and compatibility
+
+- `peer_name`
+- `card_identity`
+- `card_digest`
+- `fabric_protocol_versions`
+- `hermes_gpt_version`
+- `hermes_agent_version` where safely observable
+- `os`
+- `architecture`
+- `observed_at`
+- `expires_at` or freshness TTL
+
+### 7.2 Execution capabilities
+
+- supported runner backends;
+- per-runner availability;
+- per-runner safe posture such as read-only and workspace-write;
+- supported tool classes;
+- browser capability;
+- vision capability;
+- GPU capability and bounded hardware metadata such as vendor/class/VRAM when available;
+- provider/model identifiers that are available for selection, never provider credentials;
+- artifact transfer support and maximum safe transfer size.
+
+### 7.3 Health and capacity
+
+- latest successful health probe;
+- health state;
+- active Fabric attempts;
+- configured concurrency/capacity;
+- bounded queue/load indicator;
+- optional rolling latency hint;
+- optional grounded cost hint if the runner can report one safely.
+
+### 7.4 Authority and workspace posture
+
+Authority must be composed from **local coordinator policy**, not trusted from a peer advertisement.
+
+The effective eligibility record should contain derived fields such as:
+
+- local maximum authorization for this peer;
+- locally allowed profiles;
+- whether public/high-impact actions are allowed;
+- requested contract authorization;
+- compatible workspace/sandbox posture;
+- whether the required confinement posture was positively reported/verified.
+
+### 7.5 Trust classification per field
+
+G2 should mark each capability field as one of:
+
+1. **coordinator-observed**: peer identity, successful probe time, protocol response, local policy ceiling;
+2. **peer-attested**: runner/tool/hardware/model/load facts reported by the managed Fabric executor;
+3. **coordinator-derived**: effective eligibility after local policy is applied;
+4. **soft hint**: cost/latency/load data that may influence ranking but never create eligibility.
+
+Unknown or stale values must not be treated as affirmative capability.
+
+## 8. Candidate remote dispatch envelope
+
+Research candidate: `hermes.fabric-dispatch/v1`.
+
+Minimum fields:
+
+- `dispatch_id`: coordinator-generated stable idempotency identity;
+- `attempt_id`: unique execution attempt identity;
+- `workflow_id` where applicable;
+- `stage_id` where applicable;
+- local `task_id`;
+- `contract_sha256`;
+- canonical objective hash rather than duplicated raw objective where possible;
+- target peer identity;
+- selected runner/backend;
+- execution requirements;
+- authorization class;
+- allowed workspace/scope representation;
+- forbidden-action classes;
+- expected artifact descriptors;
+- expected test/check identifiers;
+- capability snapshot digest;
+- coordinator timestamp/expiry;
+- parent attempt/reference when retrying;
+- protocol/version metadata.
+
+Rules:
+
+- no credentials;
+- no arbitrary peer URL;
+- no peer token;
+- no authority ceiling supplied by the caller;
+- bounded fields only;
+- canonical encoding and digest;
+- remote acceptor must reject duplicate `dispatch_id`/`attempt_id` combinations that conflict with existing durable state.
+
+## 9. Candidate remote evidence contract
+
+Research candidate: `hermes.fabric-evidence/v1`.
+
+The peer may provide observations. It may not provide the authoritative final Work Contract verdict.
+
+### 9.1 Required identity/lineage
+
+- `dispatch_id`;
+- `attempt_id`;
+- local `task_id`;
+- remote A2A task ID if transport created one;
+- `contract_sha256`;
+- `peer_name`;
+- verified card identity or digest reference;
+- Fabric acceptor/runtime version;
+- runner/backend;
+- capability snapshot digest;
+- authority/scope digest actually applied;
+- start/end timestamps;
+- terminal transport/execution state.
+
+### 9.2 Bounded observed checks
+
+Candidate records:
+
+- runner process/job terminal state;
+- allowlisted test identifier;
+- command/argv digest or canonical check identifier;
+- return code;
+- bounded redacted output summary/hash where necessary;
+- confinement/sandbox posture actually used;
+- cancellation state;
+- recovery lineage.
+
+### 9.3 Artifact manifest
+
+Each returned artifact entry should carry at minimum:
+
+- logical name/basename;
+- media type when known;
+- size bytes;
+- SHA-256;
+- producer peer;
+- dispatch/attempt identity;
+- transfer reference or embedded bounded resource;
+- optional expected-artifact mapping.
+
+Remote absolute paths should not be exposed to the client-facing evidence model.
+
+### 9.4 Evidence admissibility classes
+
+The coordinator should distinguish:
+
+- **transport observation**: A2A task/status observed by the coordinator;
+- **managed-peer observation**: bounded observation produced by the deterministic Fabric acceptor/executor;
+- **coordinator-verified artifact**: bytes retrieved through an approved transfer path whose size/hash/policy the coordinator verified;
+- **coordinator-local observation**: local tests, audit records, review evidence, or other existing Work Contract sources;
+- **worker statement**: free-text summary/self-report, useful for handoff but not proof.
+
+A peer-generated `SATISFIED` string is never admissible as the final contract verdict.
+
+## 10. Capability-aware routing model
+
+Fabric routing should have two distinct phases.
+
+### 10.1 Phase A: hard eligibility filtering
+
+A candidate is excluded before scoring when any required fact is false, stale, unknown where positive proof is required, or policy-incompatible.
+
+Hard exclusions should include applicable checks for:
+
+- peer is not in the server-controlled Fabric registry;
+- live identity does not match expected identity;
+- authority manifest/registry drift;
+- requested authorization exceeds peer ceiling;
+- required profile is not allowed;
+- Fabric protocol/version incompatible;
+- capability snapshot stale;
+- peer unhealthy/unreachable;
+- required runner unavailable/not allowlisted;
+- required read/write confinement posture unavailable;
+- required tool class unavailable;
+- required model/provider unavailable/not allowlisted;
+- required browser/vision/GPU capability unavailable;
+- workspace/sandbox posture incompatible;
+- required artifact transfer capability absent;
+- peer already at a hard concurrency limit;
+- contract requests a forbidden/public/high-impact action the peer may not perform.
+
+Router scoring must never override a hard exclusion.
+
+### 10.2 Phase B: deterministic selection among eligible targets
+
+Only eligible candidates can be ranked using bounded grounded signals such as:
+
+- locality/artifact affinity;
+- active load and available slots;
+- observed recent latency;
+- hardware fit;
+- model/tool fit;
+- optional known execution cost;
+- deterministic stable tie-break by peer/backend identity.
+
+Every automatic placement should return a bounded explanation containing:
+
+- requirements evaluated;
+- excluded candidates with safe reason codes;
+- eligible candidates;
+- selected candidate;
+- score/tie-break inputs that actually affected selection;
+- capability snapshot age/digest.
+
+### 10.3 Explicit routing remains supported
+
+Manual peer/backend selection should remain possible, but explicit selection still passes the same hard eligibility and authorization checks.
+
+`manual` means `choose this eligible target`, not `bypass policy`.
+
+### 10.4 Do not reuse upstream `best` semantics as Fabric scheduling
+
+At the pinned upstream revision, `a2a_orchestrate(..., mode="best")` chooses the longest successful reply as a coarse conversational heuristic.
+
+Fabric must not use that heuristic for placement. The safe reuse point is capability vocabulary and A2A transport, not its conversational ranking rule.
+
+## 11. Failure and recovery taxonomy
+
+Names remain provisional until G2 schema/ADR work.
+
+| Condition | Safe Fabric state | Required recovery rule |
+|---|---|---|
+| No eligible target | `NO_ELIGIBLE_TARGET` | Fail closed with candidate exclusion reasons. No dispatch. |
+| Capability data stale | `CAPABILITY_STALE` | Re-probe. Stale unknown facts do not qualify a node. |
+| Peer identity mismatch | `PEER_IDENTITY_MISMATCH` | Block target; require authority/registry repair. |
+| Requested authority exceeds peer ceiling | `AUTHORITY_EXCEEDS_PEER_LIMIT` | Reject before dispatch. |
+| Submit times out, exactly one remote task recovered | `REMOTE_SUBMISSION_AMBIGUOUS_RECOVERED` | Bind recovered remote task to existing dispatch/attempt. Do not resubmit. |
+| Submit times out, no unique task recovered | `REMOTE_SUBMISSION_AMBIGUOUS` | Block/inspect. Write-capable work must not be blindly retried. |
+| Duplicate dispatch ID arrives at peer | `DUPLICATE_DISPATCH` | Return existing durable attempt state if identical; reject conflicting envelope. |
+| Coordinator restarts while remote attempt active | `RECONCILING` | Reload durable dispatch journal, poll managed peer, never auto-mark success. |
+| Peer restarts and A2A task state disappears | `REMOTE_TASK_LOST` | Query peer Fabric journal/durable runner mapping. If not recoverable, block. |
+| Peer unavailable | `REMOTE_PEER_UNAVAILABLE` | Preserve attempt identity; do not infer failure or success from transport absence. |
+| Cancel requested while completion races | `REMOTE_CANCEL_AMBIGUOUS` | Reconcile terminal evidence. Never launch a second write-capable attempt while the first may still mutate. |
+| Remote evidence missing | `REMOTE_EVIDENCE_MISSING` | `INCONCLUSIVE`/blocked, never satisfied. |
+| Evidence malformed or lineage mismatch | `REMOTE_EVIDENCE_INVALID` | Reject evidence and block validation. |
+| Artifact path/shape unsafe | `REMOTE_ARTIFACT_UNSAFE` | Reject transfer/admission. |
+| Artifact digest mismatch | `REMOTE_ARTIFACT_HASH_MISMATCH` | Reject artifact and contract satisfaction. |
+| Artifact over bound | `REMOTE_ARTIFACT_TOO_LARGE` | Reject or require an explicitly approved alternate transfer path. |
+| Remote effective authority differs from dispatch | `REMOTE_AUTHORITY_DRIFT` | Block attempt and treat as security finding. |
+| Push/SSE stream breaks | `REMOTE_LIVENESS_DEGRADED` | Fall back to bounded polling. Streaming is an optimization, not correctness source. |
+| Remote worker says done but checks are absent | normal validator `INCONCLUSIVE`/`NOT_SATISFIED` | Preserve existing Work Contract rules. |
+
+## 12. Retry and write-concurrency rule
+
+G2 must make this explicit because it is the most dangerous distributed race.
+
+Recommended default:
+
+- a read-only attempt may be retryable once the coordinator has bounded evidence that the old attempt is unreachable/terminal according to policy;
+- a write-capable attempt must not be superseded while the prior attempt may still mutate the same scope;
+- retries get a new `attempt_id` under the same stable `dispatch_id`/stage lineage;
+- coordinator and peer journals must make the active attempt visible;
+- cancellation is idempotent and attempt-specific;
+- a human override for an irreconcilable write attempt must be explicit, audited, and must not be represented as proof that the old attempt stopped.
+
+G2 may choose lease/epoch semantics, but it must solve the same invariant: two uncertain write attempts must not silently become concurrent.
+
+## 13. Security questions that G2/G3 must resolve
+
+### S1. What is a Fabric-capable peer?
+
+Recommended direction: a peer must advertise a compatible Fabric capability and expose a deterministic Hermes GPT acceptor/executor. Generic A2A compatibility alone is insufficient for verified stages.
+
+### S2. How are additional nodes enrolled?
+
+The current authority manifest is deliberately narrow. G2 needs a versioned registry/manifest strategy that allows managed nodes without allowing callers to create authority by supplying URLs, credentials, identities, profiles, or ceilings.
+
+### S3. How is the remote Fabric acceptor bound to A2A?
+
+Options to decide:
+
+- dedicated A2A served agent/profile for Fabric;
+- versioned structured DataPart routed to a deterministic local Hermes GPT tool/service;
+- another binding that still uses A2A transport but does not trust natural-language envelope interpretation.
+
+### S4. What remote evidence is trustworthy enough to admit?
+
+G2 must distinguish transport-observed, managed-peer-observed, coordinator-verified, and worker-stated data. A compromised remote OS cannot be made trustworthy by schema design alone, so the threat model must explicitly state what a managed peer compromise means.
+
+### S5. Does evidence require additional signing?
+
+A2A bearer identity authenticates the transport request path, and push notifications can be HMAC-signed. G2 must decide whether Fabric evidence/artifact manifests need their own keyed signature or whether authenticated transport plus coordinator/peer durable journals is sufficient for the target threat model.
+
+No signing key may be embedded in Work Contracts or capability manifests.
+
+### S6. How is capability freshness bound to identity?
+
+A capability snapshot must not survive identity drift or be replayed indefinitely. G2 needs snapshot TTL/digest rules and re-probe conditions.
+
+### S7. How are remote artifact references retrieved safely?
+
+Direct arbitrary URLs introduce SSRF and credential risks. G2 should prefer an approved Fabric/A2A transfer mechanism with strict size/type/hash/path controls rather than allowing evidence to point the coordinator at arbitrary fetch URLs.
+
+### S8. How are workspaces named across machines?
+
+A coordinator absolute path cannot be assumed to exist on another OS/host. G2 needs logical workspace identity or peer-local allowed workspace mapping. The caller must not get to choose an arbitrary remote absolute path.
+
+### S9. What is the compatibility policy?
+
+A Fabric node must fail closed on unsupported envelope/protocol versions, unknown required features, or incompatible evidence schemas.
+
+### S10. What is the fully compromised-peer threat model?
+
+Research conclusion: Fabric can defend strongly against malformed input, stale state, authority drift, accidental duplication, buggy agents, and transport/restart ambiguity. It cannot cryptographically prove the truth of a filesystem observation made by a fully compromised remote OS that also holds the peer's runtime credentials.
+
+G3 must state this boundary explicitly rather than implying impossible remote attestation guarantees.
+
+### S11. Can router soft signals create hidden policy?
+
+No. Cost, latency, load, and answer quality are ranking hints only after hard eligibility. Router explanations must expose the material selection reasons.
+
+### S12. Can Flight Deck introduce remote actions directly?
+
+No. Any stop/retry/reassign/cancel action must continue through existing gated `hermes_*` mutation paths and server-controlled peer resolution.
+
+## 14. Explicit v0.8 non-goals
+
+The research pass confirms these should remain out of v0.8 unless a safety-critical dependency proves otherwise:
+
+- first-class persistent Missions/project object;
+- generic Flight Deck WebSocket/event-stream redesign;
+- multi-tenant/multi-owner SaaS control plane;
+- public unauthenticated Operator or Fabric service;
+- caller-supplied arbitrary peer URLs/tokens in Fabric;
+- credential distribution through Work Contracts;
+- removal or automation of final human approval;
+- trusting remote textual self-report as completion proof;
+- a generic scheduler for every A2A-compatible third-party agent;
+- weakening local Pi/runner filesystem confinement to make remote execution easier.
+
+## 15. Recommended acceptance tests
+
+### 15.1 Contract and seam unit tests
+
+- canonical Fabric dispatch envelope is deterministic and hash-stable;
+- conflicting duplicate dispatch ID is rejected;
+- identical idempotent replay returns existing attempt identity;
+- credentials/secret-looking fields rejected from Fabric payloads;
+- evidence with wrong contract/dispatch/attempt/peer identity rejected;
+- remote `SATISFIED` self-report ignored;
+- missing evidence cannot satisfy a contract;
+- unknown schema/version fails closed.
+
+### 15.2 Capability/router unit tests
+
+- healthy eligible local and remote candidates;
+- stale capability snapshot excluded;
+- identity mismatch excluded;
+- insufficient authorization excluded;
+- read-only peer excluded from write-capable contract;
+- missing required runner/tool/model/GPU/browser/vision capability excluded;
+- missing writable confinement excluded;
+- incompatible workspace mapping excluded;
+- hard concurrency ceiling excluded;
+- no eligible target returns deterministic explanation;
+- deterministic tie-break;
+- explicit peer/backend override still runs hard filters;
+- soft cost/load/latency signals cannot resurrect an excluded node;
+- upstream conversational `best` heuristic is never used for Fabric placement.
+
+### 15.3 Dispatch/recovery integration tests
+
+- successful remote read-only stage;
+- successful remote write-capable stage under explicit authorized workspace mapping;
+- timeout after successful submission recovers the same remote task and does not duplicate;
+- timeout with no unique recovery leaves attempt ambiguous/blocked;
+- coordinator process restart while remote attempt is active;
+- peer process restart while remote attempt is active;
+- A2A task record disappears but peer Fabric journal survives;
+- peer Fabric journal missing after restart produces blocked/lost state, not retry-success;
+- cancellation of active attempt;
+- duplicate cancellation;
+- cancel/completion race;
+- write retry cannot create two active mutations;
+- read-only retry lineage preserved;
+- push/SSE loss falls back to polling without changing correctness.
+
+### 15.4 Artifact/evidence adversarial tests
+
+- valid artifact digest/size accepted;
+- hash mismatch rejected;
+- oversized artifact rejected;
+- traversal-like logical name rejected;
+- symlink/special-file source rejected by peer acceptor;
+- denied secret path never exported;
+- remote absolute path not surfaced to client;
+- malformed artifact metadata rejected;
+- arbitrary external artifact URL rejected unless an explicitly safe transfer scheme is approved;
+- evidence output bounded and redacted;
+- artifact/evidence lineage mismatch rejected.
+
+### 15.5 Authority/security tests
+
+- caller cannot supply peer URL/token;
+- caller cannot raise peer authorization ceiling;
+- peer cannot self-declare wider authorization;
+- live card identity drift blocks dispatch;
+- stale capability record from old identity cannot be reused;
+- remote runner receives no more scope than Work Contract grants;
+- public/high-impact restrictions remain enforced;
+- remote peer text cannot reach Operator slash-command bypass;
+- Flight Deck action cannot bypass existing operator mutation gate.
+
+### 15.6 Backward-compatibility tests
+
+- local-only Work Contracts behave unchanged;
+- current Swarm workflow shape remains valid;
+- explicit `fleet`, `pi_rpc`, `omx`, and `codex` runner selection remains valid;
+- contracts omitting `execution` keep the documented compatibility behavior;
+- existing Mission Control/Event History redaction and bounds remain unchanged;
+- final Swarm approval still requires the existing human Owner/direct gate.
+
+### 15.7 Real two-host G6 acceptance
+
+On two authenticated machines:
+
+1. coordinator creates/owns a bounded Work Contract/Swarm;
+2. Fabric obtains fresh capability records;
+3. `auto` placement selects a remote managed Fabric node and explains why;
+4. remote deterministic acceptor validates the dispatch before worker execution;
+5. remote runner executes with no more authority than the contract grants;
+6. coordinator observes transport identity/state and receives bounded evidence/artifact metadata;
+7. one ambiguous/recoverable condition is induced;
+8. reconciliation proves no duplicate unsafe write occurred;
+9. coordinator validator reaches its verdict from admissible evidence;
+10. independent review evidence is recorded;
+11. final approval remains human/Owner-gated.
+
+Required receipts:
+
+- exact coordinator and peer builds/versions;
+- non-secret peer identities;
+- dispatch/attempt/remote-task identities;
+- contract hash;
+- capability snapshot digest/age;
+- placement explanation;
+- authority/scope applied;
+- relevant coordinator event/audit lineage;
+- artifact hashes;
+- recovery evidence;
+- validation verdict;
+- final approval record.
+
+## 16. G2 architecture decision list
+
+The research pass recommends that #29 explicitly decide and record ADRs for at least these items:
+
+1. **Transport:** official Hermes A2A v1.0 remains the Fabric network transport.
+2. **Managed peer requirement:** verified Fabric stages require a compatible deterministic Hermes GPT Fabric acceptor/executor; generic A2A peers remain unverified delegation targets.
+3. **Interface versioning:** introduce Fabric v2 dispatch/evidence interfaces or an additive adapter layer rather than silently redefining v0.7 seams.
+4. **Coordinator journal:** define durable dispatch/attempt record schema and state machine.
+5. **Peer journal:** define durable remote acceptance/attempt state written before write-capable execution.
+6. **Identity/idempotency:** define stable `dispatch_id`, per-run `attempt_id`, A2A task mapping, replay rules, and lineage.
+7. **Node registry/authority:** define safe extensible managed-node enrollment while retaining server-controlled identities, credentials, profile limits, and authorization ceilings.
+8. **Capability schema/trust:** define fields, freshness, provenance classes, digesting, and hard vs soft routing inputs.
+9. **Placement:** define eligibility filters, deterministic scoring/tie-break, explanations, manual override rules, and `execution.backend=auto` semantics.
+10. **Remote workspace mapping:** define logical workspace identity and peer-local path resolution without caller-controlled absolute remote paths.
+11. **Evidence:** define `hermes.fabric-evidence/v1`, admissibility classes, validation integration, and remote attestation threat boundary.
+12. **Artifacts:** define manifest and transfer mechanism using existing export/path/hash principles.
+13. **Cancellation/retry:** define idempotent cancel, terminal races, leases/epochs or equivalent protection against concurrent uncertain writes.
+14. **Recovery:** define coordinator restart, peer restart, task loss, liveness degradation, and fail-closed state transitions.
+15. **Events/UI:** define coordinator-side Fabric event lineage and bounded Flight Deck node/placement/evidence read models with no new authority path.
+16. **Compatibility:** define protocol/version negotiation, rollout behavior, and unchanged local-only contracts/swarms/runners.
+17. **Threat model:** explicitly document what Fabric protects against and what a fully compromised managed peer can still falsify.
+
+## 17. Recommended architecture bias for G2
+
+The research package does not approve an implementation, but it does narrow the safe design space substantially.
+
+Preferred shape:
 
 ```text
 Trusted client
     |
 Hermes GPT coordinator
     |
-    +-- Work Contract + Swarm policy/validation
-    +-- Fabric placement/router
-    +-- Fabric DispatchAdapter
+    +-- existing Operator policy / Work Contracts / Swarm validation
+    +-- Fabric node registry + local authority ceilings
+    +-- Fabric capability probe/cache
+    +-- Fabric placement router
+    +-- durable dispatch/attempt journal
+    +-- A2A Fabric DispatchAdapter
     |       |
-    |       +-- local runner
-    |       +-- A2A remote peer
+    |       +---------------- authenticated A2A ----------------+
+    |                                                         |
+    |                                              Managed Fabric peer
+    |                                                         |
+    |                                      deterministic Fabric acceptor
+    |                                                         |
+    |                                     local runner + confinement/policy
+    |                                                         |
+    |                                      durable peer attempt journal
+    |                                                         |
+    +-- EvidenceProvider <------ bounded evidence/artifacts ----+
     |
-    +-- EvidenceProvider(s)
-    |       +-- local observed state
-    |       +-- remote bounded evidence/artifact manifest
-    |
-    +-- existing audit/events/review/final human approval
+    +-- existing Work Contract validator
+    +-- existing Event History / Mission Control / Flight Deck read models
+    +-- independent review
+    +-- final human approval
 ```
 
-The coordinator should produce a canonical dispatch identity that survives transport retries/recovery and binds at minimum:
+Streaming/push can reduce polling and improve UX. Polling plus durable journals must remain sufficient for correctness.
 
-- contract hash;
-- local task/stage identity;
-- target peer identity;
-- authorization class;
-- allowed workspace/scope;
-- forbidden actions;
-- execution requirements;
-- dispatch attempt/lineage identity.
+## 18. G1 exit checklist
 
-Whether this becomes an extended `WorkOrder` or a versioned Fabric envelope is an open G2 decision.
+- [x] Verified current-state architecture from frozen Hermes GPT implementation.
+- [x] Evidence/source matrix maps material claims to implementation and tests.
+- [x] Gap analysis completed.
+- [x] Candidate capability manifest fields and provenance model completed.
+- [x] Candidate remote dispatch/evidence contracts completed.
+- [x] Candidate routing inputs and hard exclusions completed.
+- [x] Failure/recovery taxonomy completed.
+- [x] Security questions requiring G2/G3 decisions completed.
+- [x] Explicit v0.8 non-goals confirmed.
+- [x] Recommended unit, integration, adversarial, compatibility, and two-host acceptance tests completed.
+- [x] Current upstream Hermes A2A implementation inspected and pinned, including adapter, protocol, task-store durability, tests, and capability orchestration behavior.
+- [x] No production implementation performed during G1.
 
-## 5. Research gaps
+## 19. G1 verdict
 
-### 5.1 Seam versioning
+**PASS, research complete.**
 
-Determine whether extending `DispatchAdapter` in place is backward-compatible enough, or whether a v2 interface is cleaner. Real remote execution likely needs explicit operations/fields for:
+The package is implementation-grounded and sufficiently specific for #29 to begin architecture/ADR work without guessing about current Hermes GPT or upstream Hermes behavior.
 
-- idempotent submit;
-- status;
-- cancel;
-- collect evidence;
-- collect artifact manifest / artifact transfer;
-- capability snapshot;
-- ambiguous submission / recovery state.
+The largest architecture risks are now known rather than hidden:
 
-### 5.2 Evidence semantics
+1. deterministic peer-side Fabric acceptance instead of natural-language authority interpretation;
+2. durable coordinator and peer attempt identity across restart/timeout ambiguity;
+3. capability/authority separation in automatic placement;
+4. evidence admission that never confuses self-report with proof;
+5. safe artifact transfer;
+6. prevention of concurrent uncertain write attempts;
+7. honest threat-model treatment of a fully compromised remote host.
 
-Define what remote data can count as coordinator-observed evidence. Candidate classes include:
-
-- A2A task identity/status observed by coordinator;
-- returned artifact hashes + bounded metadata;
-- test command identifiers/results under contract-controlled execution;
-- peer/runtime identity verified against the local fleet authority manifest;
-- remote audit/event references that can be cryptographically or structurally bound to the task/contract.
-
-A peer-authored textual claim such as `tests passed` or `done` cannot become sufficient evidence by itself.
-
-### 5.3 Capability freshness and identity
-
-Research how Agent Card skills/capabilities change over time and what current Hermes exposes about health/load. A router needs a freshness model so stale capability data fails closed rather than becoming affirmative eligibility.
-
-### 5.4 Artifact transport
-
-Research A2A artifact support in current upstream implementation and decide whether Hermes GPT can safely map it onto existing bounded export semantics or needs a dedicated Fabric artifact envelope. Required properties include size bounds, hashes, path/secret protections, symlink/special-file rejection, and producer/task/contract lineage.
-
-### 5.5 Lifecycle/recovery
-
-Map exact semantics for:
-
-- timeout after submit;
-- duplicate submit;
-- coordinator restart while remote task runs;
-- peer restart;
-- peer unreachable then returns;
-- cancellation race with completion;
-- retry after ambiguous state;
-- artifact/evidence unavailable after task completion.
-
-The desired rule is conservative: unknown or missing remote state becomes blocked/ambiguous/retryable-with-proof, never silently done.
-
-### 5.6 Placement
-
-Research a two-stage router:
-
-1. **Eligibility filtering**: identity, authority, workspace/sandbox posture, required runner/tools/model/hardware, health/freshness.
-2. **Selection/scoring**: deterministic tie-break over eligible candidates using grounded signals such as current load, locality, estimated latency/cost when available.
-
-Manual explicit routing must remain supported and must not bypass eligibility/policy checks.
-
-## 6. Failure taxonomy to carry into G2/G3
-
-At minimum:
-
-- `NO_ELIGIBLE_TARGET`
-- `CAPABILITY_STALE`
-- `PEER_IDENTITY_MISMATCH`
-- `AUTHORITY_EXCEEDS_PEER_LIMIT`
-- `REMOTE_SUBMISSION_AMBIGUOUS`
-- `REMOTE_TASK_LOST`
-- `REMOTE_PEER_UNAVAILABLE`
-- `REMOTE_CANCEL_AMBIGUOUS`
-- `REMOTE_EVIDENCE_MISSING`
-- `REMOTE_EVIDENCE_INVALID`
-- `REMOTE_ARTIFACT_UNSAFE`
-- `REMOTE_ARTIFACT_HASH_MISMATCH`
-- `REMOTE_ARTIFACT_TOO_LARGE`
-- `REMOTE_AUTHORITY_DRIFT`
-
-Names are provisional until architecture review.
-
-## 7. Non-goals confirmed for v0.8 research
-
-- multi-tenant / multi-owner SaaS control plane;
-- public unauthenticated Operator or A2A widening;
-- caller-supplied arbitrary peer credentials/URLs through Fabric;
-- removal of final human approval;
-- first-class Missions object;
-- generic Flight Deck push-streaming redesign;
-- treating remote self-report as completion proof.
-
-## 8. Initial acceptance scenario
-
-A valid G6 candidate should be able to prove, on two real authenticated machines:
-
-1. coordinator creates/owns a bounded Work Contract / Swarm;
-2. Fabric observes eligible nodes;
-3. `auto` placement selects a remote target and explains why;
-4. remote stage executes under no more authority than the contract grants;
-5. coordinator observes task identity/status and receives bounded evidence/artifact hashes;
-6. an induced ambiguous condition is reconciled without duplicate unsafe work;
-7. contract validation remains fail closed;
-8. independent review evidence is recorded;
-9. final approval remains human/Owner-gated.
-
-## 9. Sources inspected in the first pass
-
-Frozen Hermes GPT baseline:
-
-- `seams.py`
-- `operator_fleet.py`
-- `docs/design/pluggable-runner-architecture.md`
-- `operator_runners.py`
-- `docs/design/v0.7-flight-deck-architecture.md`
-- `docs/flight-deck-coverage.md`
-- `AGENTS.md`
-
-Current upstream Hermes Agent:
-
-- `website/docs/user-guide/messaging/a2a.md`
-- A2A plugin/tests identified for deeper implementation inspection
-
-## 10. Next research pass
-
-Before G1 completion:
-
-1. inspect upstream A2A task/artifact models and tests, not only docs;
-2. inspect the remainder of `operator_fleet.py` authority verification and completion bundle parsing;
-3. inspect `operator_contract.py` exact observed-state acceptance hooks;
-4. inspect `operator_swarm.py` dispatch/advance/reconcile integration points;
-5. inspect runner capability/status surfaces and confinement posture exposure;
-6. map current event/audit stores needed for multi-host lineage;
-7. produce a source/evidence matrix and concrete G2 decision list.
+G2 may refine names and schema shapes. It should not reopen the core decision that transport success, peer self-report, or advertised capability are insufficient substitutes for Hermes GPT authorization and validation.

--- a/docs/releases/v0.8-fabric-research-package.md
+++ b/docs/releases/v0.8-fabric-research-package.md
@@ -1,0 +1,254 @@
+# Hermes GPT v0.8 — Fabric Research Package
+
+- Status: IN PROGRESS — G1 research only
+- Program: #27
+- Gate: #28
+- Frozen baseline: `4bb85d1eb7abf0974077b63c131013613793bb72`
+- Started: 2026-08-19
+- Rule: implementation and current tests outrank historical design artifacts.
+
+## 1. Research question
+
+What is the smallest safe architecture that lets an existing Hermes GPT Work Contract / Swarm stage execute on another authenticated Hermes machine, return bounded observed evidence and artifacts, and remain subject to the coordinator's existing authority and fail-closed completion model?
+
+The second question is placement: once remote execution exists, what facts can Hermes GPT safely use to choose a local/remote node and execution backend automatically without turning capability advertising into authorization?
+
+## 2. Product thesis under test
+
+Fabric should scale **where work runs**, not **what is trusted**.
+
+The coordinator remains responsible for policy, authorization, Work Contract identity, completion validation, review requirements, audit/event lineage, and final human approval. A remote peer is an execution host. Its self-report is transport data, never sufficient proof that a contract is satisfied.
+
+## 3. Verified baseline facts
+
+### 3.1 v0.7 ships cross-machine seams, not remote Swarm execution
+
+`seams.py` explicitly states that v0.7 ships interfaces only. The current `WorkOrder` contains:
+
+- `task_id`
+- `objective_sha256`
+- `assigned_agent`
+- `authority_class`
+- `allowed_workspaces`
+- `forbidden_actions`
+- `contract_sha256`
+- `parent_ref`
+- bounded metadata
+
+`DispatchAdapter` exposes `dispatch(work_order) -> ref`, `poll(ref)`, and `collect(ref)`. `EvidenceProvider` exposes `collect(contract_sha256, task_id, host)`.
+
+Immediate gap: the seam itself does not yet define cancellation, idempotency, capability snapshots, remote artifact envelopes, transport ambiguity states, restart reconciliation, or proof lineage sufficient for a real multi-host implementation.
+
+### 3.2 Hermes GPT already uses official Hermes A2A v1.0 for fleet routing
+
+`operator_fleet.py` no longer depends on the legacy bridge for normal dispatch. It reads known peers from Hermes `config.yaml` `a2a_agents`, discovers Agent Cards, resolves configured bearer authentication, and sends tasks using A2A JSON-RPC.
+
+This is strategically important: v0.8 should not invent a second remote transport when the official Hermes platform already provides the cross-machine execution channel.
+
+### 3.3 Dispatch-timeout ambiguity already has a useful recovery primitive
+
+Current fleet dispatch creates a unique A2A `contextId`. If `SendMessage` times out, Hermes GPT performs a bounded `ListTasks` lookup for that context and, when exactly one valid task is found, raises `FleetDispatchTimeout` carrying the peer-assigned task ID.
+
+This means the code already recognizes the critical distributed-systems fact that a timeout does not mean submission failed. Fabric should generalize this identity/recovery pattern and must never blindly resubmit write-capable work after an ambiguous timeout.
+
+### 3.4 Current upstream Hermes A2A already exposes the lifecycle primitives Fabric needs
+
+Current upstream Hermes documentation describes A2A v1.0 support for:
+
+- Agent Card discovery;
+- Hermes-to-Hermes cross-machine calls;
+- `SendMessage` / `SendStreamingMessage`;
+- `GetTask`;
+- `ListTasks`;
+- `CancelTask`;
+- `SubscribeToTask`;
+- SSE streaming;
+- signed push notifications;
+- configured peer capabilities;
+- per-peer authenticated identities;
+- A2A audit logging;
+- prompt-injection framing of inbound peer text as untrusted input.
+
+The first architecture bias is therefore: use A2A task identity/lifecycle as transport, keep Hermes GPT Work Contracts as the authority/verification layer.
+
+### 3.5 Upstream capability advertising is useful but is not authorization
+
+Hermes peers can advertise capabilities/skills and upstream exposes `a2a_orchestrate(capability, ..., mode=all|first|best)`. Configured `a2a_agents` entries can also carry capability hints.
+
+Fabric can potentially reuse those concepts for discovery, but a reported `coding`, `browser`, `gpu`, or similar capability must not imply:
+
+- write authorization;
+- workspace access;
+- runner confinement availability;
+- model/provider availability at dispatch time;
+- acceptable load/health;
+- evidence quality;
+- permission to perform a public/high-impact action.
+
+Any automatic router therefore needs a strict split between **capability** and **authority**. Hard authority/safety constraints must filter candidates before any capability/load/cost scoring occurs.
+
+## 4. Candidate architecture shape to investigate, not yet approved
+
+```text
+Trusted client
+    |
+Hermes GPT coordinator
+    |
+    +-- Work Contract + Swarm policy/validation
+    +-- Fabric placement/router
+    +-- Fabric DispatchAdapter
+    |       |
+    |       +-- local runner
+    |       +-- A2A remote peer
+    |
+    +-- EvidenceProvider(s)
+    |       +-- local observed state
+    |       +-- remote bounded evidence/artifact manifest
+    |
+    +-- existing audit/events/review/final human approval
+```
+
+The coordinator should produce a canonical dispatch identity that survives transport retries/recovery and binds at minimum:
+
+- contract hash;
+- local task/stage identity;
+- target peer identity;
+- authorization class;
+- allowed workspace/scope;
+- forbidden actions;
+- execution requirements;
+- dispatch attempt/lineage identity.
+
+Whether this becomes an extended `WorkOrder` or a versioned Fabric envelope is an open G2 decision.
+
+## 5. Research gaps
+
+### 5.1 Seam versioning
+
+Determine whether extending `DispatchAdapter` in place is backward-compatible enough, or whether a v2 interface is cleaner. Real remote execution likely needs explicit operations/fields for:
+
+- idempotent submit;
+- status;
+- cancel;
+- collect evidence;
+- collect artifact manifest / artifact transfer;
+- capability snapshot;
+- ambiguous submission / recovery state.
+
+### 5.2 Evidence semantics
+
+Define what remote data can count as coordinator-observed evidence. Candidate classes include:
+
+- A2A task identity/status observed by coordinator;
+- returned artifact hashes + bounded metadata;
+- test command identifiers/results under contract-controlled execution;
+- peer/runtime identity verified against the local fleet authority manifest;
+- remote audit/event references that can be cryptographically or structurally bound to the task/contract.
+
+A peer-authored textual claim such as `tests passed` or `done` cannot become sufficient evidence by itself.
+
+### 5.3 Capability freshness and identity
+
+Research how Agent Card skills/capabilities change over time and what current Hermes exposes about health/load. A router needs a freshness model so stale capability data fails closed rather than becoming affirmative eligibility.
+
+### 5.4 Artifact transport
+
+Research A2A artifact support in current upstream implementation and decide whether Hermes GPT can safely map it onto existing bounded export semantics or needs a dedicated Fabric artifact envelope. Required properties include size bounds, hashes, path/secret protections, symlink/special-file rejection, and producer/task/contract lineage.
+
+### 5.5 Lifecycle/recovery
+
+Map exact semantics for:
+
+- timeout after submit;
+- duplicate submit;
+- coordinator restart while remote task runs;
+- peer restart;
+- peer unreachable then returns;
+- cancellation race with completion;
+- retry after ambiguous state;
+- artifact/evidence unavailable after task completion.
+
+The desired rule is conservative: unknown or missing remote state becomes blocked/ambiguous/retryable-with-proof, never silently done.
+
+### 5.6 Placement
+
+Research a two-stage router:
+
+1. **Eligibility filtering**: identity, authority, workspace/sandbox posture, required runner/tools/model/hardware, health/freshness.
+2. **Selection/scoring**: deterministic tie-break over eligible candidates using grounded signals such as current load, locality, estimated latency/cost when available.
+
+Manual explicit routing must remain supported and must not bypass eligibility/policy checks.
+
+## 6. Failure taxonomy to carry into G2/G3
+
+At minimum:
+
+- `NO_ELIGIBLE_TARGET`
+- `CAPABILITY_STALE`
+- `PEER_IDENTITY_MISMATCH`
+- `AUTHORITY_EXCEEDS_PEER_LIMIT`
+- `REMOTE_SUBMISSION_AMBIGUOUS`
+- `REMOTE_TASK_LOST`
+- `REMOTE_PEER_UNAVAILABLE`
+- `REMOTE_CANCEL_AMBIGUOUS`
+- `REMOTE_EVIDENCE_MISSING`
+- `REMOTE_EVIDENCE_INVALID`
+- `REMOTE_ARTIFACT_UNSAFE`
+- `REMOTE_ARTIFACT_HASH_MISMATCH`
+- `REMOTE_ARTIFACT_TOO_LARGE`
+- `REMOTE_AUTHORITY_DRIFT`
+
+Names are provisional until architecture review.
+
+## 7. Non-goals confirmed for v0.8 research
+
+- multi-tenant / multi-owner SaaS control plane;
+- public unauthenticated Operator or A2A widening;
+- caller-supplied arbitrary peer credentials/URLs through Fabric;
+- removal of final human approval;
+- first-class Missions object;
+- generic Flight Deck push-streaming redesign;
+- treating remote self-report as completion proof.
+
+## 8. Initial acceptance scenario
+
+A valid G6 candidate should be able to prove, on two real authenticated machines:
+
+1. coordinator creates/owns a bounded Work Contract / Swarm;
+2. Fabric observes eligible nodes;
+3. `auto` placement selects a remote target and explains why;
+4. remote stage executes under no more authority than the contract grants;
+5. coordinator observes task identity/status and receives bounded evidence/artifact hashes;
+6. an induced ambiguous condition is reconciled without duplicate unsafe work;
+7. contract validation remains fail closed;
+8. independent review evidence is recorded;
+9. final approval remains human/Owner-gated.
+
+## 9. Sources inspected in the first pass
+
+Frozen Hermes GPT baseline:
+
+- `seams.py`
+- `operator_fleet.py`
+- `docs/design/pluggable-runner-architecture.md`
+- `operator_runners.py`
+- `docs/design/v0.7-flight-deck-architecture.md`
+- `docs/flight-deck-coverage.md`
+- `AGENTS.md`
+
+Current upstream Hermes Agent:
+
+- `website/docs/user-guide/messaging/a2a.md`
+- A2A plugin/tests identified for deeper implementation inspection
+
+## 10. Next research pass
+
+Before G1 completion:
+
+1. inspect upstream A2A task/artifact models and tests, not only docs;
+2. inspect the remainder of `operator_fleet.py` authority verification and completion bundle parsing;
+3. inspect `operator_contract.py` exact observed-state acceptance hooks;
+4. inspect `operator_swarm.py` dispatch/advance/reconcile integration points;
+5. inspect runner capability/status surfaces and confinement posture exposure;
+6. map current event/audit stores needed for multi-host lineage;
+7. produce a source/evidence matrix and concrete G2 decision list.


### PR DESCRIPTION
Completes the G1 research package for Hermes GPT v0.8 Fabric from the frozen baseline `4bb85d1eb7abf0974077b63c131013613793bb72`.

Program: #27
Research gate: #28
Upstream Hermes Agent pinned for research: `ad889540f20ba49157976487a29becb762ce7933`

This PR is **research/docs only**. It does not implement remote execution or change runtime authority.

G1 now contains:
- verified Work Contract, Swarm, Fleet/A2A, runner, recovery, events, export, OAuth, and Flight Deck current-state mapping;
- implementation/test evidence matrix;
- exact v0.7 seam gap analysis;
- current upstream A2A transport/task-store/capability findings;
- candidate Fabric node capability manifest and provenance classes;
- candidate `hermes.fabric-dispatch/v1` and `hermes.fabric-evidence/v1` contracts;
- deterministic hard-filter-then-score routing model;
- failure/recovery taxonomy for timeout, duplicate submit, peer/coordinator restart, cancellation races, stale capability data, evidence loss, and artifacts;
- explicit G2/G3 security questions and threat-model boundary;
- recommended unit, integration, adversarial, compatibility, and two-host acceptance tests;
- 17-item G2 ADR/architecture decision list.

Key research conclusion: official Hermes A2A should remain the transport, but a **verified Fabric node must expose a deterministic Hermes GPT Fabric acceptor/executor**. Generic inbound A2A tasks ultimately enter a live agent session, which is not an acceptable authority boundary for distributed write-capable Work Contracts.

A second critical finding is that the pinned upstream A2A `TaskStore` is in-memory. Fabric therefore needs durable coordinator and peer attempt identity/journaling for restart-safe distributed mutation.

The G1 document records a PASS verdict. Merge/release is not implied by that verdict. G2 architecture work remains separately gated by #29 and G3 security review by #30.