### PR TITLE
feat(v0.8): implement Fabric managed remote dispatch core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run full test suite
         run: python -m pytest -q
       - name: Run runner regression tests
-        run: python -m pytest -q test_operator_runners.py
+        run: python -m pytest -q test_operator_runners.py test_operator_fabric.py
       - name: Run binary export regression tests
         run: python -m pytest -q test_operator_export.py test_server_export.py
       - name: Compile operator modules
@@ -35,6 +35,7 @@ jobs:
           codex_config.py
           operator_codex.py
           operator_contract.py
+          operator_fabric.py
           operator_fleet.py
           operator_runners.py
           operator_swarm.py
@@ -61,6 +62,7 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: >-
           python -m ruff check
+          operator_fabric.py test_operator_fabric.py
           operator_runners.py test_operator_runners.py
           runner_confinement.py test_runner_confinement.py test_runner_confinement_policy.py
           operator_export.py test_operator_export.py test_server_export.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           test_operator_runners.py
           test_operator_fabric.py
           test_operator_fabric_adversarial.py
+          test_operator_fabric_control.py
       - name: Run binary export regression tests
         run: python -m pytest -q test_operator_export.py test_server_export.py
       - name: Compile operator modules
@@ -40,6 +41,7 @@ jobs:
           operator_codex.py
           operator_contract.py
           operator_fabric.py
+          operator_fabric_control.py
           operator_fleet.py
           operator_runners.py
           operator_swarm.py
@@ -66,7 +68,8 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: >-
           python -m ruff check
-          operator_fabric.py test_operator_fabric.py test_operator_fabric_adversarial.py
+          operator_fabric.py operator_fabric_control.py
+          test_operator_fabric.py test_operator_fabric_adversarial.py test_operator_fabric_control.py
           operator_runners.py test_operator_runners.py
           runner_confinement.py test_runner_confinement.py test_runner_confinement_policy.py
           operator_export.py test_operator_export.py test_server_export.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Run full test suite
         run: python -m pytest -q
       - name: Run runner regression tests
-        run: python -m pytest -q test_operator_runners.py test_operator_fabric.py
+        run: >-
+          python -m pytest -q
+          test_operator_runners.py
+          test_operator_fabric.py
+          test_operator_fabric_adversarial.py
       - name: Run binary export regression tests
         run: python -m pytest -q test_operator_export.py test_server_export.py
       - name: Compile operator modules
@@ -62,7 +66,7 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: >-
           python -m ruff check
-          operator_fabric.py test_operator_fabric.py
+          operator_fabric.py test_operator_fabric.py test_operator_fabric_adversarial.py
           operator_runners.py test_operator_runners.py
           runner_confinement.py test_runner_confinement.py test_runner_confinement_policy.py
           operator_export.py test_operator_export.py test_server_export.py

--- a/operator_fabric.py
+++ b/operator_fabric.py
@@ -1,0 +1,1131 @@
+"""Hermes GPT v0.8 Fabric managed remote dispatch and evidence core.
+
+Fabric uses A2A v1.0 as a bounded transport, but the verified peer endpoint is
+owned by Hermes GPT and parses structured DataParts before any agent/LLM path.
+The coordinator remains the authority owner and Work Contract validator.
+
+G4-A intentionally does not implement automatic placement, artifact transfer,
+or Flight Deck UI. Those belong to later v0.8 slices.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import re
+import sqlite3
+import ssl
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Callable
+
+import operator_fleet as op_fleet
+import operator_policy as op
+import operator_runners as op_runners
+
+FABRIC_VERSION = 1
+REQUEST_SCHEMA = "hermes.fabric-request/v1"
+RESPONSE_SCHEMA = "hermes.fabric-response/v1"
+DISPATCH_SCHEMA = "hermes.fabric-dispatch/v1"
+EVIDENCE_SCHEMA = "hermes.fabric-evidence/v1"
+CAPABILITY_SCHEMA = "hermes.fabric-capability/v1"
+NODE_REGISTRY_SCHEMA = "hermes.fabric-node-registry/v1"
+PEER_POLICY_SCHEMA = "hermes.fabric-peer-policy/v1"
+
+NODE_REGISTRY_ENV = "HERMES_GPT_FABRIC_NODE_REGISTRY"
+PEER_POLICY_ENV = "HERMES_GPT_FABRIC_PEER_POLICY"
+PEER_TOKENS_ENV = "HERMES_GPT_FABRIC_PEER_TOKENS"
+COORDINATOR_DB_ENV = "HERMES_GPT_FABRIC_COORDINATOR_DB"
+PEER_DB_ENV = "HERMES_GPT_FABRIC_PEER_DB"
+
+_MAX_BODY = 128 * 1024
+_MAX_STRING = 8_000
+_MAX_ITEMS = 64
+_MAX_DEPTH = 8
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_NODE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_PROFILE_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_BACKEND_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_PRINCIPAL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,127}$")
+_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+_SECRETISH_KEY_RE = re.compile(r"(?:secret|token|password|passwd|api[_-]?key|credential|private[_-]?key)", re.I)
+_URLISH_KEY_RE = re.compile(r"(?:url|uri|endpoint|host|hostname|proxy)", re.I)
+_AUTH_RANK = {"none": 0, "read_only": 1, "reversible_write": 2, "high_impact": 3}
+_TERMINAL_PEER = frozenset({"SUCCEEDED", "FAILED", "CANCELLED", "LOST_AMBIGUOUS", "BLOCKED"})
+_TERMINAL_COORD = frozenset({"COMPLETED", "FAILED", "CANCELLED", "BLOCKED"})
+_SAFE_EVIDENCE_PROVENANCE = frozenset({"coordinator_observed", "managed_peer_structured", "artifact_verified", "coordinator_local"})
+_DEFAULT_FEATURES = ("dispatch-v1", "evidence-v1", "idempotency-v1", "principal-auth-v1", "closed-schema-v1")
+
+
+class FabricError(RuntimeError):
+    def __init__(self, code: str, message: str, *, ambiguous: bool = False):
+        super().__init__(message)
+        self.code = code
+        self.ambiguous = ambiguous
+
+
+class _DuplicateKey(ValueError):
+    pass
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _strict_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in out:
+            raise _DuplicateKey(f"duplicate JSON field {key!r}")
+        out[key] = value
+    return out
+
+
+def strict_json_loads(raw: str | bytes, *, maximum: int = _MAX_BODY) -> Any:
+    if isinstance(raw, bytes):
+        if len(raw) > maximum:
+            raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "JSON payload exceeds the bounded limit")
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise FabricError("FABRIC_INVALID_JSON", "payload is not valid UTF-8") from exc
+    elif isinstance(raw, str):
+        if len(raw.encode("utf-8")) > maximum:
+            raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "JSON payload exceeds the bounded limit")
+        text = raw
+    else:
+        raise FabricError("FABRIC_INVALID_JSON", "payload must be UTF-8 JSON")
+    try:
+        return json.loads(text, object_pairs_hook=_strict_pairs)
+    except _DuplicateKey as exc:
+        raise FabricError("FABRIC_AMBIGUOUS_JSON", str(exc)) from exc
+    except json.JSONDecodeError as exc:
+        raise FabricError("FABRIC_INVALID_JSON", "payload is not valid JSON") from exc
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _closed(obj: Any, *, required: set[str], optional: set[str] = frozenset(), name: str) -> dict[str, Any]:
+    if not isinstance(obj, dict):
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} must be an object")
+    keys = set(obj)
+    missing = required - keys
+    unknown = keys - required - optional
+    if missing:
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} is missing required fields")
+    if unknown:
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} contains unknown fields")
+    return obj
+
+
+def _bounded_string(value: Any, *, field: str, maximum: int = _MAX_STRING, pattern: re.Pattern[str] | None = None, required: bool = True) -> str:
+    if not isinstance(value, str) or (required and not value) or len(value.encode("utf-8")) > maximum:
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} is invalid")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains control characters")
+    if pattern is not None and not pattern.fullmatch(value):
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} has an invalid format")
+    return value
+
+
+def _bounded_strings(value: Any, *, field: str, maximum: int = _MAX_ITEMS, item_max: int = 2_000) -> list[str]:
+    if not isinstance(value, list) or len(value) > maximum:
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} must be a bounded list")
+    return [_bounded_string(item, field=f"{field} item", maximum=item_max) for item in value]
+
+
+def _bounded_json(value: Any, *, field: str, depth: int = 0) -> Any:
+    if depth > _MAX_DEPTH:
+        raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} exceeds nesting depth")
+    if value is None or isinstance(value, (bool, int, float)):
+        if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+            raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains a non-finite number")
+        return value
+    if isinstance(value, str):
+        if len(value.encode("utf-8")) > _MAX_STRING:
+            raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains an oversized string")
+        if "://" in value:
+            raise FabricError("FABRIC_CALLER_NETWORK_TARGET", f"{field} may not contain caller-supplied URLs")
+        return value
+    if isinstance(value, list):
+        if len(value) > _MAX_ITEMS:
+            raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains too many items")
+        return [_bounded_json(item, field=field, depth=depth + 1) for item in value]
+    if isinstance(value, dict):
+        if len(value) > _MAX_ITEMS:
+            raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains too many keys")
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or len(key) > 128:
+                raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} has an invalid key")
+            if _SECRETISH_KEY_RE.search(key):
+                raise FabricError("FABRIC_CALLER_CREDENTIAL", f"{field} may not contain credential fields")
+            if _URLISH_KEY_RE.search(key):
+                raise FabricError("FABRIC_CALLER_NETWORK_TARGET", f"{field} may not contain network target fields")
+            out[key] = _bounded_json(item, field=f"{field}.{key}", depth=depth + 1)
+        return out
+    raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains a non-JSON value")
+
+
+def _root(hermes_root: Path | None = None) -> Path:
+    configured = hermes_root or Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    normalized = op.normalize_hermes_data_root(configured)
+    return Path(normalized or Path.home() / ".hermes")
+
+
+def _config_path(env_name: str, default_name: str, hermes_root: Path | None = None) -> Path:
+    configured = os.environ.get(env_name, "").strip()
+    path = Path(configured).expanduser() if configured else _root(hermes_root) / "config" / default_name
+    if not path.is_absolute():
+        raise FabricError("FABRIC_CONFIG_INVALID", f"{env_name} must resolve to an absolute path")
+    if op.is_denied_path(path) or path.is_symlink():
+        raise FabricError("FABRIC_CONFIG_INVALID", "Fabric configuration path is not allowed")
+    return path
+
+
+def _read_closed_json(path: Path, *, maximum: int = _MAX_BODY) -> dict[str, Any]:
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise FabricError("FABRIC_CONFIG_MISSING", f"Fabric configuration is missing: {path.name}") from exc
+    value = strict_json_loads(raw, maximum=maximum)
+    if not isinstance(value, dict):
+        raise FabricError("FABRIC_CONFIG_INVALID", "Fabric configuration must be an object")
+    return value
+
+
+@dataclass(frozen=True)
+class FabricNode:
+    name: str
+    a2a_peer_name: str
+    expected_identity: str
+    coordinator_principal: str
+    enabled: bool
+    allowed_profiles: tuple[str, ...]
+    max_authorization: str
+    allowed_remote_backends: tuple[str, ...]
+    logical_workspaces: tuple[str, ...]
+    required_features: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkspaceMapping:
+    logical_id: str
+    local_path: Path
+    revision: str
+    conflict_domain: str
+
+
+@dataclass(frozen=True)
+class FabricPeerPolicy:
+    node_name: str
+    identity: str
+    allowed_coordinator_principals: tuple[str, ...]
+    allowed_profiles: tuple[str, ...]
+    max_authorization: str
+    allowed_backends: tuple[str, ...]
+    required_features: tuple[str, ...]
+    workspace_mappings: dict[str, WorkspaceMapping]
+    digest: str
+
+
+def load_node_registry(path: Path | None = None, *, hermes_root: Path | None = None) -> dict[str, FabricNode]:
+    path = path or _config_path(NODE_REGISTRY_ENV, "fabric-nodes.json", hermes_root)
+    raw = _read_closed_json(path)
+    _closed(raw, required={"schema", "version", "nodes"}, name="node registry")
+    if raw["schema"] != NODE_REGISTRY_SCHEMA or raw["version"] != 1 or not isinstance(raw["nodes"], list):
+        raise FabricError("FABRIC_CONFIG_INVALID", "node registry schema/version is invalid")
+    if len(raw["nodes"]) > 128:
+        raise FabricError("FABRIC_CONFIG_INVALID", "node registry contains too many nodes")
+    result: dict[str, FabricNode] = {}
+    for item in raw["nodes"]:
+        item = _closed(item, required={"name", "a2a_peer_name", "expected_identity", "coordinator_principal", "enabled", "allowed_profiles", "max_authorization", "allowed_remote_backends", "logical_workspaces", "required_features"}, name="node")
+        name = _bounded_string(item["name"], field="node.name", pattern=_NODE_RE)
+        if name in result:
+            raise FabricError("FABRIC_CONFIG_INVALID", "node names must be unique")
+        peer_name = _bounded_string(item["a2a_peer_name"], field="node.a2a_peer_name", pattern=op_fleet._AGENT_RE)
+        identity = _bounded_string(item["expected_identity"], field="node.expected_identity", maximum=128)
+        principal = _bounded_string(item["coordinator_principal"], field="node.coordinator_principal", pattern=_PRINCIPAL_RE)
+        if not isinstance(item["enabled"], bool):
+            raise FabricError("FABRIC_CONFIG_INVALID", "node.enabled must be boolean")
+        profiles = tuple(_bounded_strings(item["allowed_profiles"], field="node.allowed_profiles", maximum=32, item_max=64))
+        if any(not _PROFILE_RE.fullmatch(p) for p in profiles):
+            raise FabricError("FABRIC_CONFIG_INVALID", "node allowed profile is invalid")
+        max_auth = _bounded_string(item["max_authorization"], field="node.max_authorization", maximum=32)
+        if max_auth not in _AUTH_RANK:
+            raise FabricError("FABRIC_CONFIG_INVALID", "node max_authorization is invalid")
+        backends = tuple(_bounded_strings(item["allowed_remote_backends"], field="node.allowed_remote_backends", maximum=32, item_max=64))
+        if any(not _BACKEND_RE.fullmatch(b) or b in {"fabric", "fleet"} for b in backends):
+            raise FabricError("FABRIC_CONFIG_INVALID", "node remote backend allowlist is invalid")
+        workspaces = tuple(_bounded_strings(item["logical_workspaces"], field="node.logical_workspaces", maximum=64, item_max=128))
+        features = tuple(_bounded_strings(item["required_features"], field="node.required_features", maximum=32, item_max=128))
+        result[name] = FabricNode(name, peer_name, identity, principal, item["enabled"], profiles, max_auth, backends, workspaces, features)
+    return result
+
+
+def load_peer_policy(path: Path | None = None, *, hermes_root: Path | None = None) -> FabricPeerPolicy:
+    path = path or _config_path(PEER_POLICY_ENV, "fabric-peer-policy.json", hermes_root)
+    raw = _read_closed_json(path)
+    _closed(raw, required={"schema", "version", "node_name", "identity", "allowed_coordinator_principals", "allowed_profiles", "max_authorization", "allowed_backends", "required_features", "workspace_mappings"}, name="peer policy")
+    if raw["schema"] != PEER_POLICY_SCHEMA or raw["version"] != 1:
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer policy schema/version is invalid")
+    node_name = _bounded_string(raw["node_name"], field="peer.node_name", pattern=_NODE_RE)
+    identity = _bounded_string(raw["identity"], field="peer.identity", maximum=128)
+    principals = tuple(_bounded_strings(raw["allowed_coordinator_principals"], field="peer.allowed_coordinator_principals", maximum=32, item_max=128))
+    if not principals or any(not _PRINCIPAL_RE.fullmatch(p) for p in principals):
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer principals are invalid")
+    profiles = tuple(_bounded_strings(raw["allowed_profiles"], field="peer.allowed_profiles", maximum=32, item_max=64))
+    if not profiles or any(not _PROFILE_RE.fullmatch(p) for p in profiles):
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer profiles are invalid")
+    max_auth = _bounded_string(raw["max_authorization"], field="peer.max_authorization", maximum=32)
+    if max_auth not in _AUTH_RANK:
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer max_authorization is invalid")
+    backends = tuple(_bounded_strings(raw["allowed_backends"], field="peer.allowed_backends", maximum=32, item_max=64))
+    if not backends or any(not _BACKEND_RE.fullmatch(b) or b in {"fabric", "fleet"} for b in backends):
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer backend allowlist is invalid")
+    features = tuple(_bounded_strings(raw["required_features"], field="peer.required_features", maximum=32, item_max=128))
+    mappings_raw = raw["workspace_mappings"]
+    if not isinstance(mappings_raw, dict) or not mappings_raw or len(mappings_raw) > 64:
+        raise FabricError("FABRIC_CONFIG_INVALID", "peer workspace mappings are invalid")
+    mappings: dict[str, WorkspaceMapping] = {}
+    for logical_id, mapping in mappings_raw.items():
+        logical_id = _bounded_string(logical_id, field="workspace logical id", maximum=128)
+        mapping = _closed(mapping, required={"local_path", "revision", "conflict_domain"}, name="workspace mapping")
+        local_path_text = _bounded_string(mapping["local_path"], field="workspace.local_path", maximum=1_000)
+        local_path = Path(local_path_text).expanduser()
+        if not local_path.is_absolute() or op.is_denied_path(local_path):
+            raise FabricError("FABRIC_CONFIG_INVALID", "workspace mapping path is not allowed")
+        try:
+            if local_path.is_symlink():
+                raise FabricError("FABRIC_CONFIG_INVALID", "workspace mapping root may not be a symlink")
+        except OSError as exc:
+            raise FabricError("FABRIC_CONFIG_INVALID", "workspace mapping cannot be inspected") from exc
+        revision = _bounded_string(mapping["revision"], field="workspace.revision", maximum=128)
+        conflict_domain = _bounded_string(mapping["conflict_domain"], field="workspace.conflict_domain", maximum=128)
+        mappings[logical_id] = WorkspaceMapping(logical_id, local_path.resolve(), revision, conflict_domain)
+    digest = sha256_json(raw)
+    return FabricPeerPolicy(node_name, identity, principals, profiles, max_auth, backends, features, mappings, digest)
+
+
+def load_peer_tokens(value: str | None = None) -> dict[str, str]:
+    raw_value = value if value is not None else os.environ.get(PEER_TOKENS_ENV, "")
+    if not raw_value:
+        raise FabricError("FABRIC_PRINCIPAL_CONFIG_MISSING", "verified Fabric requires configured coordinator-principal tokens")
+    raw = strict_json_loads(raw_value, maximum=32_000)
+    if not isinstance(raw, dict) or not raw or len(raw) > 32:
+        raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "peer token map is invalid")
+    out: dict[str, str] = {}
+    seen_tokens: set[str] = set()
+    for principal, token in raw.items():
+        principal = _bounded_string(principal, field="coordinator principal", pattern=_PRINCIPAL_RE)
+        if not isinstance(token, str) or len(token) < 16 or len(token.encode("utf-8")) > 1_024:
+            raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "peer bearer token is invalid")
+        if token in seen_tokens:
+            raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "each coordinator principal must have a unique bearer token")
+        out[principal] = token
+        seen_tokens.add(token)
+    return out
+
+
+def _db_path(env_name: str, default_name: str, hermes_root: Path | None = None) -> Path:
+    configured = os.environ.get(env_name, "").strip()
+    path = Path(configured).expanduser() if configured else _root(hermes_root) / "fabric" / default_name
+    if not path.is_absolute() or op.is_denied_path(path) or path.is_symlink():
+        raise FabricError("FABRIC_JOURNAL_PATH_INVALID", "Fabric journal path is not allowed")
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    db = sqlite3.connect(path, timeout=5.0)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("PRAGMA foreign_keys=ON")
+    return db
+
+
+def _init_coordinator_db(path: Path) -> None:
+    with _connect(path) as db:
+        db.executescript("""
+            CREATE TABLE IF NOT EXISTS dispatches (
+              dispatch_id TEXT PRIMARY KEY, task_id TEXT NOT NULL, contract_sha256 TEXT NOT NULL,
+              node_name TEXT NOT NULL, evidence_policy_json TEXT NOT NULL, created_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS dispatches_task_idx ON dispatches(task_id);
+            CREATE TABLE IF NOT EXISTS attempts (
+              attempt_id TEXT PRIMARY KEY, dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+              envelope_sha256 TEXT NOT NULL, node_name TEXT NOT NULL, peer_name TEXT NOT NULL,
+              remote_backend TEXT NOT NULL, coordinator_principal TEXT NOT NULL, capability_sha256 TEXT NOT NULL,
+              peer_policy_sha256 TEXT, state TEXT NOT NULL, remote_task_id TEXT, evidence_json TEXT,
+              error_code TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS attempts_dispatch_idx ON attempts(dispatch_id);
+        """)
+
+
+def _init_peer_db(path: Path) -> None:
+    with _connect(path) as db:
+        db.executescript("""
+            CREATE TABLE IF NOT EXISTS attempts (
+              attempt_id TEXT PRIMARY KEY, dispatch_id TEXT NOT NULL, envelope_sha256 TEXT NOT NULL,
+              contract_sha256 TEXT NOT NULL, task_id TEXT NOT NULL, coordinator_principal TEXT NOT NULL,
+              node_name TEXT NOT NULL, remote_backend TEXT NOT NULL, logical_workspace TEXT NOT NULL,
+              conflict_domain TEXT NOT NULL, authorization_class TEXT NOT NULL, policy_sha256 TEXT NOT NULL,
+              local_task_id TEXT NOT NULL, state TEXT NOT NULL, dispatch_result_json TEXT,
+              created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS write_claims (
+              conflict_domain TEXT PRIMARY KEY, attempt_id TEXT NOT NULL, state TEXT NOT NULL,
+              acquired_at TEXT NOT NULL, released_at TEXT
+            );
+        """)
+
+
+def _is_loopback_url(url: str) -> bool:
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _require_secure_transport(url: str) -> None:
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise FabricError("FABRIC_TRANSPORT_INVALID", "configured Fabric peer URL is invalid")
+    if parsed.username or parsed.password:
+        raise FabricError("FABRIC_TRANSPORT_INVALID", "Fabric peer URL may not contain credentials")
+    if parsed.scheme != "https" and not _is_loopback_url(url):
+        raise FabricError("FABRIC_TRANSPORT_INSECURE", "non-loopback verified Fabric requires HTTPS")
+
+
+def _http_json(url: str, *, headers: dict[str, str], timeout: int, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = canonical_json(body).encode("utf-8") if body is not None else None
+    req_headers = {"Accept": "application/json", **headers}
+    if data is not None:
+        req_headers.update({"Content-Type": "application/json", "A2A-Version": "1.0"})
+    req = urllib.request.Request(url, data=data, headers=req_headers, method="POST" if data is not None else "GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            raw = resp.read(_MAX_BODY + 1)
+    except (TimeoutError, urllib.error.URLError) as exc:
+        reason = getattr(exc, "reason", None)
+        if isinstance(exc, TimeoutError) or isinstance(reason, TimeoutError):
+            raise FabricError("FABRIC_TRANSPORT_TIMEOUT", "Fabric peer request timed out", ambiguous=body is not None) from exc
+        raise FabricError("FABRIC_PEER_UNAVAILABLE", "Fabric peer is unavailable", ambiguous=body is not None) from exc
+    if len(raw) > _MAX_BODY:
+        raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "Fabric peer response exceeds the bounded limit")
+    parsed = strict_json_loads(raw)
+    if not isinstance(parsed, dict):
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric peer returned a non-object response")
+    return parsed
+
+
+def _fabric_card(base_url: str, headers: dict[str, str], timeout: int) -> dict[str, Any]:
+    return _http_json(base_url.rstrip("/") + "/.well-known/agent-card.json", headers=headers, timeout=timeout)
+
+
+def _peer_entry(node: FabricNode) -> dict[str, Any]:
+    peers = op_fleet._a2a_peers_with_resolved_tokens()
+    entry = peers.get(node.a2a_peer_name)
+    if not isinstance(entry, dict):
+        raise FabricError("FABRIC_NODE_NOT_ENROLLED", "managed node has no configured A2A peer")
+    url = entry.get("url")
+    if not isinstance(url, str):
+        raise FabricError("FABRIC_NODE_NOT_ENROLLED", "managed node peer has no configured URL")
+    _require_secure_transport(url)
+    headers = op_fleet._auth_header(entry)
+    if "Authorization" not in headers:
+        raise FabricError("FABRIC_PRINCIPAL_AUTH_REQUIRED", "verified Fabric requires a configured bearer credential")
+    return entry
+
+
+def _extract_data_response(task: Any) -> tuple[str | None, dict[str, Any]]:
+    task_id: str | None = None
+    found: list[dict[str, Any]] = []
+    def walk(node: Any, depth: int = 0) -> None:
+        nonlocal task_id
+        if depth > 10 or len(found) > 8:
+            return
+        if isinstance(node, dict):
+            if task_id is None and isinstance(node.get("id"), str) and _ID_RE.fullmatch(node["id"]):
+                task_id = node["id"]
+            if isinstance(node.get("data"), dict) and node.get("mediaType") == "application/json":
+                found.append(node["data"])
+            for key in ("result", "task", "status", "message", "parts", "artifacts"):
+                if key in node:
+                    walk(node[key], depth + 1)
+        elif isinstance(node, list):
+            for item in node[:_MAX_ITEMS]:
+                walk(item, depth + 1)
+    walk(task)
+    if len(found) != 1:
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric A2A response must contain exactly one structured DataPart")
+    return task_id, found[0]
+
+
+def _validate_response(response: Any, *, operation: str) -> dict[str, Any]:
+    response = _closed(response, required={"schema", "version", "operation", "ok", "code", "data"}, name="Fabric response")
+    if response["schema"] != RESPONSE_SCHEMA or response["version"] != FABRIC_VERSION or response["operation"] != operation:
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric response binding does not match the request")
+    if not isinstance(response["ok"], bool) or not isinstance(response["code"], str) or not isinstance(response["data"], dict):
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric response fields are invalid")
+    return response
+
+
+def _rpc_call(node: FabricNode, request: dict[str, Any], *, timeout: int) -> tuple[str | None, dict[str, Any]]:
+    entry = _peer_entry(node)
+    base_url = str(entry["url"])
+    headers = op_fleet._auth_header(entry)
+    card = _fabric_card(base_url, headers, min(max(timeout, 1), 15))
+    if card.get("name") != node.expected_identity:
+        raise FabricError("FABRIC_PEER_IDENTITY_MISMATCH", "managed peer identity does not match the node registry")
+    rpc_url = base_url.rstrip("/")
+    interfaces = card.get("supportedInterfaces")
+    if isinstance(interfaces, list):
+        for iface in interfaces:
+            if isinstance(iface, dict) and iface.get("protocolBinding") == "JSONRPC" and isinstance(iface.get("url"), str):
+                candidate = iface["url"]
+                _require_secure_transport(candidate)
+                if urllib.parse.urlparse(candidate).hostname != urllib.parse.urlparse(base_url).hostname:
+                    raise FabricError("FABRIC_PEER_IDENTITY_MISMATCH", "Agent Card redirected Fabric to a different host")
+                rpc_url = candidate
+                break
+    req_id = "frpc-" + hashlib.sha256((canonical_json(request) + str(time.time_ns())).encode()).hexdigest()[:20]
+    dispatch_id = str(request.get("dispatch_id") or request.get("request_id") or req_id)
+    body = {"jsonrpc": "2.0", "id": req_id, "method": "SendMessage", "params": {"message": {"role": "ROLE_USER", "parts": [{"data": request, "mediaType": "application/json"}], "messageId": "msg-" + req_id[5:], "contextId": dispatch_id}}}
+    outer = _http_json(rpc_url, headers=headers, timeout=max(1, min(timeout, 120)), body=body)
+    _closed(outer, required={"jsonrpc", "id"}, optional={"result", "error"}, name="A2A JSON-RPC response")
+    if outer.get("jsonrpc") != "2.0" or outer.get("id") != req_id:
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "A2A response identity mismatch")
+    if "error" in outer:
+        error = outer["error"] if isinstance(outer["error"], dict) else {}
+        raise FabricError(str(error.get("data", {}).get("code") or "FABRIC_REMOTE_ERROR"), str(error.get("message") or "Fabric peer rejected the request"))
+    if "result" not in outer:
+        raise FabricError("FABRIC_PROTOCOL_ERROR", "A2A response contains no result")
+    remote_task_id, response = _extract_data_response(outer["result"])
+    return remote_task_id, _validate_response(response, operation=str(request["operation"]))
+
+
+def _evidence_policy(options: dict[str, Any]) -> dict[str, tuple[str, ...]]:
+    raw = options.get("evidence_provenance")
+    if raw is None:
+        return {"run_state": ("managed_peer_structured", "coordinator_observed")}
+    raw = _closed(raw, required={"run_state"}, name="execution.options.evidence_provenance")
+    values = tuple(_bounded_strings(raw["run_state"], field="evidence_provenance.run_state", maximum=8, item_max=64))
+    if not values or any(value not in _SAFE_EVIDENCE_PROVENANCE for value in values):
+        raise FabricError("FABRIC_EVIDENCE_POLICY_INVALID", "run_state evidence provenance is invalid")
+    return {"run_state": values}
+
+
+def _fabric_options(contract: dict[str, Any]) -> tuple[str, str, str, dict[str, Any], dict[str, tuple[str, ...]]]:
+    execution = contract.get("execution")
+    if not isinstance(execution, dict) or execution.get("backend") != "fabric":
+        raise FabricError("FABRIC_EXECUTION_INVALID", "Fabric backend requires execution.backend=fabric")
+    options = execution.get("options")
+    if not isinstance(options, dict):
+        raise FabricError("FABRIC_EXECUTION_INVALID", "Fabric execution options must be an object")
+    allowed = {"node", "remote_backend", "logical_workspace", "remote_options", "evidence_provenance"}
+    if set(options) - allowed:
+        raise FabricError("FABRIC_SCHEMA_INVALID", "Fabric execution options contain unknown fields")
+    node_name = _bounded_string(options.get("node"), field="execution.options.node", pattern=_NODE_RE)
+    remote_backend = _bounded_string(options.get("remote_backend"), field="execution.options.remote_backend", pattern=_BACKEND_RE)
+    if remote_backend in {"fabric", "fleet"}:
+        raise FabricError("FABRIC_EXECUTION_INVALID", "nested Fabric/fleet delegation is not allowed")
+    logical_workspace = _bounded_string(options.get("logical_workspace"), field="execution.options.logical_workspace", maximum=128)
+    remote_options = _bounded_json(options.get("remote_options") or {}, field="execution.options.remote_options")
+    if not isinstance(remote_options, dict):
+        raise FabricError("FABRIC_EXECUTION_INVALID", "remote_options must be an object")
+    return node_name, remote_backend, logical_workspace, remote_options, _evidence_policy(options)
+
+
+def _contract_sha(contract: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(contract).encode("utf-8")).hexdigest()
+
+
+def _dispatch_id(contract_sha: str, task_id: str, node_name: str) -> str:
+    return "fabd-" + hashlib.sha256(f"{contract_sha}:{task_id}:{node_name}".encode()).hexdigest()[:32]
+
+
+def _attempt_id(dispatch_id: str, sequence: int = 1) -> str:
+    return "faba-" + hashlib.sha256(f"{dispatch_id}:{sequence}".encode()).hexdigest()[:32]
+
+
+def _auth_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FabricError("FABRIC_AUTHORITY_DENIED", "authorization must be an object")
+    allowed = {"class", "approved", "approved_by", "approval_reference"}
+    if set(value) - allowed:
+        raise FabricError("FABRIC_AUTHORITY_DENIED", "authorization contains unknown fields")
+    auth_class = value.get("class")
+    if auth_class not in _AUTH_RANK or not isinstance(value.get("approved"), bool):
+        raise FabricError("FABRIC_AUTHORITY_DENIED", "authorization is invalid")
+    out: dict[str, Any] = {"class": auth_class, "approved": value["approved"]}
+    for key in ("approved_by", "approval_reference"):
+        if key in value:
+            out[key] = _bounded_string(value[key], field=f"authorization.{key}", maximum=128)
+    if auth_class == "high_impact" and (not out["approved"] or "approved_by" not in out or "approval_reference" not in out):
+        raise FabricError("FABRIC_AUTHORITY_DENIED", "high-impact authorization requires explicit approval metadata")
+    return out
+
+
+def _build_envelope(contract: dict[str, Any], node: FabricNode, *, remote_backend: str, logical_workspace: str, remote_options: dict[str, Any], evidence_policy: dict[str, tuple[str, ...]], capability_sha: str) -> dict[str, Any]:
+    contract_sha = _contract_sha(contract)
+    task_id = _bounded_string(contract.get("task_id"), field="contract.task_id", pattern=op_fleet._TASK_ID_RE)
+    dispatch_id = _dispatch_id(contract_sha, task_id, node.name)
+    attempt_id = _attempt_id(dispatch_id)
+    envelope = {
+        "schema": DISPATCH_SCHEMA, "version": FABRIC_VERSION, "dispatch_id": dispatch_id, "attempt_id": attempt_id,
+        "contract_sha256": contract_sha, "task_id": task_id, "target_node": node.name,
+        "coordinator_principal": node.coordinator_principal,
+        "assigned_profile": _bounded_string(contract.get("assigned_profile"), field="contract.assigned_profile", pattern=_PROFILE_RE),
+        "objective": _bounded_string(contract.get("objective"), field="contract.objective", maximum=8_000),
+        "inputs": _bounded_strings(contract.get("inputs", []), field="contract.inputs"),
+        "constraints": _bounded_strings(contract.get("constraints", []), field="contract.constraints"),
+        "authorization": _auth_object(contract.get("authorization")), "logical_workspace": logical_workspace,
+        "remote_backend": remote_backend, "remote_options": remote_options,
+        "required_features": list(dict.fromkeys((*_DEFAULT_FEATURES, *node.required_features))),
+        "capability_snapshot_sha256": capability_sha, "evidence_policy": {"run_state": list(evidence_policy["run_state"])},
+        "created_at": _now(),
+    }
+    if len(canonical_json(envelope).encode("utf-8")) > 64_000:
+        raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "canonical Fabric dispatch envelope exceeds 64 KB")
+    return envelope
+
+
+def _validate_envelope(value: Any) -> dict[str, Any]:
+    required = {"schema", "version", "dispatch_id", "attempt_id", "contract_sha256", "task_id", "target_node", "coordinator_principal", "assigned_profile", "objective", "inputs", "constraints", "authorization", "logical_workspace", "remote_backend", "remote_options", "required_features", "capability_snapshot_sha256", "evidence_policy", "created_at"}
+    env = _closed(value, required=required, name="Fabric dispatch envelope")
+    if env["schema"] != DISPATCH_SCHEMA or env["version"] != FABRIC_VERSION:
+        raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "Fabric dispatch schema/version is unsupported")
+    _bounded_string(env["dispatch_id"], field="dispatch_id", pattern=_ID_RE)
+    _bounded_string(env["attempt_id"], field="attempt_id", pattern=_ID_RE)
+    _bounded_string(env["contract_sha256"], field="contract_sha256", pattern=_SHA_RE)
+    _bounded_string(env["task_id"], field="task_id", pattern=op_fleet._TASK_ID_RE)
+    _bounded_string(env["target_node"], field="target_node", pattern=_NODE_RE)
+    _bounded_string(env["coordinator_principal"], field="coordinator_principal", pattern=_PRINCIPAL_RE)
+    _bounded_string(env["assigned_profile"], field="assigned_profile", pattern=_PROFILE_RE)
+    _bounded_string(env["objective"], field="objective", maximum=8_000)
+    _bounded_strings(env["inputs"], field="inputs")
+    _bounded_strings(env["constraints"], field="constraints")
+    _auth_object(env["authorization"])
+    _bounded_string(env["logical_workspace"], field="logical_workspace", maximum=128)
+    backend = _bounded_string(env["remote_backend"], field="remote_backend", pattern=_BACKEND_RE)
+    if backend in {"fabric", "fleet"}:
+        raise FabricError("FABRIC_EXECUTION_INVALID", "nested Fabric/fleet delegation is not allowed")
+    _bounded_json(env["remote_options"], field="remote_options")
+    _bounded_strings(env["required_features"], field="required_features", maximum=32, item_max=128)
+    _bounded_string(env["capability_snapshot_sha256"], field="capability_snapshot_sha256", pattern=_SHA_RE)
+    evidence_policy = _closed(env["evidence_policy"], required={"run_state"}, name="evidence_policy")
+    provenance = _bounded_strings(evidence_policy["run_state"], field="evidence_policy.run_state", maximum=8, item_max=64)
+    if not provenance or any(item not in _SAFE_EVIDENCE_PROVENANCE for item in provenance):
+        raise FabricError("FABRIC_EVIDENCE_POLICY_INVALID", "Fabric run-state evidence policy is invalid")
+    _bounded_string(env["created_at"], field="created_at", maximum=128)
+    return env
+
+
+def _request(operation: str, principal: str, *, data: dict[str, Any], dispatch_id: str = "", attempt_id: str = "") -> dict[str, Any]:
+    request = {"schema": REQUEST_SCHEMA, "version": FABRIC_VERSION, "operation": operation, "coordinator_principal": principal, "request_id": "freq-" + hashlib.sha256(f"{operation}:{dispatch_id}:{attempt_id}:{time.time_ns()}".encode()).hexdigest()[:24], "data": data}
+    if dispatch_id:
+        request["dispatch_id"] = dispatch_id
+    if attempt_id:
+        request["attempt_id"] = attempt_id
+    return request
+
+
+def _validate_request(value: Any) -> dict[str, Any]:
+    request = _closed(value, required={"schema", "version", "operation", "coordinator_principal", "request_id", "data"}, optional={"dispatch_id", "attempt_id"}, name="Fabric request")
+    if request["schema"] != REQUEST_SCHEMA or request["version"] != FABRIC_VERSION:
+        raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "Fabric request schema/version is unsupported")
+    operation = _bounded_string(request["operation"], field="operation", maximum=32)
+    if operation not in {"capabilities", "accept", "status", "reconcile", "cancel", "evidence"}:
+        raise FabricError("FABRIC_OPERATION_UNSUPPORTED", "Fabric operation is unsupported")
+    _bounded_string(request["coordinator_principal"], field="coordinator_principal", pattern=_PRINCIPAL_RE)
+    _bounded_string(request["request_id"], field="request_id", pattern=_ID_RE)
+    if "dispatch_id" in request:
+        _bounded_string(request["dispatch_id"], field="dispatch_id", pattern=_ID_RE)
+    if "attempt_id" in request:
+        _bounded_string(request["attempt_id"], field="attempt_id", pattern=_ID_RE)
+    if not isinstance(request["data"], dict):
+        raise FabricError("FABRIC_SCHEMA_INVALID", "Fabric request data must be an object")
+    return request
+
+
+def _response(operation: str, *, ok: bool, code: str, data: dict[str, Any]) -> dict[str, Any]:
+    return {"schema": RESPONSE_SCHEMA, "version": FABRIC_VERSION, "operation": operation, "ok": ok, "code": code, "data": data}
+
+
+def _audit(tool: str, *, success: bool, changed: bool, summary: str, extra: dict[str, Any]) -> None:
+    try:
+        policy = op.OperatorPolicy()
+        op.audit_record(tool=tool, level=policy.level or "read_only", apply_mode=policy.apply_mode, dry_run=not changed, success=success, changed=changed, summary=summary[:500], extra=extra)
+    except Exception:
+        pass
+
+
+class FabricPeerService:
+    """Deterministic managed peer acceptor. No request reaches an LLM path."""
+    def __init__(self, *, policy_loader: Callable[[], FabricPeerPolicy] | None = None, tokens: dict[str, str] | None = None, db_path: Path | None = None, dispatch_fn: Callable[..., dict[str, Any]] | None = None, observed_fn: Callable[[str], list[dict[str, Any]]] | None = None, cancel_fn: Callable[[str, str], dict[str, Any]] | None = None, hermes_root: Path | None = None):
+        self.hermes_root = hermes_root
+        self.policy_loader = policy_loader or (lambda: load_peer_policy(hermes_root=hermes_root))
+        self.tokens = tokens or load_peer_tokens()
+        self.db_path = db_path or _db_path(PEER_DB_ENV, "peer.db", hermes_root)
+        _init_peer_db(self.db_path)
+        self.dispatch_fn = dispatch_fn or self._dispatch_local
+        self.observed_fn = observed_fn or (lambda task_id: op_runners.observed_runs(task_id, hermes_root=hermes_root))
+        self.cancel_fn = cancel_fn or self._cancel_local
+        self._lock = threading.RLock()
+
+    def _dispatch_local(self, contract: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        return op_runners.dispatch_contract(contract, confirm=True, dry_run=False, timeout=int(kwargs.get("timeout", 30)), hermes_root=self.hermes_root)
+
+    def _cancel_local(self, backend: str, task_id: str) -> dict[str, Any]:
+        return op_runners.get_backend(backend).cancel(task_id, hermes_root=self.hermes_root)
+
+    def authenticate(self, authorization: str) -> str:
+        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_REQUIRED", "verified Fabric requires bearer authentication")
+        presented = authorization[7:]
+        matches = [principal for principal, token in self.tokens.items() if hmac.compare_digest(token, presented)]
+        if len(matches) != 1:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "coordinator principal authentication failed")
+        return matches[0]
+
+    def capabilities(self, policy: FabricPeerPolicy) -> dict[str, Any]:
+        payload = {"schema": CAPABILITY_SCHEMA, "version": FABRIC_VERSION, "node_name": policy.node_name, "identity": policy.identity, "features": list(dict.fromkeys((*_DEFAULT_FEATURES, *policy.required_features))), "operations": ["capabilities", "accept", "status", "reconcile", "cancel", "evidence"], "policy_sha256": policy.digest}
+        payload["snapshot_sha256"] = sha256_json(payload)
+        return payload
+
+    def handle(self, request_value: dict[str, Any], authorization: str) -> dict[str, Any]:
+        request = _validate_request(request_value)
+        principal = self.authenticate(authorization)
+        if principal != request["coordinator_principal"]:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "authenticated principal does not match the request")
+        policy = self.policy_loader()
+        if principal not in policy.allowed_coordinator_principals:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "coordinator principal is not authorized by peer policy")
+        operation = request["operation"]
+        if operation == "capabilities":
+            _closed(request["data"], required=set(), name="capabilities data")
+            return _response(operation, ok=True, code="FABRIC_OK", data=self.capabilities(policy))
+        if operation == "accept":
+            return self._accept(request, principal, policy)
+        _closed(request["data"], required=set(), name=f"{operation} data")
+        dispatch_id = _bounded_string(request.get("dispatch_id"), field="dispatch_id", pattern=_ID_RE)
+        attempt_id = _bounded_string(request.get("attempt_id"), field="attempt_id", pattern=_ID_RE)
+        if operation == "status":
+            data = self._status(dispatch_id, attempt_id, reconcile=False)
+        elif operation == "reconcile":
+            data = self._status(dispatch_id, attempt_id, reconcile=True)
+        elif operation == "cancel":
+            data = self._cancel(dispatch_id, attempt_id, principal, policy)
+        elif operation == "evidence":
+            data = self._evidence(dispatch_id, attempt_id, principal, policy)
+        else:
+            raise FabricError("FABRIC_OPERATION_UNSUPPORTED", "unsupported Fabric operation")
+        return _response(operation, ok=True, code="FABRIC_OK", data=data)
+
+    def _authorize_envelope(self, env: dict[str, Any], principal: str, policy: FabricPeerPolicy) -> WorkspaceMapping:
+        if env["coordinator_principal"] != principal:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "dispatch principal mismatch")
+        if env["target_node"] != policy.node_name:
+            raise FabricError("FABRIC_NODE_IDENTITY_MISMATCH", "dispatch targets a different managed node")
+        if env["assigned_profile"] not in policy.allowed_profiles:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "assigned profile is outside peer policy")
+        auth = _auth_object(env["authorization"])
+        if _AUTH_RANK[auth["class"]] > _AUTH_RANK[policy.max_authorization]:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "dispatch exceeds peer authorization ceiling")
+        if env["remote_backend"] not in policy.allowed_backends:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "remote backend is outside peer policy")
+        mapping = policy.workspace_mappings.get(env["logical_workspace"])
+        if mapping is None:
+            raise FabricError("FABRIC_WORKSPACE_DENIED", "logical workspace is not mapped on the peer")
+        if not set(env["required_features"]) <= set((*_DEFAULT_FEATURES, *policy.required_features)):
+            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "peer does not support all required Fabric features")
+        return mapping
+
+    def _local_contract(self, env: dict[str, Any], mapping: WorkspaceMapping) -> dict[str, Any]:
+        return {"schema": "hermes.work-contract/v1", "task_id": env["attempt_id"], "objective": env["objective"], "assigned_agent": env["target_node"], "assigned_profile": env["assigned_profile"], "inputs": list(env["inputs"]), "constraints": list(env["constraints"]), "allowed_scope": {"workspaces": [str(mapping.local_path)], "profiles": [env["assigned_profile"]]}, "forbidden_actions": [], "expected_artifacts": [], "tests": [], "review_requirements": {"required": False, "reviewer": "", "evidence": "", "approval_required": False}, "completion_criteria": {"run_state": {"terminal": True, "outcome_ok": ["completed"]}, "artifacts_present": False, "tests_pass": False, "review_satisfied": False, "no_forbidden_actions": True}, "authorization": dict(env["authorization"]), "execution": {"backend": env["remote_backend"], "options": _bounded_json(env["remote_options"], field="remote_options")}}
+
+    def _accept(self, request: dict[str, Any], principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+        data = _closed(request["data"], required={"envelope"}, name="accept data")
+        env = _validate_envelope(data["envelope"])
+        if request.get("dispatch_id") and request["dispatch_id"] != env["dispatch_id"]:
+            raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "request and envelope dispatch identity differ")
+        if request.get("attempt_id") and request["attempt_id"] != env["attempt_id"]:
+            raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "request and envelope attempt identity differ")
+        mapping = self._authorize_envelope(env, principal, policy)
+        envelope_sha = sha256_json(env)
+        now = _now()
+        with self._lock, _connect(self.db_path) as db:
+            existing = db.execute("SELECT * FROM attempts WHERE attempt_id=?", (env["attempt_id"],)).fetchone()
+            if existing is not None:
+                if existing["dispatch_id"] != env["dispatch_id"] or existing["envelope_sha256"] != envelope_sha:
+                    raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "attempt identity was reused with different canonical content")
+                return _response("accept", ok=True, code="FABRIC_IDEMPOTENT_REPLAY", data={"dispatch_id": existing["dispatch_id"], "attempt_id": existing["attempt_id"], "state": existing["state"], "local_task_id": existing["local_task_id"], "policy_sha256": existing["policy_sha256"]})
+            auth_class = env["authorization"]["class"]
+            if _AUTH_RANK[auth_class] >= _AUTH_RANK["reversible_write"]:
+                claim = db.execute("SELECT * FROM write_claims WHERE conflict_domain=?", (mapping.conflict_domain,)).fetchone()
+                if claim is not None and claim["state"] == "ACTIVE":
+                    raise FabricError("FABRIC_WRITE_OWNERSHIP_BLOCKED", "peer write conflict domain already has an active claim")
+                db.execute("INSERT OR REPLACE INTO write_claims(conflict_domain, attempt_id, state, acquired_at, released_at) VALUES(?,?,?,?,NULL)", (mapping.conflict_domain, env["attempt_id"], "ACTIVE", now))
+            db.execute("INSERT INTO attempts(attempt_id,dispatch_id,envelope_sha256,contract_sha256,task_id,coordinator_principal,node_name,remote_backend,logical_workspace,conflict_domain,authorization_class,policy_sha256,local_task_id,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (env["attempt_id"], env["dispatch_id"], envelope_sha, env["contract_sha256"], env["task_id"], principal, policy.node_name, env["remote_backend"], env["logical_workspace"], mapping.conflict_domain, auth_class, policy.digest, env["attempt_id"], "ACCEPTED", now, now))
+        prestart = self.policy_loader()
+        prestart_mapping = self._authorize_envelope(env, principal, prestart)
+        if prestart_mapping.local_path != mapping.local_path or prestart_mapping.revision != mapping.revision or prestart_mapping.conflict_domain != mapping.conflict_domain:
+            with _connect(self.db_path) as db:
+                db.execute("UPDATE attempts SET state=?, policy_sha256=?, updated_at=? WHERE attempt_id=?", ("BLOCKED", prestart.digest, _now(), env["attempt_id"]))
+            raise FabricError("FABRIC_POLICY_DRIFT", "peer workspace policy changed between acceptance and runner start")
+        local_contract = self._local_contract(env, prestart_mapping)
+        try:
+            backend = op_runners.get_backend(env["remote_backend"])
+            if not bool(backend.availability(hermes_root=self.hermes_root).get("available")):
+                raise FabricError("FABRIC_RUNNER_UNAVAILABLE", "remote runner is unavailable at pre-start revalidation")
+        except LookupError as exc:
+            raise FabricError("FABRIC_RUNNER_UNAVAILABLE", "remote runner is not registered") from exc
+        result = self.dispatch_fn(local_contract, timeout=30)
+        if not isinstance(result, dict):
+            result = {"success": False, "code": "FABRIC_RUNNER_INVALID_RESULT"}
+        state = "RUNNING" if bool(result.get("success")) else "FAILED"
+        with _connect(self.db_path) as db:
+            db.execute("UPDATE attempts SET state=?, dispatch_result_json=?, policy_sha256=?, updated_at=? WHERE attempt_id=?", (state, canonical_json(_bounded_json(result, field="dispatch_result")), prestart.digest, _now(), env["attempt_id"]))
+        _audit("hermes_fabric_peer_accept", success=bool(result.get("success")), changed=bool(result.get("success")), summary=f"Fabric attempt accepted on {policy.node_name}", extra={"dispatch_id": env["dispatch_id"], "attempt_id": env["attempt_id"], "task_id": env["task_id"], "backend": env["remote_backend"], "principal": principal, "policy_sha256": prestart.digest})
+        return _response("accept", ok=bool(result.get("success")), code="FABRIC_ACCEPTED" if result.get("success") else str(result.get("code") or "FABRIC_RUNNER_REJECTED"), data={"dispatch_id": env["dispatch_id"], "attempt_id": env["attempt_id"], "state": state, "local_task_id": env["attempt_id"], "policy_sha256": prestart.digest})
+
+    def _row(self, dispatch_id: str, attempt_id: str) -> sqlite3.Row:
+        with _connect(self.db_path) as db:
+            row = db.execute("SELECT * FROM attempts WHERE attempt_id=? AND dispatch_id=?", (attempt_id, dispatch_id)).fetchone()
+        if row is None:
+            raise FabricError("FABRIC_ATTEMPT_NOT_FOUND", "Fabric attempt is not present in the peer journal")
+        return row
+
+    def _status(self, dispatch_id: str, attempt_id: str, *, reconcile: bool) -> dict[str, Any]:
+        row = self._row(dispatch_id, attempt_id)
+        if row["state"] in _TERMINAL_PEER:
+            return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": row["state"], "local_task_id": row["local_task_id"], "policy_sha256": row["policy_sha256"]}
+        primary = _latest_run(self.observed_fn(row["local_task_id"]))
+        state = row["state"]
+        if primary is not None:
+            run_state = str(primary.get("state") or primary.get("status") or "").lower()
+            if run_state in {"completed", "succeeded", "success"}: state = "SUCCEEDED"
+            elif run_state in {"failed", "error"}: state = "FAILED"
+            elif run_state in {"cancelled", "canceled"}: state = "CANCELLED"
+            else: state = "RUNNING"
+        elif reconcile and state in {"ACCEPTED", "RUNNING", "CANCEL_REQUESTED"}:
+            state = "LOST_AMBIGUOUS"
+        with _connect(self.db_path) as db:
+            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
+        return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "local_task_id": row["local_task_id"], "policy_sha256": row["policy_sha256"]}
+
+    def _cancel(self, dispatch_id: str, attempt_id: str, principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+        row = self._row(dispatch_id, attempt_id)
+        if row["coordinator_principal"] != principal or row["node_name"] != policy.node_name:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "cancel identity does not match accepted attempt")
+        if row["state"] in _TERMINAL_PEER:
+            return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": row["state"], "idempotent": True}
+        with _connect(self.db_path) as db:
+            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", ("CANCEL_REQUESTED", _now(), attempt_id))
+        result = self.cancel_fn(row["remote_backend"], row["local_task_id"])
+        state = "CANCELLED" if bool(result.get("success")) and str(result.get("state") or "").lower() in {"cancelled", "canceled"} else "CANCEL_REQUESTED"
+        with _connect(self.db_path) as db:
+            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
+        return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "changed": bool(result.get("changed"))}
+
+    def _evidence(self, dispatch_id: str, attempt_id: str, principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+        status = self._status(dispatch_id, attempt_id, reconcile=False)
+        row = self._row(dispatch_id, attempt_id)
+        if row["coordinator_principal"] != principal or row["node_name"] != policy.node_name:
+            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "evidence identity does not match accepted attempt")
+        if status["state"] not in {"SUCCEEDED", "FAILED", "CANCELLED"}:
+            raise FabricError("FABRIC_EVIDENCE_NOT_READY", "terminal remote execution evidence is not available")
+        primary = _latest_run(self.observed_fn(row["local_task_id"]))
+        observations: list[dict[str, Any]] = []
+        if primary is not None:
+            observations.append({"kind": "run_state", "provenance": "managed_peer_structured", "state": str(primary.get("status") or primary.get("state") or ""), "outcome": str(primary.get("outcome") or primary.get("state") or primary.get("status") or ""), "started_at": str(primary.get("started_at") or primary.get("dispatched_at") or ""), "ended_at": str(primary.get("ended_at") or primary.get("completed_at") or ""), "error": op.redact_output(str(primary.get("error") or ""))[:1_000], "source": f"runner:{row['remote_backend']}"})
+        evidence = {"schema": EVIDENCE_SCHEMA, "version": FABRIC_VERSION, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "contract_sha256": row["contract_sha256"], "task_id": row["task_id"], "node_name": row["node_name"], "peer_identity": policy.identity, "coordinator_principal": principal, "remote_backend": row["remote_backend"], "terminal_state": status["state"], "observations": observations, "policy_sha256": row["policy_sha256"], "created_at": _now()}
+        return {"evidence": evidence}
+
+
+def _latest_run(runs: Any) -> dict[str, Any] | None:
+    if not isinstance(runs, list): return None
+    candidates = [run for run in runs if isinstance(run, dict)]
+    if not candidates: return None
+    return max(candidates, key=lambda run: (str(run.get("started_at") or run.get("dispatched_at") or ""), str(run.get("ended_at") or run.get("completed_at") or ""), str(run.get("status") or run.get("state") or "")))
+
+
+def _validate_evidence(value: Any, *, attempt: Any, node: FabricNode, allowed_provenance: tuple[str, ...]) -> dict[str, Any]:
+    required = {"schema", "version", "dispatch_id", "attempt_id", "contract_sha256", "task_id", "node_name", "peer_identity", "coordinator_principal", "remote_backend", "terminal_state", "observations", "policy_sha256", "created_at"}
+    evidence = _closed(value, required=required, name="Fabric evidence")
+    if evidence["schema"] != EVIDENCE_SCHEMA or evidence["version"] != FABRIC_VERSION:
+        raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence schema/version is invalid")
+    exact = {"dispatch_id": attempt["dispatch_id"], "attempt_id": attempt["attempt_id"], "node_name": node.name, "peer_identity": node.expected_identity, "coordinator_principal": node.coordinator_principal, "remote_backend": attempt["remote_backend"]}
+    for key, expected in exact.items():
+        if evidence.get(key) != expected:
+            raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", f"evidence {key} does not match the admitted attempt")
+    with _connect(Path(attempt["_coordinator_db"])) as db:
+        dispatch = db.execute("SELECT * FROM dispatches WHERE dispatch_id=?", (attempt["dispatch_id"],)).fetchone()
+    if dispatch is None or evidence.get("contract_sha256") != dispatch["contract_sha256"] or evidence.get("task_id") != dispatch["task_id"]:
+        raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", "evidence contract/task lineage does not match")
+    if attempt.get("peer_policy_sha256") and evidence.get("policy_sha256") != attempt.get("peer_policy_sha256"):
+        raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", "evidence peer policy digest does not match accepted attempt")
+    if evidence["terminal_state"] not in {"SUCCEEDED", "FAILED", "CANCELLED"}:
+        raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence is not terminal")
+    observations = evidence["observations"]
+    if not isinstance(observations, list) or len(observations) > _MAX_ITEMS:
+        raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence observations are invalid")
+    clean: list[dict[str, Any]] = []
+    for observation in observations:
+        observation = _closed(observation, required={"kind", "provenance", "state", "outcome", "started_at", "ended_at", "error", "source"}, name="evidence observation")
+        if observation["kind"] != "run_state":
+            raise FabricError("FABRIC_EVIDENCE_REJECTED", "G4-A accepts only run_state remote observations")
+        provenance = _bounded_string(observation["provenance"], field="observation.provenance", maximum=64)
+        if provenance not in allowed_provenance or provenance == "worker_statement":
+            raise FabricError("FABRIC_EVIDENCE_PROVENANCE_REJECTED", "evidence provenance is not allowed for the check")
+        clean.append({key: (_bounded_string(observation[key], field=f"observation.{key}", maximum=1_000, required=False) if key not in {"provenance", "kind"} else observation[key]) for key in observation})
+    evidence = dict(evidence); evidence["observations"] = clean
+    return evidence
+
+
+class FabricCoordinator:
+    def __init__(self, *, registry_loader: Callable[[], dict[str, FabricNode]] | None = None, db_path: Path | None = None, rpc: Callable[[FabricNode, dict[str, Any], int], tuple[str | None, dict[str, Any]]] | None = None, hermes_root: Path | None = None):
+        self.hermes_root = hermes_root
+        self.registry_loader = registry_loader or (lambda: load_node_registry(hermes_root=hermes_root))
+        self.db_path = db_path or _db_path(COORDINATOR_DB_ENV, "coordinator.db", hermes_root)
+        _init_coordinator_db(self.db_path)
+        self.rpc = rpc or (lambda node, request, timeout: _rpc_call(node, request, timeout=timeout))
+        self._lock = threading.RLock()
+
+    def _node(self, name: str) -> FabricNode:
+        node = self.registry_loader().get(name)
+        if node is None or not node.enabled:
+            raise FabricError("FABRIC_NODE_NOT_ENROLLED", "Fabric node is not enrolled/enabled")
+        return node
+
+    def _capabilities(self, node: FabricNode, timeout: int) -> dict[str, Any]:
+        _, response = self.rpc(node, _request("capabilities", node.coordinator_principal, data={}), timeout)
+        response = _validate_response(response, operation="capabilities")
+        if not response["ok"]:
+            raise FabricError(response["code"], "Fabric capability negotiation failed")
+        data = _closed(response["data"], required={"schema", "version", "node_name", "identity", "features", "operations", "policy_sha256", "snapshot_sha256"}, name="capability response")
+        if data["schema"] != CAPABILITY_SCHEMA or data["version"] != FABRIC_VERSION or data["node_name"] != node.name or data["identity"] != node.expected_identity:
+            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "managed peer capability identity/version is incompatible")
+        features = set(_bounded_strings(data["features"], field="capability.features", maximum=32, item_max=128))
+        if not set((*_DEFAULT_FEATURES, *node.required_features)) <= features:
+            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "managed peer lacks required Fabric features")
+        if data["snapshot_sha256"] != sha256_json({key: data[key] for key in data if key != "snapshot_sha256"}):
+            raise FabricError("FABRIC_PROTOCOL_ERROR", "capability snapshot digest is invalid")
+        return data
+
+    def dispatch(self, contract: dict[str, Any], *, dry_run: bool, confirm: bool, timeout: int) -> dict[str, Any]:
+        node_name, remote_backend, logical_workspace, remote_options, evidence_policy = _fabric_options(contract)
+        node = self._node(node_name)
+        if contract.get("assigned_agent") != node.name:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "Fabric contract assigned_agent must match the managed node name")
+        if contract.get("assigned_profile") not in node.allowed_profiles:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "contract profile is outside managed-node policy")
+        auth = _auth_object(contract.get("authorization"))
+        if _AUTH_RANK[auth["class"]] > _AUTH_RANK[node.max_authorization]:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "contract authorization exceeds managed-node ceiling")
+        if remote_backend not in node.allowed_remote_backends:
+            raise FabricError("FABRIC_AUTHORITY_DENIED", "remote backend is outside managed-node policy")
+        if logical_workspace not in node.logical_workspaces:
+            raise FabricError("FABRIC_WORKSPACE_DENIED", "logical workspace is outside managed-node policy")
+        contract_sha = _contract_sha(contract); stable_dispatch_id = _dispatch_id(contract_sha, str(contract["task_id"]), node.name)
+        if dry_run:
+            return {"success": True, "dry_run": True, "changed": False, "backend": "fabric", "node": node.name, "dispatch_id": stable_dispatch_id, "remote_backend": remote_backend, "logical_workspace": logical_workspace, "live_peer_verification": "required_before_dispatch"}
+        if not confirm:
+            raise FabricError("CONFIRMATION_REQUIRED", "Fabric dispatch requires confirm=true")
+        with _connect(self.db_path) as db:
+            existing = db.execute("SELECT a.* FROM attempts a WHERE a.dispatch_id=? ORDER BY a.created_at LIMIT 1", (stable_dispatch_id,)).fetchone()
+        if existing is not None:
+            return {"success": existing["state"] in {"SUBMITTED", "RUNNING", "TERMINAL_REPORTED", "COMPLETED"}, "changed": False, "backend": "fabric", "node": node.name, "dispatch_id": stable_dispatch_id, "attempt_id": existing["attempt_id"], "state": existing["state"], "remote_task_id": existing["remote_task_id"], "idempotent": True}
+        capabilities = self._capabilities(node, timeout)
+        envelope = _build_envelope(contract, node, remote_backend=remote_backend, logical_workspace=logical_workspace, remote_options=remote_options, evidence_policy=evidence_policy, capability_sha=capabilities["snapshot_sha256"])
+        envelope_sha = sha256_json(envelope); dispatch_id = envelope["dispatch_id"]; attempt_id = envelope["attempt_id"]; now = _now()
+        with self._lock, _connect(self.db_path) as db:
+            db.execute("INSERT OR IGNORE INTO dispatches(dispatch_id,task_id,contract_sha256,node_name,evidence_policy_json,created_at) VALUES(?,?,?,?,?,?)", (dispatch_id, envelope["task_id"], envelope["contract_sha256"], node.name, canonical_json({k: list(v) for k, v in evidence_policy.items()}), now))
+            db.execute("INSERT OR REPLACE INTO attempts(attempt_id,dispatch_id,envelope_sha256,node_name,peer_name,remote_backend,coordinator_principal,capability_sha256,peer_policy_sha256,state,remote_task_id,evidence_json,error_code,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,NULL,?,NULL,NULL,NULL,?,?)", (attempt_id, dispatch_id, envelope_sha, node.name, node.a2a_peer_name, remote_backend, node.coordinator_principal, capabilities["snapshot_sha256"], "SUBMITTING", now, now))
+        request = _request("accept", node.coordinator_principal, data={"envelope": envelope}, dispatch_id=dispatch_id, attempt_id=attempt_id)
+        try:
+            remote_task_id, response = self.rpc(node, request, timeout)
+        except FabricError as exc:
+            state = "SUBMISSION_AMBIGUOUS" if exc.ambiguous else "BLOCKED"
+            with _connect(self.db_path) as db:
+                db.execute("UPDATE attempts SET state=?, error_code=?, updated_at=? WHERE attempt_id=?", (state, exc.code, _now(), attempt_id))
+            _audit("hermes_fabric_dispatch", success=False, changed=exc.ambiguous, summary="Fabric dispatch ambiguous" if exc.ambiguous else "Fabric dispatch failed", extra={"dispatch_id": dispatch_id, "attempt_id": attempt_id, "node": node.name, "code": exc.code, "principal": node.coordinator_principal})
+            if exc.ambiguous:
+                return {"success": False, "changed": True, "backend": "fabric", "code": exc.code, "node": node.name, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "submission_may_have_succeeded": True, "suggested_action": "Reconcile this Fabric attempt; do not create a replacement writer."}
+            raise
+        response = _validate_response(response, operation="accept"); data = response["data"]
+        if data.get("dispatch_id") != dispatch_id or data.get("attempt_id") != attempt_id:
+            raise FabricError("FABRIC_PROTOCOL_ERROR", "peer accept response lineage mismatch")
+        state = "SUBMITTED" if response["ok"] else "BLOCKED"
+        with _connect(self.db_path) as db:
+            db.execute("UPDATE attempts SET state=?, remote_task_id=?, peer_policy_sha256=?, error_code=?, updated_at=? WHERE attempt_id=?", (state, remote_task_id, data.get("policy_sha256"), None if response["ok"] else response["code"], _now(), attempt_id))
+        _audit("hermes_fabric_dispatch", success=response["ok"], changed=response["ok"], summary=f"Fabric attempt submitted to {node.name}", extra={"dispatch_id": dispatch_id, "attempt_id": attempt_id, "task_id": envelope["task_id"], "node": node.name, "remote_backend": remote_backend, "principal": node.coordinator_principal, "remote_task_id": remote_task_id or ""})
+        return {"success": response["ok"], "changed": response["ok"], "backend": "fabric", "node": node.name, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "remote_task_id": remote_task_id, "state": state, "code": response["code"]}
+
+    def _attempt(self, attempt_id: str) -> tuple[sqlite3.Row, sqlite3.Row, FabricNode]:
+        with _connect(self.db_path) as db:
+            attempt = db.execute("SELECT * FROM attempts WHERE attempt_id=?", (attempt_id,)).fetchone()
+            if attempt is None: raise FabricError("FABRIC_ATTEMPT_NOT_FOUND", "coordinator Fabric attempt does not exist")
+            dispatch = db.execute("SELECT * FROM dispatches WHERE dispatch_id=?", (attempt["dispatch_id"],)).fetchone()
+        if dispatch is None: raise FabricError("FABRIC_JOURNAL_CORRUPT", "coordinator dispatch lineage is missing")
+        return attempt, dispatch, self._node(attempt["node_name"])
+
+    def poll(self, attempt_id: str, *, reconcile: bool = False, timeout: int = 15) -> dict[str, Any]:
+        attempt, dispatch, node = self._attempt(attempt_id); operation = "reconcile" if reconcile else "status"
+        _, response = self.rpc(node, _request(operation, node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
+        response = _validate_response(response, operation=operation); data = response["data"]
+        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id: raise FabricError("FABRIC_PROTOCOL_ERROR", "peer status lineage mismatch")
+        peer_state = str(data.get("state") or "")
+        state = {"ACCEPTED":"SUBMITTED","RUNNING":"RUNNING","CANCEL_REQUESTED":"CANCEL_REQUESTED","SUCCEEDED":"TERMINAL_REPORTED","FAILED":"TERMINAL_REPORTED","CANCELLED":"CANCELLED","LOST_AMBIGUOUS":"BLOCKED","BLOCKED":"BLOCKED"}.get(peer_state,"BLOCKED")
+        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
+        return {"success": True, "backend": "fabric", "node": node.name, "dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "state": state, "peer_state": peer_state, "task_id": dispatch["task_id"]}
+
+    def collect(self, attempt_id: str, *, timeout: int = 15) -> dict[str, Any]:
+        attempt, dispatch, node = self._attempt(attempt_id)
+        _, response = self.rpc(node, _request("evidence", node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
+        response = _validate_response(response, operation="evidence")
+        if not response["ok"]: raise FabricError(response["code"], "peer did not return admissible evidence")
+        data = _closed(response["data"], required={"evidence"}, name="evidence response")
+        policy_raw = strict_json_loads(dispatch["evidence_policy_json"], maximum=16_000); allowed = tuple(policy_raw.get("run_state") or []) if isinstance(policy_raw, dict) else ()
+        attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(self.db_path)
+        admitted = _validate_evidence(data["evidence"], attempt=attempt_map, node=node, allowed_provenance=allowed)
+        terminal = admitted["terminal_state"]; state = "COMPLETED" if terminal == "SUCCEEDED" else "FAILED" if terminal == "FAILED" else "CANCELLED"
+        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, evidence_json=?, updated_at=? WHERE attempt_id=?", (state, canonical_json(admitted), _now(), attempt_id))
+        _audit("hermes_fabric_evidence", success=True, changed=False, summary=f"Fabric evidence admitted from {node.name}", extra={"dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "task_id": dispatch["task_id"], "node": node.name, "principal": node.coordinator_principal, "terminal_state": terminal})
+        return {"success": True, "backend": "fabric", "node": node.name, "dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "state": state, "evidence": admitted}
+
+    def cancel(self, attempt_id: str, *, timeout: int = 15) -> dict[str, Any]:
+        attempt, dispatch, node = self._attempt(attempt_id)
+        _, response = self.rpc(node, _request("cancel", node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
+        response = _validate_response(response, operation="cancel"); data=response["data"]
+        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id: raise FabricError("FABRIC_PROTOCOL_ERROR", "peer cancel lineage mismatch")
+        state = "CANCELLED" if data.get("state") == "CANCELLED" else "CANCEL_REQUESTED"
+        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
+        return {"success": True, "changed": bool(data.get("changed")), "backend": "fabric", "attempt_id": attempt_id, "dispatch_id": attempt["dispatch_id"], "task_id": dispatch["task_id"], "state": state}
+
+    def observed_runs(self, task_id: str, *, refresh: bool = True) -> list[dict[str, Any]]:
+        with _connect(self.db_path) as db: rows = db.execute("SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id WHERE d.task_id=? ORDER BY a.created_at", (task_id,)).fetchall()
+        if refresh:
+            for row in rows:
+                try:
+                    if row["state"] not in _TERMINAL_COORD:
+                        status = self.poll(row["attempt_id"], reconcile=row["state"] == "SUBMISSION_AMBIGUOUS", timeout=10)
+                        if status["state"] == "TERMINAL_REPORTED": self.collect(row["attempt_id"], timeout=10)
+                    elif row["state"] in {"COMPLETED", "FAILED", "CANCELLED"} and not row["evidence_json"]: self.collect(row["attempt_id"], timeout=10)
+                except FabricError: continue
+            with _connect(self.db_path) as db: rows = db.execute("SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id WHERE d.task_id=? ORDER BY a.created_at", (task_id,)).fetchall()
+        out=[]
+        for row in rows:
+            if not row["evidence_json"]: continue
+            try: evidence = strict_json_loads(row["evidence_json"], maximum=_MAX_BODY)
+            except FabricError: continue
+            for observation in evidence.get("observations", []) if isinstance(evidence, dict) else []:
+                if not isinstance(observation, dict) or observation.get("kind") != "run_state" or observation.get("provenance") not in _SAFE_EVIDENCE_PROVENANCE: continue
+                terminal=evidence.get("terminal_state"); mapped="completed" if terminal=="SUCCEEDED" else "failed" if terminal=="FAILED" else "cancelled"
+                out.append({"task_id":task_id,"status":mapped,"outcome":mapped,"error":observation.get("error") or "","started_at":observation.get("started_at") or "","ended_at":observation.get("ended_at") or "","scope":f"fabric:{row['node_name']}","backend":"fabric","remote_backend":row["remote_backend"],"attempt_id":row["attempt_id"],"dispatch_id":row["dispatch_id"],"evidence_provenance":observation.get("provenance")})
+        return out
+
+
+@dataclass
+class FabricBackend:
+    name: str = "fabric"
+    coordinator_factory: Callable[..., FabricCoordinator] = FabricCoordinator
+    def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        try:
+            enabled=sorted(name for name,node in load_node_registry(hermes_root=hermes_root).items() if node.enabled)
+            return {"available":bool(enabled),"node_count":len(enabled),"reason":None if enabled else "no enabled Fabric nodes"}
+        except Exception as exc: return {"available":False,"node_count":0,"reason":op.redact_output(str(exc))[:300]}
+    def dispatch(self, contract: dict[str, Any], *, confirm: bool, dry_run: bool, timeout: int, hermes_root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
+        coordinator=kwargs.get("fabric_coordinator") or self.coordinator_factory(hermes_root=hermes_root)
+        try: return coordinator.dispatch(contract,dry_run=dry_run,confirm=confirm,timeout=timeout)
+        except FabricError as exc: return {"success":False,"ok":False,"changed":bool(exc.ambiguous),"backend":self.name,"code":exc.code,"safe_message":op.redact_output(str(exc))[:300],"submission_may_have_succeeded":bool(exc.ambiguous)}
+    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]: return self.coordinator_factory(hermes_root=hermes_root).observed_runs(task_id)
+    def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]:
+        try: return self.coordinator_factory(hermes_root=hermes_root).cancel(task_id)
+        except FabricError as exc: return {"success":False,"changed":False,"backend":self.name,"code":exc.code,"safe_message":op.redact_output(str(exc))[:300]}
+
+
+def register_runner_backend() -> None:
+    try:
+        if isinstance(op_runners.get_backend("fabric"), FabricBackend): return
+    except LookupError: pass
+    op_runners.register_backend(FabricBackend(), replace=True)
+
+
+class _PeerHandler(BaseHTTPRequestHandler):
+    server_version="HermesGPTFabric/0.8"
+    def log_message(self,_format: str,*_args: Any)->None: return
+    @property
+    def service(self)->FabricPeerService: return getattr(self.server,"fabric_service")
+    @property
+    def advertised_url(self)->str: return getattr(self.server,"fabric_advertised_url")
+    def _send(self,status:int,payload:dict[str,Any])->None:
+        encoded=canonical_json(payload).encode("utf-8"); self.send_response(status); self.send_header("Content-Type","application/json"); self.send_header("Content-Length",str(len(encoded))); self.send_header("Cache-Control","no-store"); self.end_headers(); self.wfile.write(encoded)
+    def do_GET(self)->None:  # noqa: N802
+        if urllib.parse.urlparse(self.path).path not in {"/.well-known/agent-card.json","/.well-known/agent.json"}: self._send(404,{"error":"not found"}); return
+        try:
+            p=self.service.policy_loader(); self._send(200,{"protocolVersion":"1.0","name":p.identity,"description":"Hermes GPT managed Fabric peer","version":"0.8","url":self.advertised_url,"capabilities":{},"defaultInputModes":["application/json"],"defaultOutputModes":["application/json"],"skills":[{"id":"hermes-fabric-v1","name":"Hermes Fabric v1","description":"Deterministic managed remote execution","tags":["hermes","fabric"]}],"supportedInterfaces":[{"url":self.advertised_url,"protocolBinding":"JSONRPC","protocolVersion":"1.0"}]})
+        except FabricError as exc: self._send(503,{"error":exc.code})
+    def do_POST(self)->None:  # noqa: N802
+        outer: Any = None
+        try:
+            length=int(self.headers.get("Content-Length","0"))
+            if length<=0 or length>_MAX_BODY: raise FabricError("FABRIC_PAYLOAD_TOO_LARGE","A2A request has an invalid body size")
+            outer=_closed(strict_json_loads(self.rfile.read(length)),required={"jsonrpc","id","method","params"},name="A2A JSON-RPC request")
+            if outer["jsonrpc"]!="2.0" or outer["method"] not in {"SendMessage","message/send"}: raise FabricError("FABRIC_PROTOCOL_ERROR","only A2A SendMessage is accepted by the Fabric peer")
+            params=_closed(outer["params"],required={"message"},name="A2A params"); message=_closed(params["message"],required={"role","parts","messageId","contextId"},name="A2A message")
+            if message["role"]!="ROLE_USER" or not isinstance(message["parts"],list) or len(message["parts"])!=1: raise FabricError("FABRIC_PROTOCOL_ERROR","Fabric A2A message must contain exactly one structured DataPart")
+            part=_closed(message["parts"][0],required={"data","mediaType"},name="A2A DataPart")
+            if part["mediaType"]!="application/json" or not isinstance(part["data"],dict): raise FabricError("FABRIC_PROTOCOL_ERROR","Fabric does not accept text or generic agent messages")
+            request=_validate_request(part["data"]); response=self.service.handle(request,self.headers.get("Authorization","")); context_id=request.get("dispatch_id") or message["contextId"]; task_id="ftask-"+hashlib.sha256(f"{request['request_id']}:{request.get('attempt_id','')}".encode()).hexdigest()[:24]
+            result={"id":task_id,"contextId":context_id,"status":{"state":"TASK_STATE_COMPLETED","message":{"role":"ROLE_AGENT","parts":[{"data":response,"mediaType":"application/json"}],"messageId":"resp-"+task_id[6:],"contextId":context_id}}}; self._send(200,{"jsonrpc":"2.0","id":outer["id"],"result":result})
+        except FabricError as exc:
+            self._send(200,{"jsonrpc":"2.0","id":outer.get("id") if isinstance(outer,dict) else None,"error":{"code":-32001,"message":str(exc)[:300],"data":{"code":exc.code}}})
+        except Exception: self._send(200,{"jsonrpc":"2.0","id":None,"error":{"code":-32603,"message":"internal Fabric peer error","data":{"code":"FABRIC_INTERNAL_ERROR"}}})
+
+
+def peer_main(argv: list[str] | None = None) -> None:
+    parser=argparse.ArgumentParser(prog="hermes-gpt-fabric-peer",description="Run the deterministic Hermes GPT Fabric A2A peer endpoint."); parser.add_argument("--host",default="127.0.0.1"); parser.add_argument("--port",type=int,default=4780); parser.add_argument("--cert"); parser.add_argument("--key"); parser.add_argument("--advertised-url",default=""); args=parser.parse_args(argv)
+    if bool(args.cert)!=bool(args.key): raise SystemExit("Fabric TLS requires both --cert and --key.")
+    loopback=args.host in {"127.0.0.1","localhost","::1"}
+    if not loopback and not (args.cert and args.key): raise SystemExit("Non-loopback verified Fabric requires direct TLS (--cert and --key).")
+    scheme="https" if args.cert else "http"; advertised=args.advertised_url or f"{scheme}://{args.host}:{args.port}"; _require_secure_transport(advertised); service=FabricPeerService(); server=ThreadingHTTPServer((args.host,args.port),_PeerHandler); setattr(server,"fabric_service",service); setattr(server,"fabric_advertised_url",advertised)
+    if args.cert and args.key:
+        context=ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); context.load_cert_chain(args.cert,args.key); server.socket=context.wrap_socket(server.socket,server_side=True)
+    try: server.serve_forever()
+    except KeyboardInterrupt: pass
+    finally: server.server_close()
+
+
+__all__=["FabricBackend","FabricCoordinator","FabricError","FabricNode","FabricPeerPolicy","FabricPeerService","WorkspaceMapping","canonical_json","load_node_registry","load_peer_policy","load_peer_tokens","peer_main","register_runner_backend","sha256_json","strict_json_loads"]
+
+if __name__ == "__main__": peer_main()

--- a/operator_fabric.py
+++ b/operator_fabric.py
@@ -1,11 +1,11 @@
 """Hermes GPT v0.8 Fabric managed remote dispatch and evidence core.
 
-Fabric uses A2A v1.0 as a bounded transport, but the verified peer endpoint is
-owned by Hermes GPT and parses structured DataParts before any agent/LLM path.
-The coordinator remains the authority owner and Work Contract validator.
+Fabric uses A2A v1.0 as a bounded transport, but verified Fabric requests are
+accepted by a deterministic Hermes GPT endpoint before any generic agent/LLM
+path. The coordinator remains the authority owner and Work Contract validator.
 
-G4-A intentionally does not implement automatic placement, artifact transfer,
-or Flight Deck UI. Those belong to later v0.8 slices.
+G4-A intentionally does not implement automatic placement, artifact byte
+transfer, or Flight Deck UI. Those belong to later v0.8 slices.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import math
 import os
 import re
 import sqlite3
@@ -24,11 +25,12 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import operator_fleet as op_fleet
 import operator_policy as op
@@ -59,13 +61,25 @@ _PROFILE_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 _BACKEND_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 _PRINCIPAL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@/-]{0,127}$")
 _SHA_RE = re.compile(r"^[0-9a-f]{64}$")
-_SECRETISH_KEY_RE = re.compile(r"(?:secret|token|password|passwd|api[_-]?key|credential|private[_-]?key)", re.I)
-_URLISH_KEY_RE = re.compile(r"(?:url|uri|endpoint|host|hostname|proxy)", re.I)
+_SECRETISH_KEY_RE = re.compile(
+    r"(?:secret|token|password|passwd|api[_-]?key|credential|private[_-]?key)",
+    re.IGNORECASE,
+)
+_URLISH_KEY_RE = re.compile(r"(?:url|uri|endpoint|host|hostname|proxy)", re.IGNORECASE)
 _AUTH_RANK = {"none": 0, "read_only": 1, "reversible_write": 2, "high_impact": 3}
 _TERMINAL_PEER = frozenset({"SUCCEEDED", "FAILED", "CANCELLED", "LOST_AMBIGUOUS", "BLOCKED"})
 _TERMINAL_COORD = frozenset({"COMPLETED", "FAILED", "CANCELLED", "BLOCKED"})
-_SAFE_EVIDENCE_PROVENANCE = frozenset({"coordinator_observed", "managed_peer_structured", "artifact_verified", "coordinator_local"})
-_DEFAULT_FEATURES = ("dispatch-v1", "evidence-v1", "idempotency-v1", "principal-auth-v1", "closed-schema-v1")
+_SAFE_EVIDENCE_PROVENANCE = frozenset(
+    {"coordinator_observed", "managed_peer_structured", "artifact_verified", "coordinator_local"}
+)
+_DEFAULT_FEATURES = (
+    "dispatch-v1",
+    "evidence-v1",
+    "idempotency-v1",
+    "principal-auth-v1",
+    "closed-schema-v1",
+)
+_EXPECTED_ERRORS = (OSError, RuntimeError, ValueError, TypeError, sqlite3.Error)
 
 
 class FabricError(RuntimeError):
@@ -115,27 +129,44 @@ def strict_json_loads(raw: str | bytes, *, maximum: int = _MAX_BODY) -> Any:
 
 
 def canonical_json(value: Any) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
 
 
 def sha256_json(value: Any) -> str:
     return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
 
 
-def _closed(obj: Any, *, required: set[str], optional: set[str] = frozenset(), name: str) -> dict[str, Any]:
+def _closed(
+    obj: Any,
+    *,
+    required: set[str],
+    optional: set[str] | frozenset[str] = frozenset(),
+    name: str,
+) -> dict[str, Any]:
     if not isinstance(obj, dict):
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} must be an object")
     keys = set(obj)
-    missing = required - keys
-    unknown = keys - required - optional
-    if missing:
+    if required - keys:
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} is missing required fields")
-    if unknown:
+    if keys - required - optional:
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{name} contains unknown fields")
     return obj
 
 
-def _bounded_string(value: Any, *, field: str, maximum: int = _MAX_STRING, pattern: re.Pattern[str] | None = None, required: bool = True) -> str:
+def _bounded_string(
+    value: Any,
+    *,
+    field: str,
+    maximum: int = _MAX_STRING,
+    pattern: re.Pattern[str] | None = None,
+    required: bool = True,
+) -> str:
     if not isinstance(value, str) or (required and not value) or len(value.encode("utf-8")) > maximum:
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} is invalid")
     if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
@@ -145,7 +176,13 @@ def _bounded_string(value: Any, *, field: str, maximum: int = _MAX_STRING, patte
     return value
 
 
-def _bounded_strings(value: Any, *, field: str, maximum: int = _MAX_ITEMS, item_max: int = 2_000) -> list[str]:
+def _bounded_strings(
+    value: Any,
+    *,
+    field: str,
+    maximum: int = _MAX_ITEMS,
+    item_max: int = 2_000,
+) -> list[str]:
     if not isinstance(value, list) or len(value) > maximum:
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} must be a bounded list")
     return [_bounded_string(item, field=f"{field} item", maximum=item_max) for item in value]
@@ -155,14 +192,17 @@ def _bounded_json(value: Any, *, field: str, depth: int = 0) -> Any:
     if depth > _MAX_DEPTH:
         raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} exceeds nesting depth")
     if value is None or isinstance(value, (bool, int, float)):
-        if isinstance(value, float) and (value != value or value in (float("inf"), float("-inf"))):
+        if isinstance(value, float) and not math.isfinite(value):
             raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains a non-finite number")
         return value
     if isinstance(value, str):
         if len(value.encode("utf-8")) > _MAX_STRING:
             raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains an oversized string")
         if "://" in value:
-            raise FabricError("FABRIC_CALLER_NETWORK_TARGET", f"{field} may not contain caller-supplied URLs")
+            raise FabricError(
+                "FABRIC_CALLER_NETWORK_TARGET",
+                f"{field} may not contain caller-supplied URLs",
+            )
         return value
     if isinstance(value, list):
         if len(value) > _MAX_ITEMS:
@@ -176,9 +216,15 @@ def _bounded_json(value: Any, *, field: str, depth: int = 0) -> Any:
             if not isinstance(key, str) or len(key) > 128:
                 raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} has an invalid key")
             if _SECRETISH_KEY_RE.search(key):
-                raise FabricError("FABRIC_CALLER_CREDENTIAL", f"{field} may not contain credential fields")
+                raise FabricError(
+                    "FABRIC_CALLER_CREDENTIAL",
+                    f"{field} may not contain credential fields",
+                )
             if _URLISH_KEY_RE.search(key):
-                raise FabricError("FABRIC_CALLER_NETWORK_TARGET", f"{field} may not contain network target fields")
+                raise FabricError(
+                    "FABRIC_CALLER_NETWORK_TARGET",
+                    f"{field} may not contain network target fields",
+                )
             out[key] = _bounded_json(item, field=f"{field}.{key}", depth=depth + 1)
         return out
     raise FabricError("FABRIC_SCHEMA_INVALID", f"{field} contains a non-JSON value")
@@ -246,7 +292,11 @@ class FabricPeerPolicy:
     digest: str
 
 
-def load_node_registry(path: Path | None = None, *, hermes_root: Path | None = None) -> dict[str, FabricNode]:
+def load_node_registry(
+    path: Path | None = None,
+    *,
+    hermes_root: Path | None = None,
+) -> dict[str, FabricNode]:
     path = path or _config_path(NODE_REGISTRY_ENV, "fabric-nodes.json", hermes_root)
     raw = _read_closed_json(path)
     _closed(raw, required={"schema", "version", "nodes"}, name="node registry")
@@ -254,60 +304,155 @@ def load_node_registry(path: Path | None = None, *, hermes_root: Path | None = N
         raise FabricError("FABRIC_CONFIG_INVALID", "node registry schema/version is invalid")
     if len(raw["nodes"]) > 128:
         raise FabricError("FABRIC_CONFIG_INVALID", "node registry contains too many nodes")
+
     result: dict[str, FabricNode] = {}
     for item in raw["nodes"]:
-        item = _closed(item, required={"name", "a2a_peer_name", "expected_identity", "coordinator_principal", "enabled", "allowed_profiles", "max_authorization", "allowed_remote_backends", "logical_workspaces", "required_features"}, name="node")
+        item = _closed(
+            item,
+            required={
+                "name",
+                "a2a_peer_name",
+                "expected_identity",
+                "coordinator_principal",
+                "enabled",
+                "allowed_profiles",
+                "max_authorization",
+                "allowed_remote_backends",
+                "logical_workspaces",
+                "required_features",
+            },
+            name="node",
+        )
         name = _bounded_string(item["name"], field="node.name", pattern=_NODE_RE)
         if name in result:
             raise FabricError("FABRIC_CONFIG_INVALID", "node names must be unique")
-        peer_name = _bounded_string(item["a2a_peer_name"], field="node.a2a_peer_name", pattern=op_fleet._AGENT_RE)
+        peer_name = _bounded_string(
+            item["a2a_peer_name"],
+            field="node.a2a_peer_name",
+            pattern=op_fleet._AGENT_RE,
+        )
         identity = _bounded_string(item["expected_identity"], field="node.expected_identity", maximum=128)
-        principal = _bounded_string(item["coordinator_principal"], field="node.coordinator_principal", pattern=_PRINCIPAL_RE)
+        principal = _bounded_string(
+            item["coordinator_principal"],
+            field="node.coordinator_principal",
+            pattern=_PRINCIPAL_RE,
+        )
         if not isinstance(item["enabled"], bool):
             raise FabricError("FABRIC_CONFIG_INVALID", "node.enabled must be boolean")
-        profiles = tuple(_bounded_strings(item["allowed_profiles"], field="node.allowed_profiles", maximum=32, item_max=64))
-        if any(not _PROFILE_RE.fullmatch(p) for p in profiles):
+        profiles = tuple(
+            _bounded_strings(item["allowed_profiles"], field="node.allowed_profiles", maximum=32, item_max=64)
+        )
+        if any(not _PROFILE_RE.fullmatch(profile) for profile in profiles):
             raise FabricError("FABRIC_CONFIG_INVALID", "node allowed profile is invalid")
         max_auth = _bounded_string(item["max_authorization"], field="node.max_authorization", maximum=32)
         if max_auth not in _AUTH_RANK:
             raise FabricError("FABRIC_CONFIG_INVALID", "node max_authorization is invalid")
-        backends = tuple(_bounded_strings(item["allowed_remote_backends"], field="node.allowed_remote_backends", maximum=32, item_max=64))
-        if any(not _BACKEND_RE.fullmatch(b) or b in {"fabric", "fleet"} for b in backends):
+        backends = tuple(
+            _bounded_strings(
+                item["allowed_remote_backends"],
+                field="node.allowed_remote_backends",
+                maximum=32,
+                item_max=64,
+            )
+        )
+        if any(not _BACKEND_RE.fullmatch(backend) or backend in {"fabric", "fleet"} for backend in backends):
             raise FabricError("FABRIC_CONFIG_INVALID", "node remote backend allowlist is invalid")
-        workspaces = tuple(_bounded_strings(item["logical_workspaces"], field="node.logical_workspaces", maximum=64, item_max=128))
-        features = tuple(_bounded_strings(item["required_features"], field="node.required_features", maximum=32, item_max=128))
-        result[name] = FabricNode(name, peer_name, identity, principal, item["enabled"], profiles, max_auth, backends, workspaces, features)
+        workspaces = tuple(
+            _bounded_strings(
+                item["logical_workspaces"],
+                field="node.logical_workspaces",
+                maximum=64,
+                item_max=128,
+            )
+        )
+        features = tuple(
+            _bounded_strings(
+                item["required_features"],
+                field="node.required_features",
+                maximum=32,
+                item_max=128,
+            )
+        )
+        result[name] = FabricNode(
+            name,
+            peer_name,
+            identity,
+            principal,
+            item["enabled"],
+            profiles,
+            max_auth,
+            backends,
+            workspaces,
+            features,
+        )
     return result
 
 
 def load_peer_policy(path: Path | None = None, *, hermes_root: Path | None = None) -> FabricPeerPolicy:
     path = path or _config_path(PEER_POLICY_ENV, "fabric-peer-policy.json", hermes_root)
     raw = _read_closed_json(path)
-    _closed(raw, required={"schema", "version", "node_name", "identity", "allowed_coordinator_principals", "allowed_profiles", "max_authorization", "allowed_backends", "required_features", "workspace_mappings"}, name="peer policy")
+    _closed(
+        raw,
+        required={
+            "schema",
+            "version",
+            "node_name",
+            "identity",
+            "allowed_coordinator_principals",
+            "allowed_profiles",
+            "max_authorization",
+            "allowed_backends",
+            "required_features",
+            "workspace_mappings",
+        },
+        name="peer policy",
+    )
     if raw["schema"] != PEER_POLICY_SCHEMA or raw["version"] != 1:
         raise FabricError("FABRIC_CONFIG_INVALID", "peer policy schema/version is invalid")
+
     node_name = _bounded_string(raw["node_name"], field="peer.node_name", pattern=_NODE_RE)
     identity = _bounded_string(raw["identity"], field="peer.identity", maximum=128)
-    principals = tuple(_bounded_strings(raw["allowed_coordinator_principals"], field="peer.allowed_coordinator_principals", maximum=32, item_max=128))
-    if not principals or any(not _PRINCIPAL_RE.fullmatch(p) for p in principals):
+    principals = tuple(
+        _bounded_strings(
+            raw["allowed_coordinator_principals"],
+            field="peer.allowed_coordinator_principals",
+            maximum=32,
+            item_max=128,
+        )
+    )
+    if not principals or any(not _PRINCIPAL_RE.fullmatch(principal) for principal in principals):
         raise FabricError("FABRIC_CONFIG_INVALID", "peer principals are invalid")
-    profiles = tuple(_bounded_strings(raw["allowed_profiles"], field="peer.allowed_profiles", maximum=32, item_max=64))
-    if not profiles or any(not _PROFILE_RE.fullmatch(p) for p in profiles):
+    profiles = tuple(
+        _bounded_strings(raw["allowed_profiles"], field="peer.allowed_profiles", maximum=32, item_max=64)
+    )
+    if not profiles or any(not _PROFILE_RE.fullmatch(profile) for profile in profiles):
         raise FabricError("FABRIC_CONFIG_INVALID", "peer profiles are invalid")
     max_auth = _bounded_string(raw["max_authorization"], field="peer.max_authorization", maximum=32)
     if max_auth not in _AUTH_RANK:
         raise FabricError("FABRIC_CONFIG_INVALID", "peer max_authorization is invalid")
-    backends = tuple(_bounded_strings(raw["allowed_backends"], field="peer.allowed_backends", maximum=32, item_max=64))
-    if not backends or any(not _BACKEND_RE.fullmatch(b) or b in {"fabric", "fleet"} for b in backends):
+    backends = tuple(
+        _bounded_strings(raw["allowed_backends"], field="peer.allowed_backends", maximum=32, item_max=64)
+    )
+    if not backends or any(
+        not _BACKEND_RE.fullmatch(backend) or backend in {"fabric", "fleet"}
+        for backend in backends
+    ):
         raise FabricError("FABRIC_CONFIG_INVALID", "peer backend allowlist is invalid")
-    features = tuple(_bounded_strings(raw["required_features"], field="peer.required_features", maximum=32, item_max=128))
+    features = tuple(
+        _bounded_strings(raw["required_features"], field="peer.required_features", maximum=32, item_max=128)
+    )
+
     mappings_raw = raw["workspace_mappings"]
     if not isinstance(mappings_raw, dict) or not mappings_raw or len(mappings_raw) > 64:
         raise FabricError("FABRIC_CONFIG_INVALID", "peer workspace mappings are invalid")
     mappings: dict[str, WorkspaceMapping] = {}
     for logical_id, mapping in mappings_raw.items():
         logical_id = _bounded_string(logical_id, field="workspace logical id", maximum=128)
-        mapping = _closed(mapping, required={"local_path", "revision", "conflict_domain"}, name="workspace mapping")
+        mapping = _closed(
+            mapping,
+            required={"local_path", "revision", "conflict_domain"},
+            name="workspace mapping",
+        )
         local_path_text = _bounded_string(mapping["local_path"], field="workspace.local_path", maximum=1_000)
         local_path = Path(local_path_text).expanduser()
         if not local_path.is_absolute() or op.is_denied_path(local_path):
@@ -317,20 +462,37 @@ def load_peer_policy(path: Path | None = None, *, hermes_root: Path | None = Non
                 raise FabricError("FABRIC_CONFIG_INVALID", "workspace mapping root may not be a symlink")
         except OSError as exc:
             raise FabricError("FABRIC_CONFIG_INVALID", "workspace mapping cannot be inspected") from exc
-        revision = _bounded_string(mapping["revision"], field="workspace.revision", maximum=128)
-        conflict_domain = _bounded_string(mapping["conflict_domain"], field="workspace.conflict_domain", maximum=128)
-        mappings[logical_id] = WorkspaceMapping(logical_id, local_path.resolve(), revision, conflict_domain)
-    digest = sha256_json(raw)
-    return FabricPeerPolicy(node_name, identity, principals, profiles, max_auth, backends, features, mappings, digest)
+        mappings[logical_id] = WorkspaceMapping(
+            logical_id,
+            local_path.resolve(),
+            _bounded_string(mapping["revision"], field="workspace.revision", maximum=128),
+            _bounded_string(mapping["conflict_domain"], field="workspace.conflict_domain", maximum=128),
+        )
+
+    return FabricPeerPolicy(
+        node_name,
+        identity,
+        principals,
+        profiles,
+        max_auth,
+        backends,
+        features,
+        mappings,
+        sha256_json(raw),
+    )
 
 
 def load_peer_tokens(value: str | None = None) -> dict[str, str]:
     raw_value = value if value is not None else os.environ.get(PEER_TOKENS_ENV, "")
     if not raw_value:
-        raise FabricError("FABRIC_PRINCIPAL_CONFIG_MISSING", "verified Fabric requires configured coordinator-principal tokens")
+        raise FabricError(
+            "FABRIC_PRINCIPAL_CONFIG_MISSING",
+            "verified Fabric requires configured coordinator-principal tokens",
+        )
     raw = strict_json_loads(raw_value, maximum=32_000)
     if not isinstance(raw, dict) or not raw or len(raw) > 32:
         raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "peer token map is invalid")
+
     out: dict[str, str] = {}
     seen_tokens: set[str] = set()
     for principal, token in raw.items():
@@ -338,7 +500,10 @@ def load_peer_tokens(value: str | None = None) -> dict[str, str]:
         if not isinstance(token, str) or len(token) < 16 or len(token.encode("utf-8")) > 1_024:
             raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "peer bearer token is invalid")
         if token in seen_tokens:
-            raise FabricError("FABRIC_PRINCIPAL_CONFIG_INVALID", "each coordinator principal must have a unique bearer token")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_CONFIG_INVALID",
+                "each coordinator principal must have a unique bearer token",
+            )
         out[principal] = token
         seen_tokens.add(token)
     return out
@@ -349,12 +514,15 @@ def _db_path(env_name: str, default_name: str, hermes_root: Path | None = None) 
     path = Path(configured).expanduser() if configured else _root(hermes_root) / "fabric" / default_name
     if not path.is_absolute() or op.is_denied_path(path) or path.is_symlink():
         raise FabricError("FABRIC_JOURNAL_PATH_INVALID", "Fabric journal path is not allowed")
+    return path
+
+
+def _prepare_db_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     try:
         path.parent.chmod(0o700)
     except OSError:
-        pass
-    return path
+        return
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -365,41 +533,83 @@ def _connect(path: Path) -> sqlite3.Connection:
     return db
 
 
+def _connect_readonly(path: Path) -> sqlite3.Connection:
+    uri = f"file:{urllib.parse.quote(str(path))}?mode=ro"
+    db = sqlite3.connect(uri, uri=True, timeout=5.0)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA query_only=ON")
+    return db
+
+
 def _init_coordinator_db(path: Path) -> None:
+    _prepare_db_parent(path)
     with _connect(path) as db:
-        db.executescript("""
+        db.executescript(
+            """
             CREATE TABLE IF NOT EXISTS dispatches (
-              dispatch_id TEXT PRIMARY KEY, task_id TEXT NOT NULL, contract_sha256 TEXT NOT NULL,
-              node_name TEXT NOT NULL, evidence_policy_json TEXT NOT NULL, created_at TEXT NOT NULL
+              dispatch_id TEXT PRIMARY KEY,
+              task_id TEXT NOT NULL,
+              contract_sha256 TEXT NOT NULL,
+              node_name TEXT NOT NULL,
+              evidence_policy_json TEXT NOT NULL,
+              created_at TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS dispatches_task_idx ON dispatches(task_id);
             CREATE TABLE IF NOT EXISTS attempts (
-              attempt_id TEXT PRIMARY KEY, dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
-              envelope_sha256 TEXT NOT NULL, node_name TEXT NOT NULL, peer_name TEXT NOT NULL,
-              remote_backend TEXT NOT NULL, coordinator_principal TEXT NOT NULL, capability_sha256 TEXT NOT NULL,
-              peer_policy_sha256 TEXT, state TEXT NOT NULL, remote_task_id TEXT, evidence_json TEXT,
-              error_code TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+              attempt_id TEXT PRIMARY KEY,
+              dispatch_id TEXT NOT NULL REFERENCES dispatches(dispatch_id),
+              envelope_sha256 TEXT NOT NULL,
+              node_name TEXT NOT NULL,
+              peer_name TEXT NOT NULL,
+              remote_backend TEXT NOT NULL,
+              coordinator_principal TEXT NOT NULL,
+              capability_sha256 TEXT NOT NULL,
+              peer_policy_sha256 TEXT,
+              state TEXT NOT NULL,
+              remote_task_id TEXT,
+              evidence_json TEXT,
+              error_code TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS attempts_dispatch_idx ON attempts(dispatch_id);
-        """)
+            """
+        )
 
 
 def _init_peer_db(path: Path) -> None:
+    _prepare_db_parent(path)
     with _connect(path) as db:
-        db.executescript("""
+        db.executescript(
+            """
             CREATE TABLE IF NOT EXISTS attempts (
-              attempt_id TEXT PRIMARY KEY, dispatch_id TEXT NOT NULL, envelope_sha256 TEXT NOT NULL,
-              contract_sha256 TEXT NOT NULL, task_id TEXT NOT NULL, coordinator_principal TEXT NOT NULL,
-              node_name TEXT NOT NULL, remote_backend TEXT NOT NULL, logical_workspace TEXT NOT NULL,
-              conflict_domain TEXT NOT NULL, authorization_class TEXT NOT NULL, policy_sha256 TEXT NOT NULL,
-              local_task_id TEXT NOT NULL, state TEXT NOT NULL, dispatch_result_json TEXT,
-              created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+              attempt_id TEXT PRIMARY KEY,
+              dispatch_id TEXT NOT NULL,
+              envelope_sha256 TEXT NOT NULL,
+              contract_sha256 TEXT NOT NULL,
+              task_id TEXT NOT NULL,
+              coordinator_principal TEXT NOT NULL,
+              node_name TEXT NOT NULL,
+              remote_backend TEXT NOT NULL,
+              logical_workspace TEXT NOT NULL,
+              conflict_domain TEXT NOT NULL,
+              authorization_class TEXT NOT NULL,
+              policy_sha256 TEXT NOT NULL,
+              local_task_id TEXT NOT NULL,
+              state TEXT NOT NULL,
+              dispatch_result_json TEXT,
+              created_at TEXT NOT NULL,
+              updated_at TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS write_claims (
-              conflict_domain TEXT PRIMARY KEY, attempt_id TEXT NOT NULL, state TEXT NOT NULL,
-              acquired_at TEXT NOT NULL, released_at TEXT
+              conflict_domain TEXT PRIMARY KEY,
+              attempt_id TEXT NOT NULL,
+              state TEXT NOT NULL,
+              acquired_at TEXT NOT NULL,
+              released_at TEXT
             );
-        """)
+            """
+        )
 
 
 def _is_loopback_url(url: str) -> bool:
@@ -425,20 +635,39 @@ def _require_secure_transport(url: str) -> None:
         raise FabricError("FABRIC_TRANSPORT_INSECURE", "non-loopback verified Fabric requires HTTPS")
 
 
-def _http_json(url: str, *, headers: dict[str, str], timeout: int, body: dict[str, Any] | None = None) -> dict[str, Any]:
+def _http_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    timeout: int,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     data = canonical_json(body).encode("utf-8") if body is not None else None
     req_headers = {"Accept": "application/json", **headers}
     if data is not None:
         req_headers.update({"Content-Type": "application/json", "A2A-Version": "1.0"})
-    req = urllib.request.Request(url, data=data, headers=req_headers, method="POST" if data is not None else "GET")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers=req_headers,
+        method="POST" if data is not None else "GET",
+    )
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
             raw = resp.read(_MAX_BODY + 1)
     except (TimeoutError, urllib.error.URLError) as exc:
         reason = getattr(exc, "reason", None)
         if isinstance(exc, TimeoutError) or isinstance(reason, TimeoutError):
-            raise FabricError("FABRIC_TRANSPORT_TIMEOUT", "Fabric peer request timed out", ambiguous=body is not None) from exc
-        raise FabricError("FABRIC_PEER_UNAVAILABLE", "Fabric peer is unavailable", ambiguous=body is not None) from exc
+            raise FabricError(
+                "FABRIC_TRANSPORT_TIMEOUT",
+                "Fabric peer request timed out",
+                ambiguous=body is not None,
+            ) from exc
+        raise FabricError(
+            "FABRIC_PEER_UNAVAILABLE",
+            "Fabric peer is unavailable",
+            ambiguous=body is not None,
+        ) from exc
     if len(raw) > _MAX_BODY:
         raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "Fabric peer response exceeds the bounded limit")
     parsed = strict_json_loads(raw)
@@ -448,7 +677,11 @@ def _http_json(url: str, *, headers: dict[str, str], timeout: int, body: dict[st
 
 
 def _fabric_card(base_url: str, headers: dict[str, str], timeout: int) -> dict[str, Any]:
-    return _http_json(base_url.rstrip("/") + "/.well-known/agent-card.json", headers=headers, timeout=timeout)
+    return _http_json(
+        base_url.rstrip("/") + "/.well-known/agent-card.json",
+        headers=headers,
+        timeout=timeout,
+    )
 
 
 def _peer_entry(node: FabricNode) -> dict[str, Any]:
@@ -462,13 +695,17 @@ def _peer_entry(node: FabricNode) -> dict[str, Any]:
     _require_secure_transport(url)
     headers = op_fleet._auth_header(entry)
     if "Authorization" not in headers:
-        raise FabricError("FABRIC_PRINCIPAL_AUTH_REQUIRED", "verified Fabric requires a configured bearer credential")
+        raise FabricError(
+            "FABRIC_PRINCIPAL_AUTH_REQUIRED",
+            "verified Fabric requires a configured bearer credential",
+        )
     return entry
 
 
 def _extract_data_response(task: Any) -> tuple[str | None, dict[str, Any]]:
     task_id: str | None = None
     found: list[dict[str, Any]] = []
+
     def walk(node: Any, depth: int = 0) -> None:
         nonlocal task_id
         if depth > 10 or len(found) > 8:
@@ -484,49 +721,101 @@ def _extract_data_response(task: Any) -> tuple[str | None, dict[str, Any]]:
         elif isinstance(node, list):
             for item in node[:_MAX_ITEMS]:
                 walk(item, depth + 1)
+
     walk(task)
     if len(found) != 1:
-        raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric A2A response must contain exactly one structured DataPart")
+        raise FabricError(
+            "FABRIC_PROTOCOL_ERROR",
+            "Fabric A2A response must contain exactly one structured DataPart",
+        )
     return task_id, found[0]
 
 
 def _validate_response(response: Any, *, operation: str) -> dict[str, Any]:
-    response = _closed(response, required={"schema", "version", "operation", "ok", "code", "data"}, name="Fabric response")
-    if response["schema"] != RESPONSE_SCHEMA or response["version"] != FABRIC_VERSION or response["operation"] != operation:
+    response = _closed(
+        response,
+        required={"schema", "version", "operation", "ok", "code", "data"},
+        name="Fabric response",
+    )
+    if (
+        response["schema"] != RESPONSE_SCHEMA
+        or response["version"] != FABRIC_VERSION
+        or response["operation"] != operation
+    ):
         raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric response binding does not match the request")
     if not isinstance(response["ok"], bool) or not isinstance(response["code"], str) or not isinstance(response["data"], dict):
         raise FabricError("FABRIC_PROTOCOL_ERROR", "Fabric response fields are invalid")
     return response
 
 
-def _rpc_call(node: FabricNode, request: dict[str, Any], *, timeout: int) -> tuple[str | None, dict[str, Any]]:
+def _rpc_call(
+    node: FabricNode,
+    request: dict[str, Any],
+    *,
+    timeout: int,
+) -> tuple[str | None, dict[str, Any]]:
     entry = _peer_entry(node)
     base_url = str(entry["url"])
     headers = op_fleet._auth_header(entry)
     card = _fabric_card(base_url, headers, min(max(timeout, 1), 15))
     if card.get("name") != node.expected_identity:
-        raise FabricError("FABRIC_PEER_IDENTITY_MISMATCH", "managed peer identity does not match the node registry")
+        raise FabricError(
+            "FABRIC_PEER_IDENTITY_MISMATCH",
+            "managed peer identity does not match the node registry",
+        )
+
     rpc_url = base_url.rstrip("/")
     interfaces = card.get("supportedInterfaces")
     if isinstance(interfaces, list):
-        for iface in interfaces:
-            if isinstance(iface, dict) and iface.get("protocolBinding") == "JSONRPC" and isinstance(iface.get("url"), str):
-                candidate = iface["url"]
+        for interface in interfaces:
+            if (
+                isinstance(interface, dict)
+                and interface.get("protocolBinding") == "JSONRPC"
+                and isinstance(interface.get("url"), str)
+            ):
+                candidate = interface["url"]
                 _require_secure_transport(candidate)
                 if urllib.parse.urlparse(candidate).hostname != urllib.parse.urlparse(base_url).hostname:
-                    raise FabricError("FABRIC_PEER_IDENTITY_MISMATCH", "Agent Card redirected Fabric to a different host")
+                    raise FabricError(
+                        "FABRIC_PEER_IDENTITY_MISMATCH",
+                        "Agent Card redirected Fabric to a different host",
+                    )
                 rpc_url = candidate
                 break
-    req_id = "frpc-" + hashlib.sha256((canonical_json(request) + str(time.time_ns())).encode()).hexdigest()[:20]
-    dispatch_id = str(request.get("dispatch_id") or request.get("request_id") or req_id)
-    body = {"jsonrpc": "2.0", "id": req_id, "method": "SendMessage", "params": {"message": {"role": "ROLE_USER", "parts": [{"data": request, "mediaType": "application/json"}], "messageId": "msg-" + req_id[5:], "contextId": dispatch_id}}}
+
+    request_id = "frpc-" + hashlib.sha256(
+        (canonical_json(request) + str(time.time_ns())).encode()
+    ).hexdigest()[:20]
+    dispatch_id = str(request.get("dispatch_id") or request.get("request_id") or request_id)
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "role": "ROLE_USER",
+                "parts": [{"data": request, "mediaType": "application/json"}],
+                "messageId": "msg-" + request_id[5:],
+                "contextId": dispatch_id,
+            }
+        },
+    }
     outer = _http_json(rpc_url, headers=headers, timeout=max(1, min(timeout, 120)), body=body)
-    _closed(outer, required={"jsonrpc", "id"}, optional={"result", "error"}, name="A2A JSON-RPC response")
-    if outer.get("jsonrpc") != "2.0" or outer.get("id") != req_id:
+    _closed(
+        outer,
+        required={"jsonrpc", "id"},
+        optional={"result", "error"},
+        name="A2A JSON-RPC response",
+    )
+    if outer.get("jsonrpc") != "2.0" or outer.get("id") != request_id:
         raise FabricError("FABRIC_PROTOCOL_ERROR", "A2A response identity mismatch")
     if "error" in outer:
         error = outer["error"] if isinstance(outer["error"], dict) else {}
-        raise FabricError(str(error.get("data", {}).get("code") or "FABRIC_REMOTE_ERROR"), str(error.get("message") or "Fabric peer rejected the request"))
+        data = error.get("data") if isinstance(error.get("data"), dict) else {}
+        raise FabricError(
+            str(data.get("code") or "FABRIC_REMOTE_ERROR"),
+            str(error.get("message") or "Fabric peer rejected the request"),
+        )
     if "result" not in outer:
         raise FabricError("FABRIC_PROTOCOL_ERROR", "A2A response contains no result")
     remote_task_id, response = _extract_data_response(outer["result"])
@@ -537,17 +826,31 @@ def _evidence_policy(options: dict[str, Any]) -> dict[str, tuple[str, ...]]:
     raw = options.get("evidence_provenance")
     if raw is None:
         return {"run_state": ("managed_peer_structured", "coordinator_observed")}
-    raw = _closed(raw, required={"run_state"}, name="execution.options.evidence_provenance")
-    values = tuple(_bounded_strings(raw["run_state"], field="evidence_provenance.run_state", maximum=8, item_max=64))
+    raw = _closed(
+        raw,
+        required={"run_state"},
+        name="execution.options.evidence_provenance",
+    )
+    values = tuple(
+        _bounded_strings(raw["run_state"], field="evidence_provenance.run_state", maximum=8, item_max=64)
+    )
     if not values or any(value not in _SAFE_EVIDENCE_PROVENANCE for value in values):
-        raise FabricError("FABRIC_EVIDENCE_POLICY_INVALID", "run_state evidence provenance is invalid")
+        raise FabricError(
+            "FABRIC_EVIDENCE_POLICY_INVALID",
+            "run_state evidence provenance is invalid",
+        )
     return {"run_state": values}
 
 
-def _fabric_options(contract: dict[str, Any]) -> tuple[str, str, str, dict[str, Any], dict[str, tuple[str, ...]]]:
+def _fabric_options(
+    contract: dict[str, Any],
+) -> tuple[str, str, str, dict[str, Any], dict[str, tuple[str, ...]]]:
     execution = contract.get("execution")
     if not isinstance(execution, dict) or execution.get("backend") != "fabric":
-        raise FabricError("FABRIC_EXECUTION_INVALID", "Fabric backend requires execution.backend=fabric")
+        raise FabricError(
+            "FABRIC_EXECUTION_INVALID",
+            "Fabric backend requires execution.backend=fabric",
+        )
     options = execution.get("options")
     if not isinstance(options, dict):
         raise FabricError("FABRIC_EXECUTION_INVALID", "Fabric execution options must be an object")
@@ -555,14 +858,31 @@ def _fabric_options(contract: dict[str, Any]) -> tuple[str, str, str, dict[str, 
     if set(options) - allowed:
         raise FabricError("FABRIC_SCHEMA_INVALID", "Fabric execution options contain unknown fields")
     node_name = _bounded_string(options.get("node"), field="execution.options.node", pattern=_NODE_RE)
-    remote_backend = _bounded_string(options.get("remote_backend"), field="execution.options.remote_backend", pattern=_BACKEND_RE)
+    remote_backend = _bounded_string(
+        options.get("remote_backend"),
+        field="execution.options.remote_backend",
+        pattern=_BACKEND_RE,
+    )
     if remote_backend in {"fabric", "fleet"}:
         raise FabricError("FABRIC_EXECUTION_INVALID", "nested Fabric/fleet delegation is not allowed")
-    logical_workspace = _bounded_string(options.get("logical_workspace"), field="execution.options.logical_workspace", maximum=128)
-    remote_options = _bounded_json(options.get("remote_options") or {}, field="execution.options.remote_options")
+    logical_workspace = _bounded_string(
+        options.get("logical_workspace"),
+        field="execution.options.logical_workspace",
+        maximum=128,
+    )
+    remote_options = _bounded_json(
+        options.get("remote_options") or {},
+        field="execution.options.remote_options",
+    )
     if not isinstance(remote_options, dict):
         raise FabricError("FABRIC_EXECUTION_INVALID", "remote_options must be an object")
-    return node_name, remote_backend, logical_workspace, remote_options, _evidence_policy(options)
+    return (
+        node_name,
+        remote_backend,
+        logical_workspace,
+        remote_options,
+        _evidence_policy(options),
+    )
 
 
 def _contract_sha(contract: dict[str, Any]) -> str:
@@ -590,68 +910,162 @@ def _auth_object(value: Any) -> dict[str, Any]:
     for key in ("approved_by", "approval_reference"):
         if key in value:
             out[key] = _bounded_string(value[key], field=f"authorization.{key}", maximum=128)
-    if auth_class == "high_impact" and (not out["approved"] or "approved_by" not in out or "approval_reference" not in out):
-        raise FabricError("FABRIC_AUTHORITY_DENIED", "high-impact authorization requires explicit approval metadata")
+    if auth_class == "high_impact" and (
+        not out["approved"] or "approved_by" not in out or "approval_reference" not in out
+    ):
+        raise FabricError(
+            "FABRIC_AUTHORITY_DENIED",
+            "high-impact authorization requires explicit approval metadata",
+        )
     return out
 
 
-def _build_envelope(contract: dict[str, Any], node: FabricNode, *, remote_backend: str, logical_workspace: str, remote_options: dict[str, Any], evidence_policy: dict[str, tuple[str, ...]], capability_sha: str) -> dict[str, Any]:
+def _build_envelope(
+    contract: dict[str, Any],
+    node: FabricNode,
+    *,
+    remote_backend: str,
+    logical_workspace: str,
+    remote_options: dict[str, Any],
+    evidence_policy: dict[str, tuple[str, ...]],
+    capability_sha: str,
+) -> dict[str, Any]:
     contract_sha = _contract_sha(contract)
     task_id = _bounded_string(contract.get("task_id"), field="contract.task_id", pattern=op_fleet._TASK_ID_RE)
     dispatch_id = _dispatch_id(contract_sha, task_id, node.name)
-    attempt_id = _attempt_id(dispatch_id)
     envelope = {
-        "schema": DISPATCH_SCHEMA, "version": FABRIC_VERSION, "dispatch_id": dispatch_id, "attempt_id": attempt_id,
-        "contract_sha256": contract_sha, "task_id": task_id, "target_node": node.name,
+        "schema": DISPATCH_SCHEMA,
+        "version": FABRIC_VERSION,
+        "dispatch_id": dispatch_id,
+        "attempt_id": _attempt_id(dispatch_id),
+        "contract_sha256": contract_sha,
+        "task_id": task_id,
+        "target_node": node.name,
         "coordinator_principal": node.coordinator_principal,
-        "assigned_profile": _bounded_string(contract.get("assigned_profile"), field="contract.assigned_profile", pattern=_PROFILE_RE),
+        "assigned_profile": _bounded_string(
+            contract.get("assigned_profile"),
+            field="contract.assigned_profile",
+            pattern=_PROFILE_RE,
+        ),
         "objective": _bounded_string(contract.get("objective"), field="contract.objective", maximum=8_000),
         "inputs": _bounded_strings(contract.get("inputs", []), field="contract.inputs"),
         "constraints": _bounded_strings(contract.get("constraints", []), field="contract.constraints"),
-        "authorization": _auth_object(contract.get("authorization")), "logical_workspace": logical_workspace,
-        "remote_backend": remote_backend, "remote_options": remote_options,
+        "authorization": _auth_object(contract.get("authorization")),
+        "logical_workspace": logical_workspace,
+        "remote_backend": remote_backend,
+        "remote_options": remote_options,
         "required_features": list(dict.fromkeys((*_DEFAULT_FEATURES, *node.required_features))),
-        "capability_snapshot_sha256": capability_sha, "evidence_policy": {"run_state": list(evidence_policy["run_state"])},
+        "capability_snapshot_sha256": capability_sha,
+        "evidence_policy": {"run_state": list(evidence_policy["run_state"])},
         "created_at": _now(),
     }
     if len(canonical_json(envelope).encode("utf-8")) > 64_000:
-        raise FabricError("FABRIC_PAYLOAD_TOO_LARGE", "canonical Fabric dispatch envelope exceeds 64 KB")
+        raise FabricError(
+            "FABRIC_PAYLOAD_TOO_LARGE",
+            "canonical Fabric dispatch envelope exceeds 64 KB",
+        )
     return envelope
 
 
 def _validate_envelope(value: Any) -> dict[str, Any]:
-    required = {"schema", "version", "dispatch_id", "attempt_id", "contract_sha256", "task_id", "target_node", "coordinator_principal", "assigned_profile", "objective", "inputs", "constraints", "authorization", "logical_workspace", "remote_backend", "remote_options", "required_features", "capability_snapshot_sha256", "evidence_policy", "created_at"}
-    env = _closed(value, required=required, name="Fabric dispatch envelope")
-    if env["schema"] != DISPATCH_SCHEMA or env["version"] != FABRIC_VERSION:
-        raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "Fabric dispatch schema/version is unsupported")
-    _bounded_string(env["dispatch_id"], field="dispatch_id", pattern=_ID_RE)
-    _bounded_string(env["attempt_id"], field="attempt_id", pattern=_ID_RE)
-    _bounded_string(env["contract_sha256"], field="contract_sha256", pattern=_SHA_RE)
-    _bounded_string(env["task_id"], field="task_id", pattern=op_fleet._TASK_ID_RE)
-    _bounded_string(env["target_node"], field="target_node", pattern=_NODE_RE)
-    _bounded_string(env["coordinator_principal"], field="coordinator_principal", pattern=_PRINCIPAL_RE)
-    _bounded_string(env["assigned_profile"], field="assigned_profile", pattern=_PROFILE_RE)
-    _bounded_string(env["objective"], field="objective", maximum=8_000)
-    _bounded_strings(env["inputs"], field="inputs")
-    _bounded_strings(env["constraints"], field="constraints")
-    _auth_object(env["authorization"])
-    _bounded_string(env["logical_workspace"], field="logical_workspace", maximum=128)
-    backend = _bounded_string(env["remote_backend"], field="remote_backend", pattern=_BACKEND_RE)
+    required = {
+        "schema",
+        "version",
+        "dispatch_id",
+        "attempt_id",
+        "contract_sha256",
+        "task_id",
+        "target_node",
+        "coordinator_principal",
+        "assigned_profile",
+        "objective",
+        "inputs",
+        "constraints",
+        "authorization",
+        "logical_workspace",
+        "remote_backend",
+        "remote_options",
+        "required_features",
+        "capability_snapshot_sha256",
+        "evidence_policy",
+        "created_at",
+    }
+    envelope = _closed(value, required=required, name="Fabric dispatch envelope")
+    if envelope["schema"] != DISPATCH_SCHEMA or envelope["version"] != FABRIC_VERSION:
+        raise FabricError(
+            "FABRIC_PROTOCOL_INCOMPATIBLE",
+            "Fabric dispatch schema/version is unsupported",
+        )
+    _bounded_string(envelope["dispatch_id"], field="dispatch_id", pattern=_ID_RE)
+    _bounded_string(envelope["attempt_id"], field="attempt_id", pattern=_ID_RE)
+    _bounded_string(envelope["contract_sha256"], field="contract_sha256", pattern=_SHA_RE)
+    _bounded_string(envelope["task_id"], field="task_id", pattern=op_fleet._TASK_ID_RE)
+    _bounded_string(envelope["target_node"], field="target_node", pattern=_NODE_RE)
+    _bounded_string(
+        envelope["coordinator_principal"],
+        field="coordinator_principal",
+        pattern=_PRINCIPAL_RE,
+    )
+    _bounded_string(envelope["assigned_profile"], field="assigned_profile", pattern=_PROFILE_RE)
+    _bounded_string(envelope["objective"], field="objective", maximum=8_000)
+    _bounded_strings(envelope["inputs"], field="inputs")
+    _bounded_strings(envelope["constraints"], field="constraints")
+    _auth_object(envelope["authorization"])
+    _bounded_string(envelope["logical_workspace"], field="logical_workspace", maximum=128)
+    backend = _bounded_string(envelope["remote_backend"], field="remote_backend", pattern=_BACKEND_RE)
     if backend in {"fabric", "fleet"}:
         raise FabricError("FABRIC_EXECUTION_INVALID", "nested Fabric/fleet delegation is not allowed")
-    _bounded_json(env["remote_options"], field="remote_options")
-    _bounded_strings(env["required_features"], field="required_features", maximum=32, item_max=128)
-    _bounded_string(env["capability_snapshot_sha256"], field="capability_snapshot_sha256", pattern=_SHA_RE)
-    evidence_policy = _closed(env["evidence_policy"], required={"run_state"}, name="evidence_policy")
-    provenance = _bounded_strings(evidence_policy["run_state"], field="evidence_policy.run_state", maximum=8, item_max=64)
+    _bounded_json(envelope["remote_options"], field="remote_options")
+    _bounded_strings(
+        envelope["required_features"],
+        field="required_features",
+        maximum=32,
+        item_max=128,
+    )
+    _bounded_string(
+        envelope["capability_snapshot_sha256"],
+        field="capability_snapshot_sha256",
+        pattern=_SHA_RE,
+    )
+    evidence_policy = _closed(
+        envelope["evidence_policy"],
+        required={"run_state"},
+        name="evidence_policy",
+    )
+    provenance = _bounded_strings(
+        evidence_policy["run_state"],
+        field="evidence_policy.run_state",
+        maximum=8,
+        item_max=64,
+    )
     if not provenance or any(item not in _SAFE_EVIDENCE_PROVENANCE for item in provenance):
-        raise FabricError("FABRIC_EVIDENCE_POLICY_INVALID", "Fabric run-state evidence policy is invalid")
-    _bounded_string(env["created_at"], field="created_at", maximum=128)
-    return env
+        raise FabricError(
+            "FABRIC_EVIDENCE_POLICY_INVALID",
+            "Fabric run-state evidence policy is invalid",
+        )
+    _bounded_string(envelope["created_at"], field="created_at", maximum=128)
+    return envelope
 
 
-def _request(operation: str, principal: str, *, data: dict[str, Any], dispatch_id: str = "", attempt_id: str = "") -> dict[str, Any]:
-    request = {"schema": REQUEST_SCHEMA, "version": FABRIC_VERSION, "operation": operation, "coordinator_principal": principal, "request_id": "freq-" + hashlib.sha256(f"{operation}:{dispatch_id}:{attempt_id}:{time.time_ns()}".encode()).hexdigest()[:24], "data": data}
+def _request(
+    operation: str,
+    principal: str,
+    *,
+    data: dict[str, Any],
+    dispatch_id: str = "",
+    attempt_id: str = "",
+) -> dict[str, Any]:
+    request: dict[str, Any] = {
+        "schema": REQUEST_SCHEMA,
+        "version": FABRIC_VERSION,
+        "operation": operation,
+        "coordinator_principal": principal,
+        "request_id": "freq-"
+        + hashlib.sha256(
+            f"{operation}:{dispatch_id}:{attempt_id}:{time.time_ns()}".encode()
+        ).hexdigest()[:24],
+        "data": data,
+    }
     if dispatch_id:
         request["dispatch_id"] = dispatch_id
     if attempt_id:
@@ -660,13 +1074,25 @@ def _request(operation: str, principal: str, *, data: dict[str, Any], dispatch_i
 
 
 def _validate_request(value: Any) -> dict[str, Any]:
-    request = _closed(value, required={"schema", "version", "operation", "coordinator_principal", "request_id", "data"}, optional={"dispatch_id", "attempt_id"}, name="Fabric request")
+    request = _closed(
+        value,
+        required={"schema", "version", "operation", "coordinator_principal", "request_id", "data"},
+        optional={"dispatch_id", "attempt_id"},
+        name="Fabric request",
+    )
     if request["schema"] != REQUEST_SCHEMA or request["version"] != FABRIC_VERSION:
-        raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "Fabric request schema/version is unsupported")
+        raise FabricError(
+            "FABRIC_PROTOCOL_INCOMPATIBLE",
+            "Fabric request schema/version is unsupported",
+        )
     operation = _bounded_string(request["operation"], field="operation", maximum=32)
     if operation not in {"capabilities", "accept", "status", "reconcile", "cancel", "evidence"}:
         raise FabricError("FABRIC_OPERATION_UNSUPPORTED", "Fabric operation is unsupported")
-    _bounded_string(request["coordinator_principal"], field="coordinator_principal", pattern=_PRINCIPAL_RE)
+    _bounded_string(
+        request["coordinator_principal"],
+        field="coordinator_principal",
+        pattern=_PRINCIPAL_RE,
+    )
     _bounded_string(request["request_id"], field="request_id", pattern=_ID_RE)
     if "dispatch_id" in request:
         _bounded_string(request["dispatch_id"], field="dispatch_id", pattern=_ID_RE)
@@ -678,47 +1104,107 @@ def _validate_request(value: Any) -> dict[str, Any]:
 
 
 def _response(operation: str, *, ok: bool, code: str, data: dict[str, Any]) -> dict[str, Any]:
-    return {"schema": RESPONSE_SCHEMA, "version": FABRIC_VERSION, "operation": operation, "ok": ok, "code": code, "data": data}
+    return {
+        "schema": RESPONSE_SCHEMA,
+        "version": FABRIC_VERSION,
+        "operation": operation,
+        "ok": ok,
+        "code": code,
+        "data": data,
+    }
 
 
-def _audit(tool: str, *, success: bool, changed: bool, summary: str, extra: dict[str, Any]) -> None:
+def _audit(
+    tool: str,
+    *,
+    success: bool,
+    changed: bool,
+    summary: str,
+    extra: dict[str, Any],
+) -> None:
     try:
         policy = op.OperatorPolicy()
-        op.audit_record(tool=tool, level=policy.level or "read_only", apply_mode=policy.apply_mode, dry_run=not changed, success=success, changed=changed, summary=summary[:500], extra=extra)
-    except Exception:
-        pass
+        op.audit_record(
+            tool=tool,
+            level=policy.level or "read_only",
+            apply_mode=policy.apply_mode,
+            dry_run=not changed,
+            success=success,
+            changed=changed,
+            summary=summary[:500],
+            extra=extra,
+        )
+    except _EXPECTED_ERRORS:
+        return
 
 
 class FabricPeerService:
     """Deterministic managed peer acceptor. No request reaches an LLM path."""
-    def __init__(self, *, policy_loader: Callable[[], FabricPeerPolicy] | None = None, tokens: dict[str, str] | None = None, db_path: Path | None = None, dispatch_fn: Callable[..., dict[str, Any]] | None = None, observed_fn: Callable[[str], list[dict[str, Any]]] | None = None, cancel_fn: Callable[[str, str], dict[str, Any]] | None = None, hermes_root: Path | None = None):
+
+    def __init__(
+        self,
+        *,
+        policy_loader: Callable[[], FabricPeerPolicy] | None = None,
+        tokens: dict[str, str] | None = None,
+        db_path: Path | None = None,
+        dispatch_fn: Callable[..., dict[str, Any]] | None = None,
+        observed_fn: Callable[[str], list[dict[str, Any]]] | None = None,
+        cancel_fn: Callable[[str, str], dict[str, Any]] | None = None,
+        hermes_root: Path | None = None,
+    ):
         self.hermes_root = hermes_root
         self.policy_loader = policy_loader or (lambda: load_peer_policy(hermes_root=hermes_root))
         self.tokens = tokens or load_peer_tokens()
         self.db_path = db_path or _db_path(PEER_DB_ENV, "peer.db", hermes_root)
         _init_peer_db(self.db_path)
         self.dispatch_fn = dispatch_fn or self._dispatch_local
-        self.observed_fn = observed_fn or (lambda task_id: op_runners.observed_runs(task_id, hermes_root=hermes_root))
+        self.observed_fn = observed_fn or (
+            lambda task_id: op_runners.observed_runs(task_id, hermes_root=hermes_root)
+        )
         self.cancel_fn = cancel_fn or self._cancel_local
         self._lock = threading.RLock()
 
     def _dispatch_local(self, contract: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-        return op_runners.dispatch_contract(contract, confirm=True, dry_run=False, timeout=int(kwargs.get("timeout", 30)), hermes_root=self.hermes_root)
+        return op_runners.dispatch_contract(
+            contract,
+            confirm=True,
+            dry_run=False,
+            timeout=int(kwargs.get("timeout", 30)),
+            hermes_root=self.hermes_root,
+        )
 
     def _cancel_local(self, backend: str, task_id: str) -> dict[str, Any]:
         return op_runners.get_backend(backend).cancel(task_id, hermes_root=self.hermes_root)
 
     def authenticate(self, authorization: str) -> str:
         if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_REQUIRED", "verified Fabric requires bearer authentication")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_REQUIRED",
+                "verified Fabric requires bearer authentication",
+            )
         presented = authorization[7:]
-        matches = [principal for principal, token in self.tokens.items() if hmac.compare_digest(token, presented)]
+        matches = [
+            principal
+            for principal, token in self.tokens.items()
+            if hmac.compare_digest(token, presented)
+        ]
         if len(matches) != 1:
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "coordinator principal authentication failed")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_FAILED",
+                "coordinator principal authentication failed",
+            )
         return matches[0]
 
     def capabilities(self, policy: FabricPeerPolicy) -> dict[str, Any]:
-        payload = {"schema": CAPABILITY_SCHEMA, "version": FABRIC_VERSION, "node_name": policy.node_name, "identity": policy.identity, "features": list(dict.fromkeys((*_DEFAULT_FEATURES, *policy.required_features))), "operations": ["capabilities", "accept", "status", "reconcile", "cancel", "evidence"], "policy_sha256": policy.digest}
+        payload = {
+            "schema": CAPABILITY_SCHEMA,
+            "version": FABRIC_VERSION,
+            "node_name": policy.node_name,
+            "identity": policy.identity,
+            "features": list(dict.fromkeys((*_DEFAULT_FEATURES, *policy.required_features))),
+            "operations": ["capabilities", "accept", "status", "reconcile", "cancel", "evidence"],
+            "policy_sha256": policy.digest,
+        }
         payload["snapshot_sha256"] = sha256_json(payload)
         return payload
 
@@ -726,16 +1212,23 @@ class FabricPeerService:
         request = _validate_request(request_value)
         principal = self.authenticate(authorization)
         if principal != request["coordinator_principal"]:
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "authenticated principal does not match the request")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_FAILED",
+                "authenticated principal does not match the request",
+            )
         policy = self.policy_loader()
         if principal not in policy.allowed_coordinator_principals:
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "coordinator principal is not authorized by peer policy")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_FAILED",
+                "coordinator principal is not authorized by peer policy",
+            )
         operation = request["operation"]
         if operation == "capabilities":
             _closed(request["data"], required=set(), name="capabilities data")
             return _response(operation, ok=True, code="FABRIC_OK", data=self.capabilities(policy))
         if operation == "accept":
             return self._accept(request, principal, policy)
+
         _closed(request["data"], required=set(), name=f"{operation} data")
         dispatch_id = _bounded_string(request.get("dispatch_id"), field="dispatch_id", pattern=_ID_RE)
         attempt_id = _bounded_string(request.get("attempt_id"), field="attempt_id", pattern=_ID_RE)
@@ -751,175 +1244,545 @@ class FabricPeerService:
             raise FabricError("FABRIC_OPERATION_UNSUPPORTED", "unsupported Fabric operation")
         return _response(operation, ok=True, code="FABRIC_OK", data=data)
 
-    def _authorize_envelope(self, env: dict[str, Any], principal: str, policy: FabricPeerPolicy) -> WorkspaceMapping:
-        if env["coordinator_principal"] != principal:
+    def _authorize_envelope(
+        self,
+        envelope: dict[str, Any],
+        principal: str,
+        policy: FabricPeerPolicy,
+    ) -> WorkspaceMapping:
+        if envelope["coordinator_principal"] != principal:
             raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "dispatch principal mismatch")
-        if env["target_node"] != policy.node_name:
-            raise FabricError("FABRIC_NODE_IDENTITY_MISMATCH", "dispatch targets a different managed node")
-        if env["assigned_profile"] not in policy.allowed_profiles:
+        if envelope["target_node"] != policy.node_name:
+            raise FabricError(
+                "FABRIC_NODE_IDENTITY_MISMATCH",
+                "dispatch targets a different managed node",
+            )
+        if envelope["assigned_profile"] not in policy.allowed_profiles:
             raise FabricError("FABRIC_AUTHORITY_DENIED", "assigned profile is outside peer policy")
-        auth = _auth_object(env["authorization"])
+        auth = _auth_object(envelope["authorization"])
         if _AUTH_RANK[auth["class"]] > _AUTH_RANK[policy.max_authorization]:
-            raise FabricError("FABRIC_AUTHORITY_DENIED", "dispatch exceeds peer authorization ceiling")
-        if env["remote_backend"] not in policy.allowed_backends:
+            raise FabricError(
+                "FABRIC_AUTHORITY_DENIED",
+                "dispatch exceeds peer authorization ceiling",
+            )
+        if envelope["remote_backend"] not in policy.allowed_backends:
             raise FabricError("FABRIC_AUTHORITY_DENIED", "remote backend is outside peer policy")
-        mapping = policy.workspace_mappings.get(env["logical_workspace"])
+        mapping = policy.workspace_mappings.get(envelope["logical_workspace"])
         if mapping is None:
-            raise FabricError("FABRIC_WORKSPACE_DENIED", "logical workspace is not mapped on the peer")
-        if not set(env["required_features"]) <= set((*_DEFAULT_FEATURES, *policy.required_features)):
-            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "peer does not support all required Fabric features")
+            raise FabricError(
+                "FABRIC_WORKSPACE_DENIED",
+                "logical workspace is not mapped on the peer",
+            )
+        supported = set(_DEFAULT_FEATURES).union(policy.required_features)
+        if not set(envelope["required_features"]) <= supported:
+            raise FabricError(
+                "FABRIC_PROTOCOL_INCOMPATIBLE",
+                "peer does not support all required Fabric features",
+            )
         return mapping
 
-    def _local_contract(self, env: dict[str, Any], mapping: WorkspaceMapping) -> dict[str, Any]:
-        return {"schema": "hermes.work-contract/v1", "task_id": env["attempt_id"], "objective": env["objective"], "assigned_agent": env["target_node"], "assigned_profile": env["assigned_profile"], "inputs": list(env["inputs"]), "constraints": list(env["constraints"]), "allowed_scope": {"workspaces": [str(mapping.local_path)], "profiles": [env["assigned_profile"]]}, "forbidden_actions": [], "expected_artifacts": [], "tests": [], "review_requirements": {"required": False, "reviewer": "", "evidence": "", "approval_required": False}, "completion_criteria": {"run_state": {"terminal": True, "outcome_ok": ["completed"]}, "artifacts_present": False, "tests_pass": False, "review_satisfied": False, "no_forbidden_actions": True}, "authorization": dict(env["authorization"]), "execution": {"backend": env["remote_backend"], "options": _bounded_json(env["remote_options"], field="remote_options")}}
+    def _local_contract(
+        self,
+        envelope: dict[str, Any],
+        mapping: WorkspaceMapping,
+    ) -> dict[str, Any]:
+        return {
+            "schema": "hermes.work-contract/v1",
+            "task_id": envelope["attempt_id"],
+            "objective": envelope["objective"],
+            "assigned_agent": envelope["target_node"],
+            "assigned_profile": envelope["assigned_profile"],
+            "inputs": list(envelope["inputs"]),
+            "constraints": list(envelope["constraints"]),
+            "allowed_scope": {
+                "workspaces": [str(mapping.local_path)],
+                "profiles": [envelope["assigned_profile"]],
+            },
+            "forbidden_actions": [],
+            "expected_artifacts": [],
+            "tests": [],
+            "review_requirements": {
+                "required": False,
+                "reviewer": "",
+                "evidence": "",
+                "approval_required": False,
+            },
+            "completion_criteria": {
+                "run_state": {"terminal": True, "outcome_ok": ["completed"]},
+                "artifacts_present": False,
+                "tests_pass": False,
+                "review_satisfied": False,
+                "no_forbidden_actions": True,
+            },
+            "authorization": dict(envelope["authorization"]),
+            "execution": {
+                "backend": envelope["remote_backend"],
+                "options": _bounded_json(envelope["remote_options"], field="remote_options"),
+            },
+        }
 
-    def _accept(self, request: dict[str, Any], principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+    def _accept(
+        self,
+        request: dict[str, Any],
+        principal: str,
+        policy: FabricPeerPolicy,
+    ) -> dict[str, Any]:
         data = _closed(request["data"], required={"envelope"}, name="accept data")
-        env = _validate_envelope(data["envelope"])
-        if request.get("dispatch_id") and request["dispatch_id"] != env["dispatch_id"]:
-            raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "request and envelope dispatch identity differ")
-        if request.get("attempt_id") and request["attempt_id"] != env["attempt_id"]:
-            raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "request and envelope attempt identity differ")
-        mapping = self._authorize_envelope(env, principal, policy)
-        envelope_sha = sha256_json(env)
+        envelope = _validate_envelope(data["envelope"])
+        if request.get("dispatch_id") and request["dispatch_id"] != envelope["dispatch_id"]:
+            raise FabricError(
+                "FABRIC_IDEMPOTENCY_CONFLICT",
+                "request and envelope dispatch identity differ",
+            )
+        if request.get("attempt_id") and request["attempt_id"] != envelope["attempt_id"]:
+            raise FabricError(
+                "FABRIC_IDEMPOTENCY_CONFLICT",
+                "request and envelope attempt identity differ",
+            )
+        mapping = self._authorize_envelope(envelope, principal, policy)
+        envelope_sha = sha256_json(envelope)
         now = _now()
+
         with self._lock, _connect(self.db_path) as db:
-            existing = db.execute("SELECT * FROM attempts WHERE attempt_id=?", (env["attempt_id"],)).fetchone()
+            existing = db.execute(
+                "SELECT * FROM attempts WHERE attempt_id=?",
+                (envelope["attempt_id"],),
+            ).fetchone()
             if existing is not None:
-                if existing["dispatch_id"] != env["dispatch_id"] or existing["envelope_sha256"] != envelope_sha:
-                    raise FabricError("FABRIC_IDEMPOTENCY_CONFLICT", "attempt identity was reused with different canonical content")
-                return _response("accept", ok=True, code="FABRIC_IDEMPOTENT_REPLAY", data={"dispatch_id": existing["dispatch_id"], "attempt_id": existing["attempt_id"], "state": existing["state"], "local_task_id": existing["local_task_id"], "policy_sha256": existing["policy_sha256"]})
-            auth_class = env["authorization"]["class"]
+                if (
+                    existing["dispatch_id"] != envelope["dispatch_id"]
+                    or existing["envelope_sha256"] != envelope_sha
+                ):
+                    raise FabricError(
+                        "FABRIC_IDEMPOTENCY_CONFLICT",
+                        "attempt identity was reused with different canonical content",
+                    )
+                return _response(
+                    "accept",
+                    ok=True,
+                    code="FABRIC_IDEMPOTENT_REPLAY",
+                    data={
+                        "dispatch_id": existing["dispatch_id"],
+                        "attempt_id": existing["attempt_id"],
+                        "state": existing["state"],
+                        "local_task_id": existing["local_task_id"],
+                        "policy_sha256": existing["policy_sha256"],
+                    },
+                )
+
+            auth_class = envelope["authorization"]["class"]
             if _AUTH_RANK[auth_class] >= _AUTH_RANK["reversible_write"]:
-                claim = db.execute("SELECT * FROM write_claims WHERE conflict_domain=?", (mapping.conflict_domain,)).fetchone()
+                claim = db.execute(
+                    "SELECT * FROM write_claims WHERE conflict_domain=?",
+                    (mapping.conflict_domain,),
+                ).fetchone()
                 if claim is not None and claim["state"] == "ACTIVE":
-                    raise FabricError("FABRIC_WRITE_OWNERSHIP_BLOCKED", "peer write conflict domain already has an active claim")
-                db.execute("INSERT OR REPLACE INTO write_claims(conflict_domain, attempt_id, state, acquired_at, released_at) VALUES(?,?,?,?,NULL)", (mapping.conflict_domain, env["attempt_id"], "ACTIVE", now))
-            db.execute("INSERT INTO attempts(attempt_id,dispatch_id,envelope_sha256,contract_sha256,task_id,coordinator_principal,node_name,remote_backend,logical_workspace,conflict_domain,authorization_class,policy_sha256,local_task_id,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (env["attempt_id"], env["dispatch_id"], envelope_sha, env["contract_sha256"], env["task_id"], principal, policy.node_name, env["remote_backend"], env["logical_workspace"], mapping.conflict_domain, auth_class, policy.digest, env["attempt_id"], "ACCEPTED", now, now))
+                    raise FabricError(
+                        "FABRIC_WRITE_OWNERSHIP_BLOCKED",
+                        "peer write conflict domain already has an active claim",
+                    )
+                db.execute(
+                    "INSERT OR REPLACE INTO write_claims"
+                    "(conflict_domain,attempt_id,state,acquired_at,released_at) VALUES(?,?,?,?,NULL)",
+                    (mapping.conflict_domain, envelope["attempt_id"], "ACTIVE", now),
+                )
+
+            db.execute(
+                "INSERT INTO attempts"
+                "(attempt_id,dispatch_id,envelope_sha256,contract_sha256,task_id,"
+                "coordinator_principal,node_name,remote_backend,logical_workspace,"
+                "conflict_domain,authorization_class,policy_sha256,local_task_id,state,"
+                "created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    envelope["attempt_id"],
+                    envelope["dispatch_id"],
+                    envelope_sha,
+                    envelope["contract_sha256"],
+                    envelope["task_id"],
+                    principal,
+                    policy.node_name,
+                    envelope["remote_backend"],
+                    envelope["logical_workspace"],
+                    mapping.conflict_domain,
+                    auth_class,
+                    policy.digest,
+                    envelope["attempt_id"],
+                    "ACCEPTED",
+                    now,
+                    now,
+                ),
+            )
+
+        # G3-S06: re-read local policy immediately before runner start.
         prestart = self.policy_loader()
-        prestart_mapping = self._authorize_envelope(env, principal, prestart)
-        if prestart_mapping.local_path != mapping.local_path or prestart_mapping.revision != mapping.revision or prestart_mapping.conflict_domain != mapping.conflict_domain:
+        prestart_mapping = self._authorize_envelope(envelope, principal, prestart)
+        if (
+            prestart_mapping.local_path != mapping.local_path
+            or prestart_mapping.revision != mapping.revision
+            or prestart_mapping.conflict_domain != mapping.conflict_domain
+        ):
             with _connect(self.db_path) as db:
-                db.execute("UPDATE attempts SET state=?, policy_sha256=?, updated_at=? WHERE attempt_id=?", ("BLOCKED", prestart.digest, _now(), env["attempt_id"]))
-            raise FabricError("FABRIC_POLICY_DRIFT", "peer workspace policy changed between acceptance and runner start")
-        local_contract = self._local_contract(env, prestart_mapping)
+                db.execute(
+                    "UPDATE attempts SET state=?,policy_sha256=?,updated_at=? WHERE attempt_id=?",
+                    ("BLOCKED", prestart.digest, _now(), envelope["attempt_id"]),
+                )
+            raise FabricError(
+                "FABRIC_POLICY_DRIFT",
+                "peer workspace policy changed between acceptance and runner start",
+            )
+
         try:
-            backend = op_runners.get_backend(env["remote_backend"])
-            if not bool(backend.availability(hermes_root=self.hermes_root).get("available")):
-                raise FabricError("FABRIC_RUNNER_UNAVAILABLE", "remote runner is unavailable at pre-start revalidation")
+            backend = op_runners.get_backend(envelope["remote_backend"])
         except LookupError as exc:
             raise FabricError("FABRIC_RUNNER_UNAVAILABLE", "remote runner is not registered") from exc
-        result = self.dispatch_fn(local_contract, timeout=30)
+        if not bool(backend.availability(hermes_root=self.hermes_root).get("available")):
+            raise FabricError(
+                "FABRIC_RUNNER_UNAVAILABLE",
+                "remote runner is unavailable at pre-start revalidation",
+            )
+
+        result = self.dispatch_fn(self._local_contract(envelope, prestart_mapping), timeout=30)
         if not isinstance(result, dict):
             result = {"success": False, "code": "FABRIC_RUNNER_INVALID_RESULT"}
         state = "RUNNING" if bool(result.get("success")) else "FAILED"
         with _connect(self.db_path) as db:
-            db.execute("UPDATE attempts SET state=?, dispatch_result_json=?, policy_sha256=?, updated_at=? WHERE attempt_id=?", (state, canonical_json(_bounded_json(result, field="dispatch_result")), prestart.digest, _now(), env["attempt_id"]))
-        _audit("hermes_fabric_peer_accept", success=bool(result.get("success")), changed=bool(result.get("success")), summary=f"Fabric attempt accepted on {policy.node_name}", extra={"dispatch_id": env["dispatch_id"], "attempt_id": env["attempt_id"], "task_id": env["task_id"], "backend": env["remote_backend"], "principal": principal, "policy_sha256": prestart.digest})
-        return _response("accept", ok=bool(result.get("success")), code="FABRIC_ACCEPTED" if result.get("success") else str(result.get("code") or "FABRIC_RUNNER_REJECTED"), data={"dispatch_id": env["dispatch_id"], "attempt_id": env["attempt_id"], "state": state, "local_task_id": env["attempt_id"], "policy_sha256": prestart.digest})
+            db.execute(
+                "UPDATE attempts SET state=?,dispatch_result_json=?,policy_sha256=?,updated_at=?"
+                " WHERE attempt_id=?",
+                (
+                    state,
+                    canonical_json(_bounded_json(result, field="dispatch_result")),
+                    prestart.digest,
+                    _now(),
+                    envelope["attempt_id"],
+                ),
+            )
+
+        _audit(
+            "hermes_fabric_peer_accept",
+            success=bool(result.get("success")),
+            changed=bool(result.get("success")),
+            summary=f"Fabric attempt accepted on {policy.node_name}",
+            extra={
+                "dispatch_id": envelope["dispatch_id"],
+                "attempt_id": envelope["attempt_id"],
+                "task_id": envelope["task_id"],
+                "backend": envelope["remote_backend"],
+                "principal": principal,
+                "policy_sha256": prestart.digest,
+            },
+        )
+        return _response(
+            "accept",
+            ok=bool(result.get("success")),
+            code="FABRIC_ACCEPTED" if result.get("success") else str(result.get("code") or "FABRIC_RUNNER_REJECTED"),
+            data={
+                "dispatch_id": envelope["dispatch_id"],
+                "attempt_id": envelope["attempt_id"],
+                "state": state,
+                "local_task_id": envelope["attempt_id"],
+                "policy_sha256": prestart.digest,
+            },
+        )
 
     def _row(self, dispatch_id: str, attempt_id: str) -> sqlite3.Row:
-        with _connect(self.db_path) as db:
-            row = db.execute("SELECT * FROM attempts WHERE attempt_id=? AND dispatch_id=?", (attempt_id, dispatch_id)).fetchone()
+        with _connect_readonly(self.db_path) as db:
+            row = db.execute(
+                "SELECT * FROM attempts WHERE attempt_id=? AND dispatch_id=?",
+                (attempt_id, dispatch_id),
+            ).fetchone()
         if row is None:
-            raise FabricError("FABRIC_ATTEMPT_NOT_FOUND", "Fabric attempt is not present in the peer journal")
+            raise FabricError(
+                "FABRIC_ATTEMPT_NOT_FOUND",
+                "Fabric attempt is not present in the peer journal",
+            )
         return row
 
     def _status(self, dispatch_id: str, attempt_id: str, *, reconcile: bool) -> dict[str, Any]:
         row = self._row(dispatch_id, attempt_id)
         if row["state"] in _TERMINAL_PEER:
-            return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": row["state"], "local_task_id": row["local_task_id"], "policy_sha256": row["policy_sha256"]}
+            return {
+                "dispatch_id": dispatch_id,
+                "attempt_id": attempt_id,
+                "state": row["state"],
+                "local_task_id": row["local_task_id"],
+                "policy_sha256": row["policy_sha256"],
+            }
+
         primary = _latest_run(self.observed_fn(row["local_task_id"]))
         state = row["state"]
         if primary is not None:
             run_state = str(primary.get("state") or primary.get("status") or "").lower()
-            if run_state in {"completed", "succeeded", "success"}: state = "SUCCEEDED"
-            elif run_state in {"failed", "error"}: state = "FAILED"
-            elif run_state in {"cancelled", "canceled"}: state = "CANCELLED"
-            else: state = "RUNNING"
+            if run_state in {"completed", "succeeded", "success"}:
+                state = "SUCCEEDED"
+            elif run_state in {"failed", "error"}:
+                state = "FAILED"
+            elif run_state in {"cancelled", "canceled"}:
+                state = "CANCELLED"
+            else:
+                state = "RUNNING"
         elif reconcile and state in {"ACCEPTED", "RUNNING", "CANCEL_REQUESTED"}:
             state = "LOST_AMBIGUOUS"
-        with _connect(self.db_path) as db:
-            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
-        return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "local_task_id": row["local_task_id"], "policy_sha256": row["policy_sha256"]}
 
-    def _cancel(self, dispatch_id: str, attempt_id: str, principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+        with _connect(self.db_path) as db:
+            db.execute(
+                "UPDATE attempts SET state=?,updated_at=? WHERE attempt_id=?",
+                (state, _now(), attempt_id),
+            )
+        return {
+            "dispatch_id": dispatch_id,
+            "attempt_id": attempt_id,
+            "state": state,
+            "local_task_id": row["local_task_id"],
+            "policy_sha256": row["policy_sha256"],
+        }
+
+    def _cancel(
+        self,
+        dispatch_id: str,
+        attempt_id: str,
+        principal: str,
+        policy: FabricPeerPolicy,
+    ) -> dict[str, Any]:
         row = self._row(dispatch_id, attempt_id)
         if row["coordinator_principal"] != principal or row["node_name"] != policy.node_name:
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "cancel identity does not match accepted attempt")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_FAILED",
+                "cancel identity does not match accepted attempt",
+            )
         if row["state"] in _TERMINAL_PEER:
-            return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": row["state"], "idempotent": True}
+            return {
+                "dispatch_id": dispatch_id,
+                "attempt_id": attempt_id,
+                "state": row["state"],
+                "idempotent": True,
+            }
         with _connect(self.db_path) as db:
-            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", ("CANCEL_REQUESTED", _now(), attempt_id))
+            db.execute(
+                "UPDATE attempts SET state=?,updated_at=? WHERE attempt_id=?",
+                ("CANCEL_REQUESTED", _now(), attempt_id),
+            )
         result = self.cancel_fn(row["remote_backend"], row["local_task_id"])
-        state = "CANCELLED" if bool(result.get("success")) and str(result.get("state") or "").lower() in {"cancelled", "canceled"} else "CANCEL_REQUESTED"
+        state = (
+            "CANCELLED"
+            if bool(result.get("success"))
+            and str(result.get("state") or "").lower() in {"cancelled", "canceled"}
+            else "CANCEL_REQUESTED"
+        )
         with _connect(self.db_path) as db:
-            db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
-        return {"dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "changed": bool(result.get("changed"))}
+            db.execute(
+                "UPDATE attempts SET state=?,updated_at=? WHERE attempt_id=?",
+                (state, _now(), attempt_id),
+            )
+        return {
+            "dispatch_id": dispatch_id,
+            "attempt_id": attempt_id,
+            "state": state,
+            "changed": bool(result.get("changed")),
+        }
 
-    def _evidence(self, dispatch_id: str, attempt_id: str, principal: str, policy: FabricPeerPolicy) -> dict[str, Any]:
+    def _evidence(
+        self,
+        dispatch_id: str,
+        attempt_id: str,
+        principal: str,
+        policy: FabricPeerPolicy,
+    ) -> dict[str, Any]:
         status = self._status(dispatch_id, attempt_id, reconcile=False)
         row = self._row(dispatch_id, attempt_id)
         if row["coordinator_principal"] != principal or row["node_name"] != policy.node_name:
-            raise FabricError("FABRIC_PRINCIPAL_AUTH_FAILED", "evidence identity does not match accepted attempt")
+            raise FabricError(
+                "FABRIC_PRINCIPAL_AUTH_FAILED",
+                "evidence identity does not match accepted attempt",
+            )
         if status["state"] not in {"SUCCEEDED", "FAILED", "CANCELLED"}:
-            raise FabricError("FABRIC_EVIDENCE_NOT_READY", "terminal remote execution evidence is not available")
+            raise FabricError(
+                "FABRIC_EVIDENCE_NOT_READY",
+                "terminal remote execution evidence is not available",
+            )
+
         primary = _latest_run(self.observed_fn(row["local_task_id"]))
         observations: list[dict[str, Any]] = []
         if primary is not None:
-            observations.append({"kind": "run_state", "provenance": "managed_peer_structured", "state": str(primary.get("status") or primary.get("state") or ""), "outcome": str(primary.get("outcome") or primary.get("state") or primary.get("status") or ""), "started_at": str(primary.get("started_at") or primary.get("dispatched_at") or ""), "ended_at": str(primary.get("ended_at") or primary.get("completed_at") or ""), "error": op.redact_output(str(primary.get("error") or ""))[:1_000], "source": f"runner:{row['remote_backend']}"})
-        evidence = {"schema": EVIDENCE_SCHEMA, "version": FABRIC_VERSION, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "contract_sha256": row["contract_sha256"], "task_id": row["task_id"], "node_name": row["node_name"], "peer_identity": policy.identity, "coordinator_principal": principal, "remote_backend": row["remote_backend"], "terminal_state": status["state"], "observations": observations, "policy_sha256": row["policy_sha256"], "created_at": _now()}
+            observations.append(
+                {
+                    "kind": "run_state",
+                    "provenance": "managed_peer_structured",
+                    "state": str(primary.get("status") or primary.get("state") or ""),
+                    "outcome": str(primary.get("outcome") or primary.get("state") or primary.get("status") or ""),
+                    "started_at": str(primary.get("started_at") or primary.get("dispatched_at") or ""),
+                    "ended_at": str(primary.get("ended_at") or primary.get("completed_at") or ""),
+                    "error": op.redact_output(str(primary.get("error") or ""))[:1_000],
+                    "source": f"runner:{row['remote_backend']}",
+                }
+            )
+        evidence = {
+            "schema": EVIDENCE_SCHEMA,
+            "version": FABRIC_VERSION,
+            "dispatch_id": dispatch_id,
+            "attempt_id": attempt_id,
+            "contract_sha256": row["contract_sha256"],
+            "task_id": row["task_id"],
+            "node_name": row["node_name"],
+            "peer_identity": policy.identity,
+            "coordinator_principal": principal,
+            "remote_backend": row["remote_backend"],
+            "terminal_state": status["state"],
+            "observations": observations,
+            "policy_sha256": row["policy_sha256"],
+            "created_at": _now(),
+        }
         return {"evidence": evidence}
 
 
 def _latest_run(runs: Any) -> dict[str, Any] | None:
-    if not isinstance(runs, list): return None
+    if not isinstance(runs, list):
+        return None
     candidates = [run for run in runs if isinstance(run, dict)]
-    if not candidates: return None
-    return max(candidates, key=lambda run: (str(run.get("started_at") or run.get("dispatched_at") or ""), str(run.get("ended_at") or run.get("completed_at") or ""), str(run.get("status") or run.get("state") or "")))
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda run: (
+            str(run.get("started_at") or run.get("dispatched_at") or ""),
+            str(run.get("ended_at") or run.get("completed_at") or ""),
+            str(run.get("status") or run.get("state") or ""),
+        ),
+    )
 
 
-def _validate_evidence(value: Any, *, attempt: Any, node: FabricNode, allowed_provenance: tuple[str, ...]) -> dict[str, Any]:
-    required = {"schema", "version", "dispatch_id", "attempt_id", "contract_sha256", "task_id", "node_name", "peer_identity", "coordinator_principal", "remote_backend", "terminal_state", "observations", "policy_sha256", "created_at"}
+def _validate_evidence(
+    value: Any,
+    *,
+    attempt: Any,
+    node: FabricNode,
+    allowed_provenance: tuple[str, ...],
+) -> dict[str, Any]:
+    required = {
+        "schema",
+        "version",
+        "dispatch_id",
+        "attempt_id",
+        "contract_sha256",
+        "task_id",
+        "node_name",
+        "peer_identity",
+        "coordinator_principal",
+        "remote_backend",
+        "terminal_state",
+        "observations",
+        "policy_sha256",
+        "created_at",
+    }
     evidence = _closed(value, required=required, name="Fabric evidence")
     if evidence["schema"] != EVIDENCE_SCHEMA or evidence["version"] != FABRIC_VERSION:
         raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence schema/version is invalid")
-    exact = {"dispatch_id": attempt["dispatch_id"], "attempt_id": attempt["attempt_id"], "node_name": node.name, "peer_identity": node.expected_identity, "coordinator_principal": node.coordinator_principal, "remote_backend": attempt["remote_backend"]}
+
+    exact = {
+        "dispatch_id": attempt["dispatch_id"],
+        "attempt_id": attempt["attempt_id"],
+        "node_name": node.name,
+        "peer_identity": node.expected_identity,
+        "coordinator_principal": node.coordinator_principal,
+        "remote_backend": attempt["remote_backend"],
+    }
     for key, expected in exact.items():
         if evidence.get(key) != expected:
-            raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", f"evidence {key} does not match the admitted attempt")
-    with _connect(Path(attempt["_coordinator_db"])) as db:
-        dispatch = db.execute("SELECT * FROM dispatches WHERE dispatch_id=?", (attempt["dispatch_id"],)).fetchone()
-    if dispatch is None or evidence.get("contract_sha256") != dispatch["contract_sha256"] or evidence.get("task_id") != dispatch["task_id"]:
-        raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", "evidence contract/task lineage does not match")
-    if attempt.get("peer_policy_sha256") and evidence.get("policy_sha256") != attempt.get("peer_policy_sha256"):
-        raise FabricError("FABRIC_EVIDENCE_LINEAGE_MISMATCH", "evidence peer policy digest does not match accepted attempt")
+            raise FabricError(
+                "FABRIC_EVIDENCE_LINEAGE_MISMATCH",
+                f"evidence {key} does not match the admitted attempt",
+            )
+
+    coordinator_db = Path(attempt["_coordinator_db"])
+    if not coordinator_db.is_file():
+        raise FabricError("FABRIC_JOURNAL_CORRUPT", "coordinator dispatch lineage is missing")
+    with _connect_readonly(coordinator_db) as db:
+        dispatch = db.execute(
+            "SELECT * FROM dispatches WHERE dispatch_id=?",
+            (attempt["dispatch_id"],),
+        ).fetchone()
+    if (
+        dispatch is None
+        or evidence.get("contract_sha256") != dispatch["contract_sha256"]
+        or evidence.get("task_id") != dispatch["task_id"]
+    ):
+        raise FabricError(
+            "FABRIC_EVIDENCE_LINEAGE_MISMATCH",
+            "evidence contract/task lineage does not match",
+        )
+    if attempt.get("peer_policy_sha256") and evidence.get("policy_sha256") != attempt.get(
+        "peer_policy_sha256"
+    ):
+        raise FabricError(
+            "FABRIC_EVIDENCE_LINEAGE_MISMATCH",
+            "evidence peer policy digest does not match accepted attempt",
+        )
     if evidence["terminal_state"] not in {"SUCCEEDED", "FAILED", "CANCELLED"}:
         raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence is not terminal")
+
     observations = evidence["observations"]
     if not isinstance(observations, list) or len(observations) > _MAX_ITEMS:
         raise FabricError("FABRIC_EVIDENCE_REJECTED", "evidence observations are invalid")
     clean: list[dict[str, Any]] = []
     for observation in observations:
-        observation = _closed(observation, required={"kind", "provenance", "state", "outcome", "started_at", "ended_at", "error", "source"}, name="evidence observation")
+        observation = _closed(
+            observation,
+            required={"kind", "provenance", "state", "outcome", "started_at", "ended_at", "error", "source"},
+            name="evidence observation",
+        )
         if observation["kind"] != "run_state":
-            raise FabricError("FABRIC_EVIDENCE_REJECTED", "G4-A accepts only run_state remote observations")
-        provenance = _bounded_string(observation["provenance"], field="observation.provenance", maximum=64)
+            raise FabricError(
+                "FABRIC_EVIDENCE_REJECTED",
+                "G4-A accepts only run_state remote observations",
+            )
+        provenance = _bounded_string(
+            observation["provenance"],
+            field="observation.provenance",
+            maximum=64,
+        )
         if provenance not in allowed_provenance or provenance == "worker_statement":
-            raise FabricError("FABRIC_EVIDENCE_PROVENANCE_REJECTED", "evidence provenance is not allowed for the check")
-        clean.append({key: (_bounded_string(observation[key], field=f"observation.{key}", maximum=1_000, required=False) if key not in {"provenance", "kind"} else observation[key]) for key in observation})
-    evidence = dict(evidence); evidence["observations"] = clean
-    return evidence
+            raise FabricError(
+                "FABRIC_EVIDENCE_PROVENANCE_REJECTED",
+                "evidence provenance is not allowed for the check",
+            )
+        clean.append(
+            {
+                "kind": "run_state",
+                "provenance": provenance,
+                "state": _bounded_string(observation["state"], field="observation.state", maximum=1_000, required=False),
+                "outcome": _bounded_string(observation["outcome"], field="observation.outcome", maximum=1_000, required=False),
+                "started_at": _bounded_string(observation["started_at"], field="observation.started_at", maximum=1_000, required=False),
+                "ended_at": _bounded_string(observation["ended_at"], field="observation.ended_at", maximum=1_000, required=False),
+                "error": _bounded_string(observation["error"], field="observation.error", maximum=1_000, required=False),
+                "source": _bounded_string(observation["source"], field="observation.source", maximum=1_000, required=False),
+            }
+        )
+    admitted = dict(evidence)
+    admitted["observations"] = clean
+    return admitted
 
 
 class FabricCoordinator:
-    def __init__(self, *, registry_loader: Callable[[], dict[str, FabricNode]] | None = None, db_path: Path | None = None, rpc: Callable[[FabricNode, dict[str, Any], int], tuple[str | None, dict[str, Any]]] | None = None, hermes_root: Path | None = None):
+    def __init__(
+        self,
+        *,
+        registry_loader: Callable[[], dict[str, FabricNode]] | None = None,
+        db_path: Path | None = None,
+        rpc: Callable[[FabricNode, dict[str, Any], int], tuple[str | None, dict[str, Any]]] | None = None,
+        hermes_root: Path | None = None,
+    ):
         self.hermes_root = hermes_root
-        self.registry_loader = registry_loader or (lambda: load_node_registry(hermes_root=hermes_root))
+        self.registry_loader = registry_loader or (
+            lambda: load_node_registry(hermes_root=hermes_root)
+        )
         self.db_path = db_path or _db_path(COORDINATOR_DB_ENV, "coordinator.db", hermes_root)
-        _init_coordinator_db(self.db_path)
+        # Deliberately lazy: constructing the Fabric backend during ordinary
+        # Work Contract validation must not create or mutate state.
         self.rpc = rpc or (lambda node, request, timeout: _rpc_call(node, request, timeout=timeout))
         self._lock = threading.RLock()
+
+    def _ensure_db(self) -> None:
+        _init_coordinator_db(self.db_path)
 
     def _node(self, name: str) -> FabricNode:
         node = self.registry_loader().get(name)
@@ -928,130 +1791,524 @@ class FabricCoordinator:
         return node
 
     def _capabilities(self, node: FabricNode, timeout: int) -> dict[str, Any]:
-        _, response = self.rpc(node, _request("capabilities", node.coordinator_principal, data={}), timeout)
+        _, response = self.rpc(
+            node,
+            _request("capabilities", node.coordinator_principal, data={}),
+            timeout,
+        )
         response = _validate_response(response, operation="capabilities")
         if not response["ok"]:
             raise FabricError(response["code"], "Fabric capability negotiation failed")
-        data = _closed(response["data"], required={"schema", "version", "node_name", "identity", "features", "operations", "policy_sha256", "snapshot_sha256"}, name="capability response")
-        if data["schema"] != CAPABILITY_SCHEMA or data["version"] != FABRIC_VERSION or data["node_name"] != node.name or data["identity"] != node.expected_identity:
-            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "managed peer capability identity/version is incompatible")
-        features = set(_bounded_strings(data["features"], field="capability.features", maximum=32, item_max=128))
-        if not set((*_DEFAULT_FEATURES, *node.required_features)) <= features:
-            raise FabricError("FABRIC_PROTOCOL_INCOMPATIBLE", "managed peer lacks required Fabric features")
-        if data["snapshot_sha256"] != sha256_json({key: data[key] for key in data if key != "snapshot_sha256"}):
+        data = _closed(
+            response["data"],
+            required={
+                "schema",
+                "version",
+                "node_name",
+                "identity",
+                "features",
+                "operations",
+                "policy_sha256",
+                "snapshot_sha256",
+            },
+            name="capability response",
+        )
+        if (
+            data["schema"] != CAPABILITY_SCHEMA
+            or data["version"] != FABRIC_VERSION
+            or data["node_name"] != node.name
+            or data["identity"] != node.expected_identity
+        ):
+            raise FabricError(
+                "FABRIC_PROTOCOL_INCOMPATIBLE",
+                "managed peer capability identity/version is incompatible",
+            )
+        features = set(
+            _bounded_strings(data["features"], field="capability.features", maximum=32, item_max=128)
+        )
+        if not set(_DEFAULT_FEATURES).union(node.required_features) <= features:
+            raise FabricError(
+                "FABRIC_PROTOCOL_INCOMPATIBLE",
+                "managed peer lacks required Fabric features",
+            )
+        expected_sha = sha256_json({key: data[key] for key in data if key != "snapshot_sha256"})
+        if data["snapshot_sha256"] != expected_sha:
             raise FabricError("FABRIC_PROTOCOL_ERROR", "capability snapshot digest is invalid")
         return data
 
-    def dispatch(self, contract: dict[str, Any], *, dry_run: bool, confirm: bool, timeout: int) -> dict[str, Any]:
-        node_name, remote_backend, logical_workspace, remote_options, evidence_policy = _fabric_options(contract)
+    def dispatch(
+        self,
+        contract: dict[str, Any],
+        *,
+        dry_run: bool,
+        confirm: bool,
+        timeout: int,
+    ) -> dict[str, Any]:
+        node_name, remote_backend, logical_workspace, remote_options, evidence_policy = _fabric_options(
+            contract
+        )
         node = self._node(node_name)
         if contract.get("assigned_agent") != node.name:
-            raise FabricError("FABRIC_AUTHORITY_DENIED", "Fabric contract assigned_agent must match the managed node name")
+            raise FabricError(
+                "FABRIC_AUTHORITY_DENIED",
+                "Fabric contract assigned_agent must match the managed node name",
+            )
         if contract.get("assigned_profile") not in node.allowed_profiles:
-            raise FabricError("FABRIC_AUTHORITY_DENIED", "contract profile is outside managed-node policy")
+            raise FabricError(
+                "FABRIC_AUTHORITY_DENIED",
+                "contract profile is outside managed-node policy",
+            )
         auth = _auth_object(contract.get("authorization"))
         if _AUTH_RANK[auth["class"]] > _AUTH_RANK[node.max_authorization]:
-            raise FabricError("FABRIC_AUTHORITY_DENIED", "contract authorization exceeds managed-node ceiling")
+            raise FabricError(
+                "FABRIC_AUTHORITY_DENIED",
+                "contract authorization exceeds managed-node ceiling",
+            )
         if remote_backend not in node.allowed_remote_backends:
-            raise FabricError("FABRIC_AUTHORITY_DENIED", "remote backend is outside managed-node policy")
+            raise FabricError(
+                "FABRIC_AUTHORITY_DENIED",
+                "remote backend is outside managed-node policy",
+            )
         if logical_workspace not in node.logical_workspaces:
-            raise FabricError("FABRIC_WORKSPACE_DENIED", "logical workspace is outside managed-node policy")
-        contract_sha = _contract_sha(contract); stable_dispatch_id = _dispatch_id(contract_sha, str(contract["task_id"]), node.name)
+            raise FabricError(
+                "FABRIC_WORKSPACE_DENIED",
+                "logical workspace is outside managed-node policy",
+            )
+
+        contract_sha = _contract_sha(contract)
+        stable_dispatch_id = _dispatch_id(contract_sha, str(contract["task_id"]), node.name)
         if dry_run:
-            return {"success": True, "dry_run": True, "changed": False, "backend": "fabric", "node": node.name, "dispatch_id": stable_dispatch_id, "remote_backend": remote_backend, "logical_workspace": logical_workspace, "live_peer_verification": "required_before_dispatch"}
+            return {
+                "success": True,
+                "dry_run": True,
+                "changed": False,
+                "backend": "fabric",
+                "node": node.name,
+                "dispatch_id": stable_dispatch_id,
+                "remote_backend": remote_backend,
+                "logical_workspace": logical_workspace,
+                "live_peer_verification": "required_before_dispatch",
+            }
         if not confirm:
             raise FabricError("CONFIRMATION_REQUIRED", "Fabric dispatch requires confirm=true")
-        with _connect(self.db_path) as db:
-            existing = db.execute("SELECT a.* FROM attempts a WHERE a.dispatch_id=? ORDER BY a.created_at LIMIT 1", (stable_dispatch_id,)).fetchone()
+
+        self._ensure_db()
+        with _connect_readonly(self.db_path) as db:
+            existing = db.execute(
+                "SELECT a.* FROM attempts a WHERE a.dispatch_id=? ORDER BY a.created_at LIMIT 1",
+                (stable_dispatch_id,),
+            ).fetchone()
         if existing is not None:
-            return {"success": existing["state"] in {"SUBMITTED", "RUNNING", "TERMINAL_REPORTED", "COMPLETED"}, "changed": False, "backend": "fabric", "node": node.name, "dispatch_id": stable_dispatch_id, "attempt_id": existing["attempt_id"], "state": existing["state"], "remote_task_id": existing["remote_task_id"], "idempotent": True}
+            return {
+                "success": existing["state"]
+                in {"SUBMITTED", "RUNNING", "TERMINAL_REPORTED", "COMPLETED"},
+                "changed": False,
+                "backend": "fabric",
+                "node": node.name,
+                "dispatch_id": stable_dispatch_id,
+                "attempt_id": existing["attempt_id"],
+                "state": existing["state"],
+                "remote_task_id": existing["remote_task_id"],
+                "idempotent": True,
+            }
+
         capabilities = self._capabilities(node, timeout)
-        envelope = _build_envelope(contract, node, remote_backend=remote_backend, logical_workspace=logical_workspace, remote_options=remote_options, evidence_policy=evidence_policy, capability_sha=capabilities["snapshot_sha256"])
-        envelope_sha = sha256_json(envelope); dispatch_id = envelope["dispatch_id"]; attempt_id = envelope["attempt_id"]; now = _now()
+        envelope = _build_envelope(
+            contract,
+            node,
+            remote_backend=remote_backend,
+            logical_workspace=logical_workspace,
+            remote_options=remote_options,
+            evidence_policy=evidence_policy,
+            capability_sha=capabilities["snapshot_sha256"],
+        )
+        envelope_sha = sha256_json(envelope)
+        dispatch_id = envelope["dispatch_id"]
+        attempt_id = envelope["attempt_id"]
+        now = _now()
         with self._lock, _connect(self.db_path) as db:
-            db.execute("INSERT OR IGNORE INTO dispatches(dispatch_id,task_id,contract_sha256,node_name,evidence_policy_json,created_at) VALUES(?,?,?,?,?,?)", (dispatch_id, envelope["task_id"], envelope["contract_sha256"], node.name, canonical_json({k: list(v) for k, v in evidence_policy.items()}), now))
-            db.execute("INSERT OR REPLACE INTO attempts(attempt_id,dispatch_id,envelope_sha256,node_name,peer_name,remote_backend,coordinator_principal,capability_sha256,peer_policy_sha256,state,remote_task_id,evidence_json,error_code,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,NULL,?,NULL,NULL,NULL,?,?)", (attempt_id, dispatch_id, envelope_sha, node.name, node.a2a_peer_name, remote_backend, node.coordinator_principal, capabilities["snapshot_sha256"], "SUBMITTING", now, now))
-        request = _request("accept", node.coordinator_principal, data={"envelope": envelope}, dispatch_id=dispatch_id, attempt_id=attempt_id)
+            db.execute(
+                "INSERT OR IGNORE INTO dispatches"
+                "(dispatch_id,task_id,contract_sha256,node_name,evidence_policy_json,created_at)"
+                " VALUES(?,?,?,?,?,?)",
+                (
+                    dispatch_id,
+                    envelope["task_id"],
+                    envelope["contract_sha256"],
+                    node.name,
+                    canonical_json({key: list(value) for key, value in evidence_policy.items()}),
+                    now,
+                ),
+            )
+            db.execute(
+                "INSERT OR REPLACE INTO attempts"
+                "(attempt_id,dispatch_id,envelope_sha256,node_name,peer_name,remote_backend,"
+                "coordinator_principal,capability_sha256,peer_policy_sha256,state,remote_task_id,"
+                "evidence_json,error_code,created_at,updated_at)"
+                " VALUES(?,?,?,?,?,?,?,?,NULL,?,NULL,NULL,NULL,?,?)",
+                (
+                    attempt_id,
+                    dispatch_id,
+                    envelope_sha,
+                    node.name,
+                    node.a2a_peer_name,
+                    remote_backend,
+                    node.coordinator_principal,
+                    capabilities["snapshot_sha256"],
+                    "SUBMITTING",
+                    now,
+                    now,
+                ),
+            )
+
+        request = _request(
+            "accept",
+            node.coordinator_principal,
+            data={"envelope": envelope},
+            dispatch_id=dispatch_id,
+            attempt_id=attempt_id,
+        )
         try:
             remote_task_id, response = self.rpc(node, request, timeout)
         except FabricError as exc:
             state = "SUBMISSION_AMBIGUOUS" if exc.ambiguous else "BLOCKED"
             with _connect(self.db_path) as db:
-                db.execute("UPDATE attempts SET state=?, error_code=?, updated_at=? WHERE attempt_id=?", (state, exc.code, _now(), attempt_id))
-            _audit("hermes_fabric_dispatch", success=False, changed=exc.ambiguous, summary="Fabric dispatch ambiguous" if exc.ambiguous else "Fabric dispatch failed", extra={"dispatch_id": dispatch_id, "attempt_id": attempt_id, "node": node.name, "code": exc.code, "principal": node.coordinator_principal})
+                db.execute(
+                    "UPDATE attempts SET state=?,error_code=?,updated_at=? WHERE attempt_id=?",
+                    (state, exc.code, _now(), attempt_id),
+                )
+            _audit(
+                "hermes_fabric_dispatch",
+                success=False,
+                changed=exc.ambiguous,
+                summary="Fabric dispatch ambiguous" if exc.ambiguous else "Fabric dispatch failed",
+                extra={
+                    "dispatch_id": dispatch_id,
+                    "attempt_id": attempt_id,
+                    "node": node.name,
+                    "code": exc.code,
+                    "principal": node.coordinator_principal,
+                },
+            )
             if exc.ambiguous:
-                return {"success": False, "changed": True, "backend": "fabric", "code": exc.code, "node": node.name, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "state": state, "submission_may_have_succeeded": True, "suggested_action": "Reconcile this Fabric attempt; do not create a replacement writer."}
+                return {
+                    "success": False,
+                    "changed": True,
+                    "backend": "fabric",
+                    "code": exc.code,
+                    "node": node.name,
+                    "dispatch_id": dispatch_id,
+                    "attempt_id": attempt_id,
+                    "state": state,
+                    "submission_may_have_succeeded": True,
+                    "suggested_action": (
+                        "Reconcile this Fabric attempt; do not create a replacement writer."
+                    ),
+                }
             raise
-        response = _validate_response(response, operation="accept"); data = response["data"]
+
+        response = _validate_response(response, operation="accept")
+        data = response["data"]
         if data.get("dispatch_id") != dispatch_id or data.get("attempt_id") != attempt_id:
             raise FabricError("FABRIC_PROTOCOL_ERROR", "peer accept response lineage mismatch")
         state = "SUBMITTED" if response["ok"] else "BLOCKED"
         with _connect(self.db_path) as db:
-            db.execute("UPDATE attempts SET state=?, remote_task_id=?, peer_policy_sha256=?, error_code=?, updated_at=? WHERE attempt_id=?", (state, remote_task_id, data.get("policy_sha256"), None if response["ok"] else response["code"], _now(), attempt_id))
-        _audit("hermes_fabric_dispatch", success=response["ok"], changed=response["ok"], summary=f"Fabric attempt submitted to {node.name}", extra={"dispatch_id": dispatch_id, "attempt_id": attempt_id, "task_id": envelope["task_id"], "node": node.name, "remote_backend": remote_backend, "principal": node.coordinator_principal, "remote_task_id": remote_task_id or ""})
-        return {"success": response["ok"], "changed": response["ok"], "backend": "fabric", "node": node.name, "dispatch_id": dispatch_id, "attempt_id": attempt_id, "remote_task_id": remote_task_id, "state": state, "code": response["code"]}
+            db.execute(
+                "UPDATE attempts SET state=?,remote_task_id=?,peer_policy_sha256=?,error_code=?,"
+                "updated_at=? WHERE attempt_id=?",
+                (
+                    state,
+                    remote_task_id,
+                    data.get("policy_sha256"),
+                    None if response["ok"] else response["code"],
+                    _now(),
+                    attempt_id,
+                ),
+            )
+        _audit(
+            "hermes_fabric_dispatch",
+            success=response["ok"],
+            changed=response["ok"],
+            summary=f"Fabric attempt submitted to {node.name}",
+            extra={
+                "dispatch_id": dispatch_id,
+                "attempt_id": attempt_id,
+                "task_id": envelope["task_id"],
+                "node": node.name,
+                "remote_backend": remote_backend,
+                "principal": node.coordinator_principal,
+                "remote_task_id": remote_task_id or "",
+            },
+        )
+        return {
+            "success": response["ok"],
+            "changed": response["ok"],
+            "backend": "fabric",
+            "node": node.name,
+            "dispatch_id": dispatch_id,
+            "attempt_id": attempt_id,
+            "remote_task_id": remote_task_id,
+            "state": state,
+            "code": response["code"],
+        }
 
     def _attempt(self, attempt_id: str) -> tuple[sqlite3.Row, sqlite3.Row, FabricNode]:
-        with _connect(self.db_path) as db:
-            attempt = db.execute("SELECT * FROM attempts WHERE attempt_id=?", (attempt_id,)).fetchone()
-            if attempt is None: raise FabricError("FABRIC_ATTEMPT_NOT_FOUND", "coordinator Fabric attempt does not exist")
-            dispatch = db.execute("SELECT * FROM dispatches WHERE dispatch_id=?", (attempt["dispatch_id"],)).fetchone()
-        if dispatch is None: raise FabricError("FABRIC_JOURNAL_CORRUPT", "coordinator dispatch lineage is missing")
+        if not self.db_path.is_file():
+            raise FabricError(
+                "FABRIC_ATTEMPT_NOT_FOUND",
+                "coordinator Fabric attempt does not exist",
+            )
+        with _connect_readonly(self.db_path) as db:
+            attempt = db.execute(
+                "SELECT * FROM attempts WHERE attempt_id=?",
+                (attempt_id,),
+            ).fetchone()
+            if attempt is None:
+                raise FabricError(
+                    "FABRIC_ATTEMPT_NOT_FOUND",
+                    "coordinator Fabric attempt does not exist",
+                )
+            dispatch = db.execute(
+                "SELECT * FROM dispatches WHERE dispatch_id=?",
+                (attempt["dispatch_id"],),
+            ).fetchone()
+        if dispatch is None:
+            raise FabricError("FABRIC_JOURNAL_CORRUPT", "coordinator dispatch lineage is missing")
         return attempt, dispatch, self._node(attempt["node_name"])
 
-    def poll(self, attempt_id: str, *, reconcile: bool = False, timeout: int = 15) -> dict[str, Any]:
-        attempt, dispatch, node = self._attempt(attempt_id); operation = "reconcile" if reconcile else "status"
-        _, response = self.rpc(node, _request(operation, node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
-        response = _validate_response(response, operation=operation); data = response["data"]
-        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id: raise FabricError("FABRIC_PROTOCOL_ERROR", "peer status lineage mismatch")
+    def poll(
+        self,
+        attempt_id: str,
+        *,
+        reconcile: bool = False,
+        timeout: int = 15,
+    ) -> dict[str, Any]:
+        attempt, dispatch, node = self._attempt(attempt_id)
+        operation = "reconcile" if reconcile else "status"
+        _, response = self.rpc(
+            node,
+            _request(
+                operation,
+                node.coordinator_principal,
+                data={},
+                dispatch_id=attempt["dispatch_id"],
+                attempt_id=attempt_id,
+            ),
+            timeout,
+        )
+        response = _validate_response(response, operation=operation)
+        data = response["data"]
+        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id:
+            raise FabricError("FABRIC_PROTOCOL_ERROR", "peer status lineage mismatch")
         peer_state = str(data.get("state") or "")
-        state = {"ACCEPTED":"SUBMITTED","RUNNING":"RUNNING","CANCEL_REQUESTED":"CANCEL_REQUESTED","SUCCEEDED":"TERMINAL_REPORTED","FAILED":"TERMINAL_REPORTED","CANCELLED":"CANCELLED","LOST_AMBIGUOUS":"BLOCKED","BLOCKED":"BLOCKED"}.get(peer_state,"BLOCKED")
-        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
-        return {"success": True, "backend": "fabric", "node": node.name, "dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "state": state, "peer_state": peer_state, "task_id": dispatch["task_id"]}
+        state = {
+            "ACCEPTED": "SUBMITTED",
+            "RUNNING": "RUNNING",
+            "CANCEL_REQUESTED": "CANCEL_REQUESTED",
+            "SUCCEEDED": "TERMINAL_REPORTED",
+            "FAILED": "TERMINAL_REPORTED",
+            "CANCELLED": "CANCELLED",
+            "LOST_AMBIGUOUS": "BLOCKED",
+            "BLOCKED": "BLOCKED",
+        }.get(peer_state, "BLOCKED")
+        with _connect(self.db_path) as db:
+            db.execute(
+                "UPDATE attempts SET state=?,updated_at=? WHERE attempt_id=?",
+                (state, _now(), attempt_id),
+            )
+        return {
+            "success": True,
+            "backend": "fabric",
+            "node": node.name,
+            "dispatch_id": attempt["dispatch_id"],
+            "attempt_id": attempt_id,
+            "state": state,
+            "peer_state": peer_state,
+            "task_id": dispatch["task_id"],
+        }
 
     def collect(self, attempt_id: str, *, timeout: int = 15) -> dict[str, Any]:
-        attempt, dispatch, node = self._attempt(attempt_id)
-        _, response = self.rpc(node, _request("evidence", node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
+        attempt, _dispatch, node = self._attempt(attempt_id)
+        _, response = self.rpc(
+            node,
+            _request(
+                "evidence",
+                node.coordinator_principal,
+                data={},
+                dispatch_id=attempt["dispatch_id"],
+                attempt_id=attempt_id,
+            ),
+            timeout,
+        )
         response = _validate_response(response, operation="evidence")
-        if not response["ok"]: raise FabricError(response["code"], "peer did not return admissible evidence")
+        if not response["ok"]:
+            raise FabricError(response["code"], "peer did not return admissible evidence")
         data = _closed(response["data"], required={"evidence"}, name="evidence response")
-        policy_raw = strict_json_loads(dispatch["evidence_policy_json"], maximum=16_000); allowed = tuple(policy_raw.get("run_state") or []) if isinstance(policy_raw, dict) else ()
-        attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(self.db_path)
-        admitted = _validate_evidence(data["evidence"], attempt=attempt_map, node=node, allowed_provenance=allowed)
-        terminal = admitted["terminal_state"]; state = "COMPLETED" if terminal == "SUCCEEDED" else "FAILED" if terminal == "FAILED" else "CANCELLED"
-        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, evidence_json=?, updated_at=? WHERE attempt_id=?", (state, canonical_json(admitted), _now(), attempt_id))
-        _audit("hermes_fabric_evidence", success=True, changed=False, summary=f"Fabric evidence admitted from {node.name}", extra={"dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "task_id": dispatch["task_id"], "node": node.name, "principal": node.coordinator_principal, "terminal_state": terminal})
-        return {"success": True, "backend": "fabric", "node": node.name, "dispatch_id": attempt["dispatch_id"], "attempt_id": attempt_id, "state": state, "evidence": admitted}
+        with _connect_readonly(self.db_path) as db:
+            dispatch = db.execute(
+                "SELECT * FROM dispatches WHERE dispatch_id=?",
+                (attempt["dispatch_id"],),
+            ).fetchone()
+        if dispatch is None:
+            raise FabricError("FABRIC_JOURNAL_CORRUPT", "coordinator dispatch lineage is missing")
+        policy_raw = strict_json_loads(dispatch["evidence_policy_json"], maximum=16_000)
+        allowed = (
+            tuple(policy_raw.get("run_state") or [])
+            if isinstance(policy_raw, dict)
+            else ()
+        )
+        attempt_map = dict(attempt)
+        attempt_map["_coordinator_db"] = str(self.db_path)
+        admitted = _validate_evidence(
+            data["evidence"],
+            attempt=attempt_map,
+            node=node,
+            allowed_provenance=allowed,
+        )
+        terminal = admitted["terminal_state"]
+        state = (
+            "COMPLETED"
+            if terminal == "SUCCEEDED"
+            else "FAILED"
+            if terminal == "FAILED"
+            else "CANCELLED"
+        )
+        with _connect(self.db_path) as db:
+            db.execute(
+                "UPDATE attempts SET state=?,evidence_json=?,updated_at=? WHERE attempt_id=?",
+                (state, canonical_json(admitted), _now(), attempt_id),
+            )
+        _audit(
+            "hermes_fabric_evidence",
+            success=True,
+            changed=False,
+            summary=f"Fabric evidence admitted from {node.name}",
+            extra={
+                "dispatch_id": attempt["dispatch_id"],
+                "attempt_id": attempt_id,
+                "task_id": dispatch["task_id"],
+                "node": node.name,
+                "principal": node.coordinator_principal,
+                "terminal_state": terminal,
+            },
+        )
+        return {
+            "success": True,
+            "backend": "fabric",
+            "node": node.name,
+            "dispatch_id": attempt["dispatch_id"],
+            "attempt_id": attempt_id,
+            "state": state,
+            "evidence": admitted,
+        }
 
     def cancel(self, attempt_id: str, *, timeout: int = 15) -> dict[str, Any]:
         attempt, dispatch, node = self._attempt(attempt_id)
-        _, response = self.rpc(node, _request("cancel", node.coordinator_principal, data={}, dispatch_id=attempt["dispatch_id"], attempt_id=attempt_id), timeout)
-        response = _validate_response(response, operation="cancel"); data=response["data"]
-        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id: raise FabricError("FABRIC_PROTOCOL_ERROR", "peer cancel lineage mismatch")
+        _, response = self.rpc(
+            node,
+            _request(
+                "cancel",
+                node.coordinator_principal,
+                data={},
+                dispatch_id=attempt["dispatch_id"],
+                attempt_id=attempt_id,
+            ),
+            timeout,
+        )
+        response = _validate_response(response, operation="cancel")
+        data = response["data"]
+        if data.get("dispatch_id") != attempt["dispatch_id"] or data.get("attempt_id") != attempt_id:
+            raise FabricError("FABRIC_PROTOCOL_ERROR", "peer cancel lineage mismatch")
         state = "CANCELLED" if data.get("state") == "CANCELLED" else "CANCEL_REQUESTED"
-        with _connect(self.db_path) as db: db.execute("UPDATE attempts SET state=?, updated_at=? WHERE attempt_id=?", (state, _now(), attempt_id))
-        return {"success": True, "changed": bool(data.get("changed")), "backend": "fabric", "attempt_id": attempt_id, "dispatch_id": attempt["dispatch_id"], "task_id": dispatch["task_id"], "state": state}
+        with _connect(self.db_path) as db:
+            db.execute(
+                "UPDATE attempts SET state=?,updated_at=? WHERE attempt_id=?",
+                (state, _now(), attempt_id),
+            )
+        return {
+            "success": True,
+            "changed": bool(data.get("changed")),
+            "backend": "fabric",
+            "attempt_id": attempt_id,
+            "dispatch_id": attempt["dispatch_id"],
+            "task_id": dispatch["task_id"],
+            "state": state,
+        }
 
     def observed_runs(self, task_id: str, *, refresh: bool = True) -> list[dict[str, Any]]:
-        with _connect(self.db_path) as db: rows = db.execute("SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id WHERE d.task_id=? ORDER BY a.created_at", (task_id,)).fetchall()
+        if not self.db_path.is_file():
+            return []
         if refresh:
+            with _connect_readonly(self.db_path) as db:
+                rows = db.execute(
+                    "SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id"
+                    " WHERE d.task_id=? ORDER BY a.created_at",
+                    (task_id,),
+                ).fetchall()
             for row in rows:
                 try:
                     if row["state"] not in _TERMINAL_COORD:
-                        status = self.poll(row["attempt_id"], reconcile=row["state"] == "SUBMISSION_AMBIGUOUS", timeout=10)
-                        if status["state"] == "TERMINAL_REPORTED": self.collect(row["attempt_id"], timeout=10)
-                    elif row["state"] in {"COMPLETED", "FAILED", "CANCELLED"} and not row["evidence_json"]: self.collect(row["attempt_id"], timeout=10)
-                except FabricError: continue
-            with _connect(self.db_path) as db: rows = db.execute("SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id WHERE d.task_id=? ORDER BY a.created_at", (task_id,)).fetchall()
-        out=[]
+                        status = self.poll(
+                            row["attempt_id"],
+                            reconcile=row["state"] == "SUBMISSION_AMBIGUOUS",
+                            timeout=10,
+                        )
+                        if status["state"] == "TERMINAL_REPORTED":
+                            self.collect(row["attempt_id"], timeout=10)
+                    elif row["state"] in {"COMPLETED", "FAILED", "CANCELLED"} and not row[
+                        "evidence_json"
+                    ]:
+                        self.collect(row["attempt_id"], timeout=10)
+                except FabricError:
+                    continue
+
+        with _connect_readonly(self.db_path) as db:
+            rows = db.execute(
+                "SELECT a.* FROM attempts a JOIN dispatches d ON d.dispatch_id=a.dispatch_id"
+                " WHERE d.task_id=? ORDER BY a.created_at",
+                (task_id,),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
         for row in rows:
-            if not row["evidence_json"]: continue
-            try: evidence = strict_json_loads(row["evidence_json"], maximum=_MAX_BODY)
-            except FabricError: continue
-            for observation in evidence.get("observations", []) if isinstance(evidence, dict) else []:
-                if not isinstance(observation, dict) or observation.get("kind") != "run_state" or observation.get("provenance") not in _SAFE_EVIDENCE_PROVENANCE: continue
-                terminal=evidence.get("terminal_state"); mapped="completed" if terminal=="SUCCEEDED" else "failed" if terminal=="FAILED" else "cancelled"
-                out.append({"task_id":task_id,"status":mapped,"outcome":mapped,"error":observation.get("error") or "","started_at":observation.get("started_at") or "","ended_at":observation.get("ended_at") or "","scope":f"fabric:{row['node_name']}","backend":"fabric","remote_backend":row["remote_backend"],"attempt_id":row["attempt_id"],"dispatch_id":row["dispatch_id"],"evidence_provenance":observation.get("provenance")})
+            if not row["evidence_json"]:
+                continue
+            try:
+                evidence = strict_json_loads(row["evidence_json"], maximum=_MAX_BODY)
+            except FabricError:
+                continue
+            if not isinstance(evidence, dict):
+                continue
+            for observation in evidence.get("observations", []):
+                if (
+                    not isinstance(observation, dict)
+                    or observation.get("kind") != "run_state"
+                    or observation.get("provenance") not in _SAFE_EVIDENCE_PROVENANCE
+                ):
+                    continue
+                terminal = evidence.get("terminal_state")
+                mapped = (
+                    "completed"
+                    if terminal == "SUCCEEDED"
+                    else "failed"
+                    if terminal == "FAILED"
+                    else "cancelled"
+                )
+                out.append(
+                    {
+                        "task_id": task_id,
+                        "status": mapped,
+                        "outcome": mapped,
+                        "error": observation.get("error") or "",
+                        "started_at": observation.get("started_at") or "",
+                        "ended_at": observation.get("ended_at") or "",
+                        "scope": f"fabric:{row['node_name']}",
+                        "backend": "fabric",
+                        "remote_backend": row["remote_backend"],
+                        "attempt_id": row["attempt_id"],
+                        "dispatch_id": row["dispatch_id"],
+                        "evidence_provenance": observation.get("provenance"),
+                    }
+                )
         return out
 
 
@@ -1059,73 +2316,320 @@ class FabricCoordinator:
 class FabricBackend:
     name: str = "fabric"
     coordinator_factory: Callable[..., FabricCoordinator] = FabricCoordinator
+
     def availability(self, *, hermes_root: Path | None = None) -> dict[str, Any]:
         try:
-            enabled=sorted(name for name,node in load_node_registry(hermes_root=hermes_root).items() if node.enabled)
-            return {"available":bool(enabled),"node_count":len(enabled),"reason":None if enabled else "no enabled Fabric nodes"}
-        except Exception as exc: return {"available":False,"node_count":0,"reason":op.redact_output(str(exc))[:300]}
-    def dispatch(self, contract: dict[str, Any], *, confirm: bool, dry_run: bool, timeout: int, hermes_root: Path | None = None, **kwargs: Any) -> dict[str, Any]:
-        coordinator=kwargs.get("fabric_coordinator") or self.coordinator_factory(hermes_root=hermes_root)
-        try: return coordinator.dispatch(contract,dry_run=dry_run,confirm=confirm,timeout=timeout)
-        except FabricError as exc: return {"success":False,"ok":False,"changed":bool(exc.ambiguous),"backend":self.name,"code":exc.code,"safe_message":op.redact_output(str(exc))[:300],"submission_may_have_succeeded":bool(exc.ambiguous)}
-    def observed_runs(self, task_id: str, *, hermes_root: Path | None = None) -> list[dict[str, Any]]: return self.coordinator_factory(hermes_root=hermes_root).observed_runs(task_id)
+            enabled = sorted(
+                name
+                for name, node in load_node_registry(hermes_root=hermes_root).items()
+                if node.enabled
+            )
+            return {
+                "available": bool(enabled),
+                "node_count": len(enabled),
+                "reason": None if enabled else "no enabled Fabric nodes",
+            }
+        except _EXPECTED_ERRORS as exc:
+            return {
+                "available": False,
+                "node_count": 0,
+                "reason": op.redact_output(str(exc))[:300],
+            }
+
+    def dispatch(
+        self,
+        contract: dict[str, Any],
+        *,
+        confirm: bool,
+        dry_run: bool,
+        timeout: int,
+        hermes_root: Path | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        coordinator = kwargs.get("fabric_coordinator") or self.coordinator_factory(
+            hermes_root=hermes_root
+        )
+        try:
+            return coordinator.dispatch(
+                contract,
+                dry_run=dry_run,
+                confirm=confirm,
+                timeout=timeout,
+            )
+        except FabricError as exc:
+            return {
+                "success": False,
+                "ok": False,
+                "changed": bool(exc.ambiguous),
+                "backend": self.name,
+                "code": exc.code,
+                "safe_message": op.redact_output(str(exc))[:300],
+                "submission_may_have_succeeded": bool(exc.ambiguous),
+            }
+
+    def observed_runs(
+        self,
+        task_id: str,
+        *,
+        hermes_root: Path | None = None,
+    ) -> list[dict[str, Any]]:
+        # Work Contract validation is observational. It must only read evidence
+        # previously admitted by an explicit Fabric status/evidence operation.
+        return self.coordinator_factory(hermes_root=hermes_root).observed_runs(
+            task_id,
+            refresh=False,
+        )
+
     def cancel(self, task_id: str, *, hermes_root: Path | None = None) -> dict[str, Any]:
-        try: return self.coordinator_factory(hermes_root=hermes_root).cancel(task_id)
-        except FabricError as exc: return {"success":False,"changed":False,"backend":self.name,"code":exc.code,"safe_message":op.redact_output(str(exc))[:300]}
+        try:
+            return self.coordinator_factory(hermes_root=hermes_root).cancel(task_id)
+        except FabricError as exc:
+            return {
+                "success": False,
+                "changed": False,
+                "backend": self.name,
+                "code": exc.code,
+                "safe_message": op.redact_output(str(exc))[:300],
+            }
 
 
 def register_runner_backend() -> None:
     try:
-        if isinstance(op_runners.get_backend("fabric"), FabricBackend): return
-    except LookupError: pass
+        if isinstance(op_runners.get_backend("fabric"), FabricBackend):
+            return
+    except LookupError:
+        pass
     op_runners.register_backend(FabricBackend(), replace=True)
 
 
 class _PeerHandler(BaseHTTPRequestHandler):
-    server_version="HermesGPTFabric/0.8"
-    def log_message(self,_format: str,*_args: Any)->None: return
+    server_version = "HermesGPTFabric/0.8"
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
     @property
-    def service(self)->FabricPeerService: return getattr(self.server,"fabric_service")
+    def service(self) -> FabricPeerService:
+        return self.server.fabric_service
+
     @property
-    def advertised_url(self)->str: return getattr(self.server,"fabric_advertised_url")
-    def _send(self,status:int,payload:dict[str,Any])->None:
-        encoded=canonical_json(payload).encode("utf-8"); self.send_response(status); self.send_header("Content-Type","application/json"); self.send_header("Content-Length",str(len(encoded))); self.send_header("Cache-Control","no-store"); self.end_headers(); self.wfile.write(encoded)
-    def do_GET(self)->None:  # noqa: N802
-        if urllib.parse.urlparse(self.path).path not in {"/.well-known/agent-card.json","/.well-known/agent.json"}: self._send(404,{"error":"not found"}); return
+    def advertised_url(self) -> str:
+        return self.server.fabric_advertised_url
+
+    def _send(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = canonical_json(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:
+        if urllib.parse.urlparse(self.path).path not in {
+            "/.well-known/agent-card.json",
+            "/.well-known/agent.json",
+        }:
+            self._send(404, {"error": "not found"})
+            return
         try:
-            p=self.service.policy_loader(); self._send(200,{"protocolVersion":"1.0","name":p.identity,"description":"Hermes GPT managed Fabric peer","version":"0.8","url":self.advertised_url,"capabilities":{},"defaultInputModes":["application/json"],"defaultOutputModes":["application/json"],"skills":[{"id":"hermes-fabric-v1","name":"Hermes Fabric v1","description":"Deterministic managed remote execution","tags":["hermes","fabric"]}],"supportedInterfaces":[{"url":self.advertised_url,"protocolBinding":"JSONRPC","protocolVersion":"1.0"}]})
-        except FabricError as exc: self._send(503,{"error":exc.code})
-    def do_POST(self)->None:  # noqa: N802
+            policy = self.service.policy_loader()
+            self._send(
+                200,
+                {
+                    "protocolVersion": "1.0",
+                    "name": policy.identity,
+                    "description": "Hermes GPT managed Fabric peer",
+                    "version": "0.8",
+                    "url": self.advertised_url,
+                    "capabilities": {},
+                    "defaultInputModes": ["application/json"],
+                    "defaultOutputModes": ["application/json"],
+                    "skills": [
+                        {
+                            "id": "hermes-fabric-v1",
+                            "name": "Hermes Fabric v1",
+                            "description": "Deterministic managed remote execution",
+                            "tags": ["hermes", "fabric"],
+                        }
+                    ],
+                    "supportedInterfaces": [
+                        {
+                            "url": self.advertised_url,
+                            "protocolBinding": "JSONRPC",
+                            "protocolVersion": "1.0",
+                        }
+                    ],
+                },
+            )
+        except FabricError as exc:
+            self._send(503, {"error": exc.code})
+
+    def do_POST(self) -> None:
         outer: Any = None
         try:
-            length=int(self.headers.get("Content-Length","0"))
-            if length<=0 or length>_MAX_BODY: raise FabricError("FABRIC_PAYLOAD_TOO_LARGE","A2A request has an invalid body size")
-            outer=_closed(strict_json_loads(self.rfile.read(length)),required={"jsonrpc","id","method","params"},name="A2A JSON-RPC request")
-            if outer["jsonrpc"]!="2.0" or outer["method"] not in {"SendMessage","message/send"}: raise FabricError("FABRIC_PROTOCOL_ERROR","only A2A SendMessage is accepted by the Fabric peer")
-            params=_closed(outer["params"],required={"message"},name="A2A params"); message=_closed(params["message"],required={"role","parts","messageId","contextId"},name="A2A message")
-            if message["role"]!="ROLE_USER" or not isinstance(message["parts"],list) or len(message["parts"])!=1: raise FabricError("FABRIC_PROTOCOL_ERROR","Fabric A2A message must contain exactly one structured DataPart")
-            part=_closed(message["parts"][0],required={"data","mediaType"},name="A2A DataPart")
-            if part["mediaType"]!="application/json" or not isinstance(part["data"],dict): raise FabricError("FABRIC_PROTOCOL_ERROR","Fabric does not accept text or generic agent messages")
-            request=_validate_request(part["data"]); response=self.service.handle(request,self.headers.get("Authorization","")); context_id=request.get("dispatch_id") or message["contextId"]; task_id="ftask-"+hashlib.sha256(f"{request['request_id']}:{request.get('attempt_id','')}".encode()).hexdigest()[:24]
-            result={"id":task_id,"contextId":context_id,"status":{"state":"TASK_STATE_COMPLETED","message":{"role":"ROLE_AGENT","parts":[{"data":response,"mediaType":"application/json"}],"messageId":"resp-"+task_id[6:],"contextId":context_id}}}; self._send(200,{"jsonrpc":"2.0","id":outer["id"],"result":result})
+            length = int(self.headers.get("Content-Length", "0"))
+            if length <= 0 or length > _MAX_BODY:
+                raise FabricError(
+                    "FABRIC_PAYLOAD_TOO_LARGE",
+                    "A2A request has an invalid body size",
+                )
+            outer = _closed(
+                strict_json_loads(self.rfile.read(length)),
+                required={"jsonrpc", "id", "method", "params"},
+                name="A2A JSON-RPC request",
+            )
+            if outer["jsonrpc"] != "2.0" or outer["method"] not in {
+                "SendMessage",
+                "message/send",
+            }:
+                raise FabricError(
+                    "FABRIC_PROTOCOL_ERROR",
+                    "only A2A SendMessage is accepted by the Fabric peer",
+                )
+            params = _closed(
+                outer["params"],
+                required={"message"},
+                name="A2A params",
+            )
+            message = _closed(
+                params["message"],
+                required={"role", "parts", "messageId", "contextId"},
+                name="A2A message",
+            )
+            if (
+                message["role"] != "ROLE_USER"
+                or not isinstance(message["parts"], list)
+                or len(message["parts"]) != 1
+            ):
+                raise FabricError(
+                    "FABRIC_PROTOCOL_ERROR",
+                    "Fabric A2A message must contain exactly one structured DataPart",
+                )
+            raw_part = message["parts"][0]
+            if (
+                not isinstance(raw_part, dict)
+                or "text" in raw_part
+                or "data" not in raw_part
+                or raw_part.get("mediaType") != "application/json"
+            ):
+                raise FabricError(
+                    "FABRIC_PROTOCOL_ERROR",
+                    "Fabric does not accept text or generic agent messages",
+                )
+            part = _closed(
+                raw_part,
+                required={"data", "mediaType"},
+                name="A2A DataPart",
+            )
+            if not isinstance(part["data"], dict):
+                raise FabricError(
+                    "FABRIC_PROTOCOL_ERROR",
+                    "Fabric DataPart must contain a structured JSON object",
+                )
+            request = _validate_request(part["data"])
+            response = self.service.handle(
+                request,
+                self.headers.get("Authorization", ""),
+            )
+            context_id = request.get("dispatch_id") or message["contextId"]
+            task_id = "ftask-" + hashlib.sha256(
+                f"{request['request_id']}:{request.get('attempt_id', '')}".encode()
+            ).hexdigest()[:24]
+            result = {
+                "id": task_id,
+                "contextId": context_id,
+                "status": {
+                    "state": "TASK_STATE_COMPLETED",
+                    "message": {
+                        "role": "ROLE_AGENT",
+                        "parts": [{"data": response, "mediaType": "application/json"}],
+                        "messageId": "resp-" + task_id[6:],
+                        "contextId": context_id,
+                    },
+                },
+            }
+            self._send(200, {"jsonrpc": "2.0", "id": outer["id"], "result": result})
         except FabricError as exc:
-            self._send(200,{"jsonrpc":"2.0","id":outer.get("id") if isinstance(outer,dict) else None,"error":{"code":-32001,"message":str(exc)[:300],"data":{"code":exc.code}}})
-        except Exception: self._send(200,{"jsonrpc":"2.0","id":None,"error":{"code":-32603,"message":"internal Fabric peer error","data":{"code":"FABRIC_INTERNAL_ERROR"}}})
+            self._send(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": outer.get("id") if isinstance(outer, dict) else None,
+                    "error": {
+                        "code": -32001,
+                        "message": str(exc)[:300],
+                        "data": {"code": exc.code},
+                    },
+                },
+            )
+        except (OSError, ValueError, TypeError, sqlite3.Error):
+            self._send(
+                200,
+                {
+                    "jsonrpc": "2.0",
+                    "id": outer.get("id") if isinstance(outer, dict) else None,
+                    "error": {
+                        "code": -32603,
+                        "message": "internal Fabric peer error",
+                        "data": {"code": "FABRIC_INTERNAL_ERROR"},
+                    },
+                },
+            )
 
 
 def peer_main(argv: list[str] | None = None) -> None:
-    parser=argparse.ArgumentParser(prog="hermes-gpt-fabric-peer",description="Run the deterministic Hermes GPT Fabric A2A peer endpoint."); parser.add_argument("--host",default="127.0.0.1"); parser.add_argument("--port",type=int,default=4780); parser.add_argument("--cert"); parser.add_argument("--key"); parser.add_argument("--advertised-url",default=""); args=parser.parse_args(argv)
-    if bool(args.cert)!=bool(args.key): raise SystemExit("Fabric TLS requires both --cert and --key.")
-    loopback=args.host in {"127.0.0.1","localhost","::1"}
-    if not loopback and not (args.cert and args.key): raise SystemExit("Non-loopback verified Fabric requires direct TLS (--cert and --key).")
-    scheme="https" if args.cert else "http"; advertised=args.advertised_url or f"{scheme}://{args.host}:{args.port}"; _require_secure_transport(advertised); service=FabricPeerService(); server=ThreadingHTTPServer((args.host,args.port),_PeerHandler); setattr(server,"fabric_service",service); setattr(server,"fabric_advertised_url",advertised)
+    parser = argparse.ArgumentParser(
+        prog="hermes-gpt-fabric-peer",
+        description="Run the deterministic Hermes GPT Fabric A2A peer endpoint.",
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=4780)
+    parser.add_argument("--cert")
+    parser.add_argument("--key")
+    parser.add_argument("--advertised-url", default="")
+    args = parser.parse_args(argv)
+    if bool(args.cert) != bool(args.key):
+        raise SystemExit("Fabric TLS requires both --cert and --key.")
+    loopback = args.host in {"127.0.0.1", "localhost", "::1"}
+    if not loopback and not (args.cert and args.key):
+        raise SystemExit("Non-loopback verified Fabric requires direct TLS (--cert and --key).")
+    scheme = "https" if args.cert else "http"
+    advertised = args.advertised_url or f"{scheme}://{args.host}:{args.port}"
+    _require_secure_transport(advertised)
+    service = FabricPeerService()
+    server = ThreadingHTTPServer((args.host, args.port), _PeerHandler)
+    server.fabric_service = service
+    server.fabric_advertised_url = advertised
     if args.cert and args.key:
-        context=ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); context.load_cert_chain(args.cert,args.key); server.socket=context.wrap_socket(server.socket,server_side=True)
-    try: server.serve_forever()
-    except KeyboardInterrupt: pass
-    finally: server.server_close()
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        context.load_cert_chain(args.cert, args.key)
+        server.socket = context.wrap_socket(server.socket, server_side=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
 
 
-__all__=["FabricBackend","FabricCoordinator","FabricError","FabricNode","FabricPeerPolicy","FabricPeerService","WorkspaceMapping","canonical_json","load_node_registry","load_peer_policy","load_peer_tokens","peer_main","register_runner_backend","sha256_json","strict_json_loads"]
+__all__ = [
+    "FabricBackend",
+    "FabricCoordinator",
+    "FabricError",
+    "FabricNode",
+    "FabricPeerPolicy",
+    "FabricPeerService",
+    "WorkspaceMapping",
+    "canonical_json",
+    "load_node_registry",
+    "load_peer_policy",
+    "load_peer_tokens",
+    "peer_main",
+    "register_runner_backend",
+    "sha256_json",
+    "strict_json_loads",
+]
 
-if __name__ == "__main__": peer_main()
+if __name__ == "__main__":
+    peer_main()

--- a/operator_fabric_control.py
+++ b/operator_fabric_control.py
@@ -1,0 +1,319 @@
+"""Policy-gated coordinator controls for Hermes GPT v0.8 Fabric G4-A.
+
+This module is the operator-facing control seam for distributed attempt status,
+reconciliation, evidence admission, and cancellation. It deliberately keeps
+Work Contract validation observational: callers explicitly reconcile/collect
+first, then the existing validator reads already-admitted Fabric evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+import operator_fabric as fabric
+import operator_policy as op
+
+_ATTEMPT_RE = re.compile(r"^faba-[0-9a-f]{32}$")
+
+
+def _bounded_error(exc: BaseException) -> str:
+    return op.redact_output(str(exc))[:300]
+
+
+def _audit(
+    *,
+    tool: str,
+    policy: op.OperatorPolicy,
+    dry_run: bool,
+    success: bool,
+    changed: bool,
+    summary: str,
+    attempt_id: str,
+    result: dict[str, Any] | None = None,
+    audit: Callable[..., Any] | None = None,
+) -> None:
+    audit_fn = audit or op.audit_record
+    extra: dict[str, Any] = {"attempt_id": attempt_id}
+    if isinstance(result, dict):
+        for key in ("dispatch_id", "task_id", "node", "state", "peer_state"):
+            value = result.get(key)
+            if isinstance(value, (str, int, float, bool)):
+                extra[key] = value
+    try:
+        audit_fn(
+            tool=tool,
+            level=policy.level or "read_only",
+            apply_mode=policy.apply_mode,
+            dry_run=dry_run,
+            success=success,
+            changed=changed,
+            summary=summary[:500],
+            extra=extra,
+        )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return
+
+
+def _coordinator(
+    hermes_root: Path | None,
+    coordinator: fabric.FabricCoordinator | None,
+) -> fabric.FabricCoordinator:
+    return coordinator or fabric.FabricCoordinator(hermes_root=hermes_root)
+
+
+def _attempt_id(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not _ATTEMPT_RE.fullmatch(normalized):
+        raise ValueError("attempt_id has an invalid Fabric format")
+    return normalized
+
+
+def hermes_fabric_status(
+    attempt_id: str,
+    reconcile: bool = False,
+    hermes_root: Path | None = None,
+    *,
+    coordinator: fabric.FabricCoordinator | None = None,
+    audit: Callable[..., Any] | None = None,
+) -> str:
+    """Poll or reconcile one durable Fabric attempt.
+
+    ``reconcile=false`` performs bounded status observation. ``reconcile=true``
+    is the explicit recovery path for ambiguous/restarted distributed state.
+    Neither operation creates a replacement attempt.
+    """
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("read_only")
+        attempt = _attempt_id(attempt_id)
+        result = _coordinator(hermes_root, coordinator).poll(
+            attempt,
+            reconcile=bool(reconcile),
+            timeout=15,
+        )
+        tool = "hermes_fabric_reconcile" if reconcile else "hermes_fabric_status"
+        _audit(
+            tool=tool,
+            policy=policy,
+            dry_run=True,
+            success=True,
+            changed=False,
+            summary=(
+                "reconciled Fabric attempt without replacement"
+                if reconcile
+                else "observed Fabric attempt status"
+            ),
+            attempt_id=attempt,
+            result=result,
+            audit=audit,
+        )
+        if result.get("state") in {"TERMINAL_REPORTED", "CANCELLED", "BLOCKED"}:
+            _audit(
+                tool="hermes_fabric_terminal",
+                policy=policy,
+                dry_run=True,
+                success=True,
+                changed=False,
+                summary="observed Fabric terminal/blocked state",
+                attempt_id=attempt,
+                result=result,
+                audit=audit,
+            )
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    except (PermissionError, ValueError, fabric.FabricError) as exc:
+        tool = "hermes_fabric_reconcile" if reconcile else "hermes_fabric_status"
+        _audit(
+            tool=tool,
+            policy=policy,
+            dry_run=True,
+            success=False,
+            changed=False,
+            summary="Fabric status/reconcile failed closed",
+            attempt_id=str(attempt_id or "")[:128],
+            audit=audit,
+        )
+        return json.dumps(
+            {
+                "success": False,
+                "code": getattr(exc, "code", "FABRIC_STATUS_ERROR"),
+                "safe_message": _bounded_error(exc),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+def hermes_fabric_evidence(
+    attempt_id: str,
+    hermes_root: Path | None = None,
+    *,
+    coordinator: fabric.FabricCoordinator | None = None,
+    audit: Callable[..., Any] | None = None,
+) -> str:
+    """Collect, lineage-check, and admit bounded evidence for one attempt."""
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("read_only")
+        attempt = _attempt_id(attempt_id)
+        result = _coordinator(hermes_root, coordinator).collect(attempt, timeout=15)
+        _audit(
+            tool="hermes_fabric_evidence_receipt",
+            policy=policy,
+            dry_run=True,
+            success=True,
+            changed=False,
+            summary="received and admitted Fabric evidence",
+            attempt_id=attempt,
+            result=result,
+            audit=audit,
+        )
+        _audit(
+            tool="hermes_fabric_terminal",
+            policy=policy,
+            dry_run=True,
+            success=True,
+            changed=False,
+            summary="Fabric attempt reached evidence-backed terminal state",
+            attempt_id=attempt,
+            result=result,
+            audit=audit,
+        )
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    except (PermissionError, ValueError, fabric.FabricError) as exc:
+        _audit(
+            tool="hermes_fabric_evidence_receipt",
+            policy=policy,
+            dry_run=True,
+            success=False,
+            changed=False,
+            summary="Fabric evidence admission failed closed",
+            attempt_id=str(attempt_id or "")[:128],
+            audit=audit,
+        )
+        return json.dumps(
+            {
+                "success": False,
+                "code": getattr(exc, "code", "FABRIC_EVIDENCE_ERROR"),
+                "safe_message": _bounded_error(exc),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+def hermes_fabric_cancel(
+    attempt_id: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+    *,
+    coordinator: fabric.FabricCoordinator | None = None,
+    audit: Callable[..., Any] | None = None,
+) -> str:
+    """Cancel one Fabric attempt through the durable attempt identity."""
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        effective = policy.effective_dry_run(dry_run)
+        attempt = _attempt_id(attempt_id)
+        if effective:
+            result = {
+                "success": True,
+                "dry_run": True,
+                "changed": False,
+                "backend": "fabric",
+                "attempt_id": attempt,
+                "plan": "cancel",
+            }
+            _audit(
+                tool="hermes_fabric_cancel",
+                policy=policy,
+                dry_run=True,
+                success=True,
+                changed=False,
+                summary="Fabric cancel plan",
+                attempt_id=attempt,
+                result=result,
+                audit=audit,
+            )
+            return json.dumps(result, ensure_ascii=False, indent=2)
+        if not confirm:
+            result = {
+                "success": False,
+                "code": "CONFIRMATION_REQUIRED",
+                "backend": "fabric",
+                "attempt_id": attempt,
+                "safe_message": "Fabric cancellation requires confirm=true.",
+            }
+            _audit(
+                tool="hermes_fabric_cancel",
+                policy=policy,
+                dry_run=True,
+                success=False,
+                changed=False,
+                summary="Fabric cancellation confirmation required",
+                attempt_id=attempt,
+                result=result,
+                audit=audit,
+            )
+            return json.dumps(result, ensure_ascii=False, indent=2)
+        result = _coordinator(hermes_root, coordinator).cancel(attempt, timeout=15)
+        _audit(
+            tool="hermes_fabric_cancel",
+            policy=policy,
+            dry_run=False,
+            success=bool(result.get("success")),
+            changed=bool(result.get("changed")),
+            summary=(
+                "Fabric cancellation accepted"
+                if result.get("success")
+                else "Fabric cancellation failed closed"
+            ),
+            attempt_id=attempt,
+            result=result,
+            audit=audit,
+        )
+        if result.get("state") == "CANCELLED":
+            _audit(
+                tool="hermes_fabric_terminal",
+                policy=policy,
+                dry_run=True,
+                success=True,
+                changed=False,
+                summary="Fabric attempt reached cancelled terminal state",
+                attempt_id=attempt,
+                result=result,
+                audit=audit,
+            )
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    except (PermissionError, ValueError, fabric.FabricError) as exc:
+        _audit(
+            tool="hermes_fabric_cancel",
+            policy=policy,
+            dry_run=bool(dry_run),
+            success=False,
+            changed=False,
+            summary="Fabric cancellation failed closed",
+            attempt_id=str(attempt_id or "")[:128],
+            audit=audit,
+        )
+        return json.dumps(
+            {
+                "success": False,
+                "code": getattr(exc, "code", "FABRIC_CANCEL_ERROR"),
+                "safe_message": _bounded_error(exc),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+__all__ = [
+    "hermes_fabric_cancel",
+    "hermes_fabric_evidence",
+    "hermes_fabric_status",
+]

--- a/operator_fabric_control.py
+++ b/operator_fabric_control.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import operator_fabric as fabric
 import operator_policy as op

--- a/operator_recovery.py
+++ b/operator_recovery.py
@@ -1,4 +1,4 @@
-"""Restart reconciliation for hermes-gpt v0.7 (Flight Deck, S2).
+"""Restart reconciliation for hermes-gpt v0.7+ (Flight Deck, S2).
 
 Per ADR-007 the recovery surface is **fail-closed and never auto-advancing**:
 after a process restart it marks swarm stages found in ``running`` as
@@ -6,6 +6,12 @@ after a process restart it marks swarm stages found in ``running`` as
 summary; the operator explicitly re-advances through the existing gated
 ``hermes_swarm_stage_advance``. It also reloads the durable token envelope
 (when S5's token store is present) and verifies integrity.
+
+Fabric v0.8 adds an idempotent runner-backend bootstrap here because this
+module is imported unconditionally by the operator server before tools are
+registered. Fabric's own distributed restart reconciliation remains fail-closed
+and is implemented in its durable coordinator/peer journals; this module does
+not auto-execute remote work.
 
 No auto-execution path exists. All mutations are dry-run-first with an apply
 gate.
@@ -18,8 +24,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+import operator_fabric as op_fabric
 import operator_policy as op
 import operator_swarm as op_swarm
+
+# Core runtime registration is idempotent and performs no network or mutation.
+# It makes execution.backend="fabric" visible through the existing runner
+# registry before Work Contract tools are called.
+op_fabric.register_runner_backend()
 
 TOOL_NAME = "hermes_operator_recover"
 RECONCILE_SURFACE = "swarm_restart_reconcile"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ py-modules = [
   "operator_export",
   "operator_fleet",
   "operator_fabric",
+  "operator_fabric_control",
   "operator_diagnostics",
   "operator_codex",
   "operator_session",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 
 [project.scripts]
 hermes-gpt = "server:main"
+hermes-gpt-fabric-peer = "operator_fabric:peer_main"
 
 [tool.setuptools]
 include-package-data = true
@@ -45,6 +46,7 @@ py-modules = [
   "operator_workspace",
   "operator_export",
   "operator_fleet",
+  "operator_fabric",
   "operator_diagnostics",
   "operator_codex",
   "operator_session",

--- a/test_operator_fabric.py
+++ b/test_operator_fabric.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+import operator_fabric as fabric
+
+
+class FakeBackend:
+    name = "fake"
+
+    def availability(self, *, hermes_root=None):
+        return {"available": True}
+
+    def cancel(self, task_id, *, hermes_root=None):
+        return {"success": True, "changed": True, "state": "cancelled"}
+
+
+def policy(tmp_path: Path, *, revision: str = "r1", max_auth: str = "reversible_write") -> fabric.FabricPeerPolicy:
+    mapping = fabric.WorkspaceMapping("repo", tmp_path.resolve(), revision, "workspace:repo")
+    raw = {"node": "node-a", "identity": "Hermes GPT Fabric node-a", "principals": ["coord-main"], "profiles": ["default"], "max": max_auth, "backends": ["fake"], "features": [], "mapping": {"repo": {"path": str(tmp_path.resolve()), "revision": revision, "conflict": "workspace:repo"}}}
+    return fabric.FabricPeerPolicy(node_name="node-a", identity="Hermes GPT Fabric node-a", allowed_coordinator_principals=("coord-main",), allowed_profiles=("default",), max_authorization=max_auth, allowed_backends=("fake",), required_features=(), workspace_mappings={"repo": mapping}, digest=fabric.sha256_json(raw))
+
+
+def node() -> fabric.FabricNode:
+    return fabric.FabricNode(name="node-a", a2a_peer_name="node-a-peer", expected_identity="Hermes GPT Fabric node-a", coordinator_principal="coord-main", enabled=True, allowed_profiles=("default",), max_authorization="reversible_write", allowed_remote_backends=("fake",), logical_workspaces=("repo",), required_features=())
+
+
+def contract(tmp_path: Path, *, auth_class: str = "read_only") -> dict:
+    return {"schema": "hermes.work-contract/v1", "task_id": "task-fabric-1", "objective": "Inspect the repository and report observed completion state.", "assigned_agent": "node-a", "assigned_profile": "default", "inputs": [], "constraints": ["Do not publish anything."], "allowed_scope": {"workspaces": [str(tmp_path.resolve())], "profiles": ["default"]}, "forbidden_actions": [], "expected_artifacts": [], "tests": [], "review_requirements": {"required": False, "reviewer": "", "evidence": "", "approval_required": False}, "completion_criteria": {"run_state": {"terminal": True, "outcome_ok": ["completed"]}, "artifacts_present": False, "tests_pass": False, "review_satisfied": False, "no_forbidden_actions": True}, "authorization": {"class": auth_class, "approved": True}, "execution": {"backend": "fabric", "options": {"node": "node-a", "remote_backend": "fake", "logical_workspace": "repo", "remote_options": {}, "evidence_provenance": {"run_state": ["managed_peer_structured"]}}}}
+
+
+def service(tmp_path: Path, monkeypatch, *, policy_loader=None, observed=None, dispatch_counter=None, cancel_fn=None):
+    monkeypatch.setattr(fabric.op_runners, "get_backend", lambda _name: FakeBackend())
+    observed = observed if observed is not None else []
+    dispatch_counter = dispatch_counter if dispatch_counter is not None else {"count": 0}
+    def dispatch_fn(_contract, **_kwargs):
+        dispatch_counter["count"] += 1
+        return {"success": True, "changed": True, "backend": "fake"}
+    return fabric.FabricPeerService(policy_loader=policy_loader or (lambda: policy(tmp_path)), tokens={"coord-main": "0123456789abcdef0123456789abcdef"}, db_path=tmp_path / "peer.db", dispatch_fn=dispatch_fn, observed_fn=lambda _task_id: list(observed), cancel_fn=cancel_fn or (lambda _backend, _task_id: {"success": True, "changed": True, "state": "cancelled"}), hermes_root=tmp_path)
+
+
+def rpc_for(svc: fabric.FabricPeerService):
+    def rpc(_node, request, _timeout):
+        response = svc.handle(request, "Bearer 0123456789abcdef0123456789abcdef")
+        attempt_id = request.get("attempt_id") or request.get("request_id")
+        return f"ftask-{str(attempt_id)[-12:]}", response
+    return rpc
+
+
+def coordinator(tmp_path: Path, svc: fabric.FabricPeerService, *, rpc=None) -> fabric.FabricCoordinator:
+    return fabric.FabricCoordinator(registry_loader=lambda: {"node-a": node()}, db_path=tmp_path / "coord.db", rpc=rpc or rpc_for(svc), hermes_root=tmp_path)
+
+
+def test_strict_json_rejects_duplicate_fields():
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric.strict_json_loads('{"a":1,"a":2}')
+    assert exc.value.code == "FABRIC_AMBIGUOUS_JSON"
+
+
+def test_peer_tokens_require_unique_principal_token():
+    raw = json.dumps({"coord-a": "0123456789abcdef", "coord-b": "0123456789abcdef"})
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric.load_peer_tokens(raw)
+    assert exc.value.code == "FABRIC_PRINCIPAL_CONFIG_INVALID"
+
+
+def test_non_loopback_plain_http_is_rejected():
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._require_secure_transport("http://192.0.2.10:4780")
+    assert exc.value.code == "FABRIC_TRANSPORT_INSECURE"
+    fabric._require_secure_transport("http://127.0.0.1:4780")
+
+
+def test_remote_options_reject_nested_credentials_and_urls(tmp_path):
+    c = contract(tmp_path)
+    c["execution"]["options"]["remote_options"] = {"nested": {"api_key": "nope"}}
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._fabric_options(c)
+    assert exc.value.code == "FABRIC_CALLER_CREDENTIAL"
+    c["execution"]["options"]["remote_options"] = {"nested": {"endpoint": "example"}}
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._fabric_options(c)
+    assert exc.value.code == "FABRIC_CALLER_NETWORK_TARGET"
+
+
+def test_peer_requires_authenticated_unique_principal(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch)
+    req = fabric._request("capabilities", "coord-main", data={})
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(req, "")
+    assert exc.value.code == "FABRIC_PRINCIPAL_AUTH_REQUIRED"
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(req, "Bearer wrong-wrong-wrong-wrong")
+    assert exc.value.code == "FABRIC_PRINCIPAL_AUTH_FAILED"
+
+
+def test_peer_accept_is_durable_and_idempotent(tmp_path, monkeypatch):
+    counter = {"count": 0}; svc = service(tmp_path, monkeypatch, dispatch_counter=counter); c = contract(tmp_path)
+    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    req = fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"])
+    first = svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef"); second = svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef")
+    assert first["ok"] is True; assert second["code"] == "FABRIC_IDEMPOTENT_REPLAY"; assert counter["count"] == 1
+
+
+def test_peer_rejects_conflicting_attempt_reuse(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); c = contract(tmp_path)
+    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    req = fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]); svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef")
+    forged = dict(env); forged["objective"] = "Different content under same attempt identity"
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(fabric._request("accept", "coord-main", data={"envelope": forged}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    assert exc.value.code == "FABRIC_IDEMPOTENCY_CONFLICT"
+
+
+def test_peer_rejects_authority_widening(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch, policy_loader=lambda: policy(tmp_path, max_auth="read_only")); c = contract(tmp_path, auth_class="reversible_write")
+    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    assert exc.value.code == "FABRIC_AUTHORITY_DENIED"
+
+
+def test_prestart_policy_drift_blocks_runner(tmp_path, monkeypatch):
+    calls = {"n": 0}; p1 = policy(tmp_path, revision="r1"); p2 = policy(tmp_path, revision="r2")
+    def loader():
+        calls["n"] += 1
+        return p2 if calls["n"] >= 3 else p1
+    counter = {"count": 0}; svc = service(tmp_path, monkeypatch, policy_loader=loader, dispatch_counter=counter); c = contract(tmp_path)
+    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    assert exc.value.code == "FABRIC_POLICY_DRIFT"; assert counter["count"] == 0
+
+
+def test_write_claim_blocks_second_write_in_same_conflict_domain(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); c1 = contract(tmp_path, auth_class="reversible_write")
+    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env1 = fabric._build_envelope(c1, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    svc.handle(fabric._request("accept", "coord-main", data={"envelope": env1}, dispatch_id=env1["dispatch_id"], attempt_id=env1["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    c2 = contract(tmp_path, auth_class="reversible_write"); c2["task_id"] = "task-fabric-2"
+    env2 = fabric._build_envelope(c2, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env2}, dispatch_id=env2["dispatch_id"], attempt_id=env2["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    assert exc.value.code == "FABRIC_WRITE_OWNERSHIP_BLOCKED"
+
+
+def test_peer_restart_uses_durable_journal(tmp_path, monkeypatch):
+    observed = []; svc1 = service(tmp_path, monkeypatch, observed=observed); c = contract(tmp_path)
+    cap = svc1.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
+    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    svc1.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    observed.append({"status": "completed", "outcome": "completed", "started_at": "2026-01-01T00:00:00Z", "ended_at": "2026-01-01T00:01:00Z"})
+    svc2 = service(tmp_path, monkeypatch, observed=observed)
+    status = svc2.handle(fabric._request("reconcile", "coord-main", data={}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    assert status["data"]["state"] == "SUCCEEDED"
+
+
+def test_coordinator_remote_happy_path_feeds_observed_run(tmp_path, monkeypatch):
+    observed = []; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); assert result["success"] is True
+    observed.append({"status": "completed", "outcome": "completed", "started_at": "2026-01-01T00:00:00Z", "ended_at": "2026-01-01T00:01:00Z", "error": ""})
+    runs = coord.observed_runs("task-fabric-1")
+    assert len(runs) == 1; assert runs[0]["outcome"] == "completed"; assert runs[0]["scope"] == "fabric:node-a"; assert runs[0]["evidence_provenance"] == "managed_peer_structured"
+
+
+def test_coordinator_duplicate_dispatch_does_not_resubmit(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); calls = {"accept": 0}
+    def rpc(n, request, timeout):
+        if request["operation"] == "accept": calls["accept"] += 1
+        return rpc_for(svc)(n, request, timeout)
+    coord = coordinator(tmp_path, svc, rpc=rpc); first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert first["success"] is True; assert second["idempotent"] is True; assert calls["accept"] == 1
+
+
+def test_timeout_after_submit_is_ambiguous_and_never_blindly_retried(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); calls = {"accept": 0}
+    def rpc(n, request, timeout):
+        if request["operation"] == "capabilities": return rpc_for(svc)(n, request, timeout)
+        if request["operation"] == "accept": calls["accept"] += 1; raise fabric.FabricError("FABRIC_TRANSPORT_TIMEOUT", "timed out", ambiguous=True)
+        return rpc_for(svc)(n, request, timeout)
+    coord = coordinator(tmp_path, svc, rpc=rpc); first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert first["success"] is False; assert first["state"] == "SUBMISSION_AMBIGUOUS"; assert first["submission_may_have_succeeded"] is True; assert second["success"] is False; assert second["idempotent"] is True; assert calls["accept"] == 1
+
+
+def test_wrong_lineage_and_self_certifying_evidence_are_rejected(tmp_path, monkeypatch):
+    observed = [{"status": "completed", "outcome": "completed", "started_at": "s", "ended_at": "e", "error": ""}]; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); coord.poll(result["attempt_id"]); attempt, _dispatch, n = coord._attempt(result["attempt_id"])
+    evidence = svc.handle(fabric._request("evidence", "coord-main", data={}, dispatch_id=result["dispatch_id"], attempt_id=result["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")["data"]["evidence"]
+    forged = dict(evidence); forged["contract_sha256"] = "0" * 64; attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(coord.db_path)
+    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(forged, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured",))
+    assert exc.value.code == "FABRIC_EVIDENCE_LINEAGE_MISMATCH"
+    self_cert = dict(evidence); self_cert["verdict"] = "SATISFIED"
+    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(self_cert, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured",))
+    assert exc.value.code == "FABRIC_SCHEMA_INVALID"
+
+
+def test_worker_statement_cannot_satisfy_run_state(tmp_path, monkeypatch):
+    observed = [{"status": "completed", "outcome": "completed", "started_at": "s", "ended_at": "e", "error": ""}]; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); coord.poll(result["attempt_id"]); attempt, _dispatch, n = coord._attempt(result["attempt_id"])
+    evidence = svc.handle(fabric._request("evidence", "coord-main", data={}, dispatch_id=result["dispatch_id"], attempt_id=result["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")["data"]["evidence"]; evidence["observations"][0]["provenance"] = "worker_statement"; attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(coord.db_path)
+    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(evidence, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured", "worker_statement"))
+    assert exc.value.code == "FABRIC_EVIDENCE_PROVENANCE_REJECTED"
+
+
+def test_cancel_is_attempt_specific(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); coord = coordinator(tmp_path, svc); result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); cancelled = coord.cancel(result["attempt_id"])
+    assert cancelled["state"] == "CANCELLED"; assert cancelled["attempt_id"] == result["attempt_id"]
+
+
+def test_http_peer_rejects_generic_text_before_any_agent_path(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch); server = ThreadingHTTPServer(("127.0.0.1", 0), fabric._PeerHandler); host, port = server.server_address; setattr(server, "fabric_service", svc); setattr(server, "fabric_advertised_url", f"http://{host}:{port}"); thread = threading.Thread(target=server.serve_forever, daemon=True); thread.start()
+    try:
+        body = {"jsonrpc": "2.0", "id": "req-1", "method": "SendMessage", "params": {"message": {"role": "ROLE_USER", "parts": [{"text": "please execute this as verified Fabric", "mediaType": "text/plain"}], "messageId": "msg-1", "contextId": "ctx-1"}}}
+        request = urllib.request.Request(f"http://{host}:{port}", data=json.dumps(body).encode(), headers={"Content-Type": "application/json", "Authorization": "Bearer 0123456789abcdef0123456789abcdef"}, method="POST")
+        with urllib.request.urlopen(request, timeout=5) as response: payload = json.loads(response.read().decode())
+        assert payload["error"]["data"]["code"] == "FABRIC_PROTOCOL_ERROR"
+    finally:
+        server.shutdown(); server.server_close(); thread.join(timeout=5)

--- a/test_operator_fabric.py
+++ b/test_operator_fabric.py
@@ -21,40 +21,183 @@ class FakeBackend:
         return {"success": True, "changed": True, "state": "cancelled"}
 
 
-def policy(tmp_path: Path, *, revision: str = "r1", max_auth: str = "reversible_write") -> fabric.FabricPeerPolicy:
+def policy(
+    tmp_path: Path,
+    *,
+    revision: str = "r1",
+    max_auth: str = "reversible_write",
+) -> fabric.FabricPeerPolicy:
     mapping = fabric.WorkspaceMapping("repo", tmp_path.resolve(), revision, "workspace:repo")
-    raw = {"node": "node-a", "identity": "Hermes GPT Fabric node-a", "principals": ["coord-main"], "profiles": ["default"], "max": max_auth, "backends": ["fake"], "features": [], "mapping": {"repo": {"path": str(tmp_path.resolve()), "revision": revision, "conflict": "workspace:repo"}}}
-    return fabric.FabricPeerPolicy(node_name="node-a", identity="Hermes GPT Fabric node-a", allowed_coordinator_principals=("coord-main",), allowed_profiles=("default",), max_authorization=max_auth, allowed_backends=("fake",), required_features=(), workspace_mappings={"repo": mapping}, digest=fabric.sha256_json(raw))
+    raw = {
+        "node": "node-a",
+        "identity": "Hermes GPT Fabric node-a",
+        "principals": ["coord-main"],
+        "profiles": ["default"],
+        "max": max_auth,
+        "backends": ["fake"],
+        "features": [],
+        "mapping": {
+            "repo": {
+                "path": str(tmp_path.resolve()),
+                "revision": revision,
+                "conflict": "workspace:repo",
+            }
+        },
+    }
+    return fabric.FabricPeerPolicy(
+        node_name="node-a",
+        identity="Hermes GPT Fabric node-a",
+        allowed_coordinator_principals=("coord-main",),
+        allowed_profiles=("default",),
+        max_authorization=max_auth,
+        allowed_backends=("fake",),
+        required_features=(),
+        workspace_mappings={"repo": mapping},
+        digest=fabric.sha256_json(raw),
+    )
 
 
 def node() -> fabric.FabricNode:
-    return fabric.FabricNode(name="node-a", a2a_peer_name="node-a-peer", expected_identity="Hermes GPT Fabric node-a", coordinator_principal="coord-main", enabled=True, allowed_profiles=("default",), max_authorization="reversible_write", allowed_remote_backends=("fake",), logical_workspaces=("repo",), required_features=())
+    return fabric.FabricNode(
+        name="node-a",
+        a2a_peer_name="node-a-peer",
+        expected_identity="Hermes GPT Fabric node-a",
+        coordinator_principal="coord-main",
+        enabled=True,
+        allowed_profiles=("default",),
+        max_authorization="reversible_write",
+        allowed_remote_backends=("fake",),
+        logical_workspaces=("repo",),
+        required_features=(),
+    )
 
 
 def contract(tmp_path: Path, *, auth_class: str = "read_only") -> dict:
-    return {"schema": "hermes.work-contract/v1", "task_id": "task-fabric-1", "objective": "Inspect the repository and report observed completion state.", "assigned_agent": "node-a", "assigned_profile": "default", "inputs": [], "constraints": ["Do not publish anything."], "allowed_scope": {"workspaces": [str(tmp_path.resolve())], "profiles": ["default"]}, "forbidden_actions": [], "expected_artifacts": [], "tests": [], "review_requirements": {"required": False, "reviewer": "", "evidence": "", "approval_required": False}, "completion_criteria": {"run_state": {"terminal": True, "outcome_ok": ["completed"]}, "artifacts_present": False, "tests_pass": False, "review_satisfied": False, "no_forbidden_actions": True}, "authorization": {"class": auth_class, "approved": True}, "execution": {"backend": "fabric", "options": {"node": "node-a", "remote_backend": "fake", "logical_workspace": "repo", "remote_options": {}, "evidence_provenance": {"run_state": ["managed_peer_structured"]}}}}
+    return {
+        "schema": "hermes.work-contract/v1",
+        "task_id": "task-fabric-1",
+        "objective": "Inspect the repository and report observed completion state.",
+        "assigned_agent": "node-a",
+        "assigned_profile": "default",
+        "inputs": [],
+        "constraints": ["Do not publish anything."],
+        "allowed_scope": {
+            "workspaces": [str(tmp_path.resolve())],
+            "profiles": ["default"],
+        },
+        "forbidden_actions": [],
+        "expected_artifacts": [],
+        "tests": [],
+        "review_requirements": {
+            "required": False,
+            "reviewer": "",
+            "evidence": "",
+            "approval_required": False,
+        },
+        "completion_criteria": {
+            "run_state": {"terminal": True, "outcome_ok": ["completed"]},
+            "artifacts_present": False,
+            "tests_pass": False,
+            "review_satisfied": False,
+            "no_forbidden_actions": True,
+        },
+        "authorization": {"class": auth_class, "approved": True},
+        "execution": {
+            "backend": "fabric",
+            "options": {
+                "node": "node-a",
+                "remote_backend": "fake",
+                "logical_workspace": "repo",
+                "remote_options": {},
+                "evidence_provenance": {"run_state": ["managed_peer_structured"]},
+            },
+        },
+    }
 
 
-def service(tmp_path: Path, monkeypatch, *, policy_loader=None, observed=None, dispatch_counter=None, cancel_fn=None):
+def service(
+    tmp_path: Path,
+    monkeypatch,
+    *,
+    policy_loader=None,
+    observed=None,
+    dispatch_counter=None,
+    cancel_fn=None,
+):
     monkeypatch.setattr(fabric.op_runners, "get_backend", lambda _name: FakeBackend())
     observed = observed if observed is not None else []
     dispatch_counter = dispatch_counter if dispatch_counter is not None else {"count": 0}
+
     def dispatch_fn(_contract, **_kwargs):
         dispatch_counter["count"] += 1
         return {"success": True, "changed": True, "backend": "fake"}
-    return fabric.FabricPeerService(policy_loader=policy_loader or (lambda: policy(tmp_path)), tokens={"coord-main": "0123456789abcdef0123456789abcdef"}, db_path=tmp_path / "peer.db", dispatch_fn=dispatch_fn, observed_fn=lambda _task_id: list(observed), cancel_fn=cancel_fn or (lambda _backend, _task_id: {"success": True, "changed": True, "state": "cancelled"}), hermes_root=tmp_path)
+
+    return fabric.FabricPeerService(
+        policy_loader=policy_loader or (lambda: policy(tmp_path)),
+        tokens={"coord-main": "0123456789abcdef0123456789abcdef"},
+        db_path=tmp_path / "peer.db",
+        dispatch_fn=dispatch_fn,
+        observed_fn=lambda _task_id: list(observed),
+        cancel_fn=cancel_fn
+        or (lambda _backend, _task_id: {"success": True, "changed": True, "state": "cancelled"}),
+        hermes_root=tmp_path,
+    )
 
 
 def rpc_for(svc: fabric.FabricPeerService):
     def rpc(_node, request, _timeout):
-        response = svc.handle(request, "Bearer 0123456789abcdef0123456789abcdef")
+        response = svc.handle(
+            request,
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
         attempt_id = request.get("attempt_id") or request.get("request_id")
         return f"ftask-{str(attempt_id)[-12:]}", response
+
     return rpc
 
 
-def coordinator(tmp_path: Path, svc: fabric.FabricPeerService, *, rpc=None) -> fabric.FabricCoordinator:
-    return fabric.FabricCoordinator(registry_loader=lambda: {"node-a": node()}, db_path=tmp_path / "coord.db", rpc=rpc or rpc_for(svc), hermes_root=tmp_path)
+def coordinator(
+    tmp_path: Path,
+    svc: fabric.FabricPeerService,
+    *,
+    rpc=None,
+) -> fabric.FabricCoordinator:
+    return fabric.FabricCoordinator(
+        registry_loader=lambda: {"node-a": node()},
+        db_path=tmp_path / "coord.db",
+        rpc=rpc or rpc_for(svc),
+        hermes_root=tmp_path,
+    )
+
+
+def capability(svc: fabric.FabricPeerService) -> dict:
+    return svc.handle(
+        fabric._request("capabilities", "coord-main", data={}),
+        "Bearer 0123456789abcdef0123456789abcdef",
+    )["data"]
+
+
+def envelope_for(svc: fabric.FabricPeerService, value: dict) -> dict:
+    cap = capability(svc)
+    return fabric._build_envelope(
+        value,
+        node(),
+        remote_backend="fake",
+        logical_workspace="repo",
+        remote_options={},
+        evidence_policy={"run_state": ("managed_peer_structured",)},
+        capability_sha=cap["snapshot_sha256"],
+    )
+
+
+def accept_request(envelope: dict) -> dict:
+    return fabric._request(
+        "accept",
+        "coord-main",
+        data={"envelope": envelope},
+        dispatch_id=envelope["dispatch_id"],
+        attempt_id=envelope["attempt_id"],
+    )
 
 
 def test_strict_json_rejects_duplicate_fields():
@@ -64,7 +207,12 @@ def test_strict_json_rejects_duplicate_fields():
 
 
 def test_peer_tokens_require_unique_principal_token():
-    raw = json.dumps({"coord-a": "0123456789abcdef", "coord-b": "0123456789abcdef"})
+    raw = json.dumps(
+        {
+            "coord-a": "0123456789abcdef",
+            "coord-b": "0123456789abcdef",
+        }
+    )
     with pytest.raises(fabric.FabricError) as exc:
         fabric.load_peer_tokens(raw)
     assert exc.value.code == "FABRIC_PRINCIPAL_CONFIG_INVALID"
@@ -78,151 +226,346 @@ def test_non_loopback_plain_http_is_rejected():
 
 
 def test_remote_options_reject_nested_credentials_and_urls(tmp_path):
-    c = contract(tmp_path)
-    c["execution"]["options"]["remote_options"] = {"nested": {"api_key": "nope"}}
+    value = contract(tmp_path)
+    value["execution"]["options"]["remote_options"] = {"nested": {"api_key": "nope"}}
     with pytest.raises(fabric.FabricError) as exc:
-        fabric._fabric_options(c)
+        fabric._fabric_options(value)
     assert exc.value.code == "FABRIC_CALLER_CREDENTIAL"
-    c["execution"]["options"]["remote_options"] = {"nested": {"endpoint": "example"}}
+
+    value["execution"]["options"]["remote_options"] = {"nested": {"endpoint": "example"}}
     with pytest.raises(fabric.FabricError) as exc:
-        fabric._fabric_options(c)
+        fabric._fabric_options(value)
     assert exc.value.code == "FABRIC_CALLER_NETWORK_TARGET"
 
 
 def test_peer_requires_authenticated_unique_principal(tmp_path, monkeypatch):
     svc = service(tmp_path, monkeypatch)
-    req = fabric._request("capabilities", "coord-main", data={})
+    request = fabric._request("capabilities", "coord-main", data={})
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(req, "")
+        svc.handle(request, "")
     assert exc.value.code == "FABRIC_PRINCIPAL_AUTH_REQUIRED"
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(req, "Bearer wrong-wrong-wrong-wrong")
+        svc.handle(request, "Bearer wrong-wrong-wrong-wrong")
     assert exc.value.code == "FABRIC_PRINCIPAL_AUTH_FAILED"
 
 
 def test_peer_accept_is_durable_and_idempotent(tmp_path, monkeypatch):
-    counter = {"count": 0}; svc = service(tmp_path, monkeypatch, dispatch_counter=counter); c = contract(tmp_path)
-    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
-    req = fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"])
-    first = svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef"); second = svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef")
-    assert first["ok"] is True; assert second["code"] == "FABRIC_IDEMPOTENT_REPLAY"; assert counter["count"] == 1
+    counter = {"count": 0}
+    svc = service(tmp_path, monkeypatch, dispatch_counter=counter)
+    envelope = envelope_for(svc, contract(tmp_path))
+    request = accept_request(envelope)
+    first = svc.handle(request, "Bearer 0123456789abcdef0123456789abcdef")
+    second = svc.handle(request, "Bearer 0123456789abcdef0123456789abcdef")
+    assert first["ok"] is True
+    assert second["code"] == "FABRIC_IDEMPOTENT_REPLAY"
+    assert counter["count"] == 1
 
 
 def test_peer_rejects_conflicting_attempt_reuse(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); c = contract(tmp_path)
-    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
-    req = fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]); svc.handle(req, "Bearer 0123456789abcdef0123456789abcdef")
-    forged = dict(env); forged["objective"] = "Different content under same attempt identity"
+    svc = service(tmp_path, monkeypatch)
+    envelope = envelope_for(svc, contract(tmp_path))
+    svc.handle(accept_request(envelope), "Bearer 0123456789abcdef0123456789abcdef")
+    forged = dict(envelope)
+    forged["objective"] = "Different content under same attempt identity"
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(fabric._request("accept", "coord-main", data={"envelope": forged}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+        svc.handle(
+            accept_request(forged),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
     assert exc.value.code == "FABRIC_IDEMPOTENCY_CONFLICT"
 
 
 def test_peer_rejects_authority_widening(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch, policy_loader=lambda: policy(tmp_path, max_auth="read_only")); c = contract(tmp_path, auth_class="reversible_write")
-    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    svc = service(
+        tmp_path,
+        monkeypatch,
+        policy_loader=lambda: policy(tmp_path, max_auth="read_only"),
+    )
+    envelope = envelope_for(svc, contract(tmp_path, auth_class="reversible_write"))
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+        svc.handle(
+            accept_request(envelope),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
     assert exc.value.code == "FABRIC_AUTHORITY_DENIED"
 
 
 def test_prestart_policy_drift_blocks_runner(tmp_path, monkeypatch):
-    calls = {"n": 0}; p1 = policy(tmp_path, revision="r1"); p2 = policy(tmp_path, revision="r2")
+    calls = {"n": 0}
+    first_policy = policy(tmp_path, revision="r1")
+    changed_policy = policy(tmp_path, revision="r2")
+
     def loader():
         calls["n"] += 1
-        return p2 if calls["n"] >= 3 else p1
-    counter = {"count": 0}; svc = service(tmp_path, monkeypatch, policy_loader=loader, dispatch_counter=counter); c = contract(tmp_path)
-    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+        return changed_policy if calls["n"] >= 3 else first_policy
+
+    counter = {"count": 0}
+    svc = service(
+        tmp_path,
+        monkeypatch,
+        policy_loader=loader,
+        dispatch_counter=counter,
+    )
+    envelope = envelope_for(svc, contract(tmp_path))
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
-    assert exc.value.code == "FABRIC_POLICY_DRIFT"; assert counter["count"] == 0
+        svc.handle(
+            accept_request(envelope),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
+    assert exc.value.code == "FABRIC_POLICY_DRIFT"
+    assert counter["count"] == 0
 
 
 def test_write_claim_blocks_second_write_in_same_conflict_domain(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); c1 = contract(tmp_path, auth_class="reversible_write")
-    cap = svc.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env1 = fabric._build_envelope(c1, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
-    svc.handle(fabric._request("accept", "coord-main", data={"envelope": env1}, dispatch_id=env1["dispatch_id"], attempt_id=env1["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
-    c2 = contract(tmp_path, auth_class="reversible_write"); c2["task_id"] = "task-fabric-2"
-    env2 = fabric._build_envelope(c2, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
+    svc = service(tmp_path, monkeypatch)
+    first = envelope_for(svc, contract(tmp_path, auth_class="reversible_write"))
+    svc.handle(accept_request(first), "Bearer 0123456789abcdef0123456789abcdef")
+
+    second_contract = contract(tmp_path, auth_class="reversible_write")
+    second_contract["task_id"] = "task-fabric-2"
+    second = envelope_for(svc, second_contract)
     with pytest.raises(fabric.FabricError) as exc:
-        svc.handle(fabric._request("accept", "coord-main", data={"envelope": env2}, dispatch_id=env2["dispatch_id"], attempt_id=env2["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+        svc.handle(
+            accept_request(second),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
     assert exc.value.code == "FABRIC_WRITE_OWNERSHIP_BLOCKED"
 
 
 def test_peer_restart_uses_durable_journal(tmp_path, monkeypatch):
-    observed = []; svc1 = service(tmp_path, monkeypatch, observed=observed); c = contract(tmp_path)
-    cap = svc1.handle(fabric._request("capabilities", "coord-main", data={}), "Bearer 0123456789abcdef0123456789abcdef")["data"]
-    env = fabric._build_envelope(c, node(), remote_backend="fake", logical_workspace="repo", remote_options={}, evidence_policy={"run_state": ("managed_peer_structured",)}, capability_sha=cap["snapshot_sha256"])
-    svc1.handle(fabric._request("accept", "coord-main", data={"envelope": env}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
-    observed.append({"status": "completed", "outcome": "completed", "started_at": "2026-01-01T00:00:00Z", "ended_at": "2026-01-01T00:01:00Z"})
-    svc2 = service(tmp_path, monkeypatch, observed=observed)
-    status = svc2.handle(fabric._request("reconcile", "coord-main", data={}, dispatch_id=env["dispatch_id"], attempt_id=env["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")
+    observed = []
+    first_service = service(tmp_path, monkeypatch, observed=observed)
+    envelope = envelope_for(first_service, contract(tmp_path))
+    first_service.handle(
+        accept_request(envelope),
+        "Bearer 0123456789abcdef0123456789abcdef",
+    )
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+        }
+    )
+    restarted = service(tmp_path, monkeypatch, observed=observed)
+    status = restarted.handle(
+        fabric._request(
+            "reconcile",
+            "coord-main",
+            data={},
+            dispatch_id=envelope["dispatch_id"],
+            attempt_id=envelope["attempt_id"],
+        ),
+        "Bearer 0123456789abcdef0123456789abcdef",
+    )
     assert status["data"]["state"] == "SUCCEEDED"
 
 
 def test_coordinator_remote_happy_path_feeds_observed_run(tmp_path, monkeypatch):
-    observed = []; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
-    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); assert result["success"] is True
-    observed.append({"status": "completed", "outcome": "completed", "started_at": "2026-01-01T00:00:00Z", "ended_at": "2026-01-01T00:01:00Z", "error": ""})
+    observed = []
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert result["success"] is True
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+            "error": "",
+        }
+    )
     runs = coord.observed_runs("task-fabric-1")
-    assert len(runs) == 1; assert runs[0]["outcome"] == "completed"; assert runs[0]["scope"] == "fabric:node-a"; assert runs[0]["evidence_provenance"] == "managed_peer_structured"
+    assert len(runs) == 1
+    assert runs[0]["outcome"] == "completed"
+    assert runs[0]["scope"] == "fabric:node-a"
+    assert runs[0]["evidence_provenance"] == "managed_peer_structured"
 
 
 def test_coordinator_duplicate_dispatch_does_not_resubmit(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); calls = {"accept": 0}
-    def rpc(n, request, timeout):
-        if request["operation"] == "accept": calls["accept"] += 1
-        return rpc_for(svc)(n, request, timeout)
-    coord = coordinator(tmp_path, svc, rpc=rpc); first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
-    assert first["success"] is True; assert second["idempotent"] is True; assert calls["accept"] == 1
+    svc = service(tmp_path, monkeypatch)
+    calls = {"accept": 0}
+
+    def rpc(target, request, timeout):
+        if request["operation"] == "accept":
+            calls["accept"] += 1
+        return rpc_for(svc)(target, request, timeout)
+
+    coord = coordinator(tmp_path, svc, rpc=rpc)
+    first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert first["success"] is True
+    assert second["idempotent"] is True
+    assert calls["accept"] == 1
 
 
 def test_timeout_after_submit_is_ambiguous_and_never_blindly_retried(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); calls = {"accept": 0}
-    def rpc(n, request, timeout):
-        if request["operation"] == "capabilities": return rpc_for(svc)(n, request, timeout)
-        if request["operation"] == "accept": calls["accept"] += 1; raise fabric.FabricError("FABRIC_TRANSPORT_TIMEOUT", "timed out", ambiguous=True)
-        return rpc_for(svc)(n, request, timeout)
-    coord = coordinator(tmp_path, svc, rpc=rpc); first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
-    assert first["success"] is False; assert first["state"] == "SUBMISSION_AMBIGUOUS"; assert first["submission_may_have_succeeded"] is True; assert second["success"] is False; assert second["idempotent"] is True; assert calls["accept"] == 1
+    svc = service(tmp_path, monkeypatch)
+    calls = {"accept": 0}
+
+    def rpc(target, request, timeout):
+        if request["operation"] == "capabilities":
+            return rpc_for(svc)(target, request, timeout)
+        if request["operation"] == "accept":
+            calls["accept"] += 1
+            raise fabric.FabricError(
+                "FABRIC_TRANSPORT_TIMEOUT",
+                "timed out",
+                ambiguous=True,
+            )
+        return rpc_for(svc)(target, request, timeout)
+
+    coord = coordinator(tmp_path, svc, rpc=rpc)
+    first = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    second = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert first["success"] is False
+    assert first["state"] == "SUBMISSION_AMBIGUOUS"
+    assert first["submission_may_have_succeeded"] is True
+    assert second["success"] is False
+    assert second["idempotent"] is True
+    assert calls["accept"] == 1
 
 
 def test_wrong_lineage_and_self_certifying_evidence_are_rejected(tmp_path, monkeypatch):
-    observed = [{"status": "completed", "outcome": "completed", "started_at": "s", "ended_at": "e", "error": ""}]; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
-    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); coord.poll(result["attempt_id"]); attempt, _dispatch, n = coord._attempt(result["attempt_id"])
-    evidence = svc.handle(fabric._request("evidence", "coord-main", data={}, dispatch_id=result["dispatch_id"], attempt_id=result["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")["data"]["evidence"]
-    forged = dict(evidence); forged["contract_sha256"] = "0" * 64; attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(coord.db_path)
-    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(forged, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured",))
+    observed = [
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "s",
+            "ended_at": "e",
+            "error": "",
+        }
+    ]
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    coord.poll(result["attempt_id"])
+    attempt, _dispatch, target = coord._attempt(result["attempt_id"])
+    evidence = svc.handle(
+        fabric._request(
+            "evidence",
+            "coord-main",
+            data={},
+            dispatch_id=result["dispatch_id"],
+            attempt_id=result["attempt_id"],
+        ),
+        "Bearer 0123456789abcdef0123456789abcdef",
+    )["data"]["evidence"]
+    attempt_map = dict(attempt)
+    attempt_map["_coordinator_db"] = str(coord.db_path)
+
+    forged = dict(evidence)
+    forged["contract_sha256"] = "0" * 64
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._validate_evidence(
+            forged,
+            attempt=attempt_map,
+            node=target,
+            allowed_provenance=("managed_peer_structured",),
+        )
     assert exc.value.code == "FABRIC_EVIDENCE_LINEAGE_MISMATCH"
-    self_cert = dict(evidence); self_cert["verdict"] = "SATISFIED"
-    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(self_cert, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured",))
+
+    self_certifying = dict(evidence)
+    self_certifying["verdict"] = "SATISFIED"
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._validate_evidence(
+            self_certifying,
+            attempt=attempt_map,
+            node=target,
+            allowed_provenance=("managed_peer_structured",),
+        )
     assert exc.value.code == "FABRIC_SCHEMA_INVALID"
 
 
 def test_worker_statement_cannot_satisfy_run_state(tmp_path, monkeypatch):
-    observed = [{"status": "completed", "outcome": "completed", "started_at": "s", "ended_at": "e", "error": ""}]; svc = service(tmp_path, monkeypatch, observed=observed); coord = coordinator(tmp_path, svc)
-    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); coord.poll(result["attempt_id"]); attempt, _dispatch, n = coord._attempt(result["attempt_id"])
-    evidence = svc.handle(fabric._request("evidence", "coord-main", data={}, dispatch_id=result["dispatch_id"], attempt_id=result["attempt_id"]), "Bearer 0123456789abcdef0123456789abcdef")["data"]["evidence"]; evidence["observations"][0]["provenance"] = "worker_statement"; attempt_map = dict(attempt); attempt_map["_coordinator_db"] = str(coord.db_path)
-    with pytest.raises(fabric.FabricError) as exc: fabric._validate_evidence(evidence, attempt=attempt_map, node=n, allowed_provenance=("managed_peer_structured", "worker_statement"))
+    observed = [
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "s",
+            "ended_at": "e",
+            "error": "",
+        }
+    ]
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    coord.poll(result["attempt_id"])
+    attempt, _dispatch, target = coord._attempt(result["attempt_id"])
+    evidence = svc.handle(
+        fabric._request(
+            "evidence",
+            "coord-main",
+            data={},
+            dispatch_id=result["dispatch_id"],
+            attempt_id=result["attempt_id"],
+        ),
+        "Bearer 0123456789abcdef0123456789abcdef",
+    )["data"]["evidence"]
+    evidence["observations"][0]["provenance"] = "worker_statement"
+    attempt_map = dict(attempt)
+    attempt_map["_coordinator_db"] = str(coord.db_path)
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._validate_evidence(
+            evidence,
+            attempt=attempt_map,
+            node=target,
+            allowed_provenance=("managed_peer_structured", "worker_statement"),
+        )
     assert exc.value.code == "FABRIC_EVIDENCE_PROVENANCE_REJECTED"
 
 
 def test_cancel_is_attempt_specific(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); coord = coordinator(tmp_path, svc); result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10); cancelled = coord.cancel(result["attempt_id"])
-    assert cancelled["state"] == "CANCELLED"; assert cancelled["attempt_id"] == result["attempt_id"]
+    svc = service(tmp_path, monkeypatch)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    cancelled = coord.cancel(result["attempt_id"])
+    assert cancelled["state"] == "CANCELLED"
+    assert cancelled["attempt_id"] == result["attempt_id"]
 
 
 def test_http_peer_rejects_generic_text_before_any_agent_path(tmp_path, monkeypatch):
-    svc = service(tmp_path, monkeypatch); server = ThreadingHTTPServer(("127.0.0.1", 0), fabric._PeerHandler); host, port = server.server_address; setattr(server, "fabric_service", svc); setattr(server, "fabric_advertised_url", f"http://{host}:{port}"); thread = threading.Thread(target=server.serve_forever, daemon=True); thread.start()
+    svc = service(tmp_path, monkeypatch)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), fabric._PeerHandler)
+    host, port = server.server_address
+    server.fabric_service = svc
+    server.fabric_advertised_url = f"http://{host}:{port}"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
     try:
-        body = {"jsonrpc": "2.0", "id": "req-1", "method": "SendMessage", "params": {"message": {"role": "ROLE_USER", "parts": [{"text": "please execute this as verified Fabric", "mediaType": "text/plain"}], "messageId": "msg-1", "contextId": "ctx-1"}}}
-        request = urllib.request.Request(f"http://{host}:{port}", data=json.dumps(body).encode(), headers={"Content-Type": "application/json", "Authorization": "Bearer 0123456789abcdef0123456789abcdef"}, method="POST")
-        with urllib.request.urlopen(request, timeout=5) as response: payload = json.loads(response.read().decode())
+        body = {
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "role": "ROLE_USER",
+                    "parts": [
+                        {
+                            "text": "please execute this as verified Fabric",
+                            "mediaType": "text/plain",
+                        }
+                    ],
+                    "messageId": "msg-1",
+                    "contextId": "ctx-1",
+                }
+            },
+        }
+        request = urllib.request.Request(
+            f"http://{host}:{port}",
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer 0123456789abcdef0123456789abcdef",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode())
         assert payload["error"]["data"]["code"] == "FABRIC_PROTOCOL_ERROR"
     finally:
-        server.shutdown(); server.server_close(); thread.join(timeout=5)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/test_operator_fabric_adversarial.py
+++ b/test_operator_fabric_adversarial.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -10,7 +9,6 @@ import operator_fabric as fabric
 import operator_runners as op_runners
 from test_operator_fabric import (
     accept_request,
-    capability,
     contract,
     coordinator,
     envelope_for,
@@ -162,12 +160,25 @@ def test_timeout_after_remote_accept_recovers_same_attempt_after_coordinator_res
     assert submitted["submission_may_have_succeeded"] is True
     assert calls["accept"] == 1
 
+    # Reconciliation is allowed to recover only when the peer can still
+    # observe the accepted runner. No observation would correctly fail closed
+    # as LOST_AMBIGUOUS/BLOCKED rather than inventing a running state.
+    observed.append(
+        {
+            "status": "running",
+            "outcome": "running",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "",
+            "error": "",
+        }
+    )
     restarted = coordinator(tmp_path, svc)
     status = restarted.poll(submitted["attempt_id"], reconcile=True)
     assert status["state"] == "RUNNING"
     assert status["attempt_id"] == submitted["attempt_id"]
     assert calls["accept"] == 1
 
+    observed.clear()
     observed.append(
         {
             "status": "completed",

--- a/test_operator_fabric_adversarial.py
+++ b/test_operator_fabric_adversarial.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import operator_contract as op_contract
+import operator_fabric as fabric
+import operator_runners as op_runners
+from test_operator_fabric import (
+    accept_request,
+    capability,
+    contract,
+    coordinator,
+    envelope_for,
+    node,
+    policy,
+    rpc_for,
+    service,
+)
+
+
+def test_authorized_remote_write_happy_path_returns_admissible_run(tmp_path, monkeypatch):
+    observed = []
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(
+        contract(tmp_path, auth_class="reversible_write"),
+        dry_run=False,
+        confirm=True,
+        timeout=10,
+    )
+    assert result["success"] is True
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+            "error": "",
+        }
+    )
+    status = coord.poll(result["attempt_id"], reconcile=True)
+    assert status["peer_state"] == "SUCCEEDED"
+    evidence = coord.collect(result["attempt_id"])
+    assert evidence["state"] == "COMPLETED"
+    runs = coord.observed_runs("task-fabric-1", refresh=False)
+    assert runs[0]["outcome"] == "completed"
+    assert runs[0]["evidence_provenance"] == "managed_peer_structured"
+
+
+def test_unknown_node_and_unauthorized_profile_fail_closed(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch)
+    coord = coordinator(tmp_path, svc)
+    value = contract(tmp_path)
+    value["execution"]["options"]["node"] = "node-missing"
+    with pytest.raises(fabric.FabricError) as exc:
+        coord.dispatch(value, dry_run=False, confirm=True, timeout=10)
+    assert exc.value.code == "FABRIC_NODE_NOT_ENROLLED"
+
+    value = contract(tmp_path)
+    value["assigned_profile"] = "other"
+    with pytest.raises(fabric.FabricError) as exc:
+        coord.dispatch(value, dry_run=False, confirm=True, timeout=10)
+    assert exc.value.code == "FABRIC_AUTHORITY_DENIED"
+
+
+def test_oversized_request_and_unsupported_major_are_rejected(tmp_path, monkeypatch):
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric.strict_json_loads(b"x" * (128 * 1024 + 1))
+    assert exc.value.code == "FABRIC_PAYLOAD_TOO_LARGE"
+
+    svc = service(tmp_path, monkeypatch)
+    request = fabric._request("capabilities", "coord-main", data={})
+    request["version"] = 2
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(request, "Bearer 0123456789abcdef0123456789abcdef")
+    assert exc.value.code == "FABRIC_PROTOCOL_INCOMPATIBLE"
+
+
+def test_missing_required_feature_is_rejected_before_runner_start(tmp_path, monkeypatch):
+    counter = {"count": 0}
+    svc = service(tmp_path, monkeypatch, dispatch_counter=counter)
+    envelope = envelope_for(svc, contract(tmp_path))
+    envelope["required_features"] = [*envelope["required_features"], "future-feature-v9"]
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(
+            accept_request(envelope),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
+    assert exc.value.code == "FABRIC_PROTOCOL_INCOMPATIBLE"
+    assert counter["count"] == 0
+
+
+def test_coordinator_rejects_capability_identity_drift(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch)
+
+    def drift_rpc(target, request, timeout):
+        remote_task_id, response = rpc_for(svc)(target, request, timeout)
+        if request["operation"] == "capabilities":
+            response = dict(response)
+            data = dict(response["data"])
+            data["identity"] = "spoofed-peer"
+            data["snapshot_sha256"] = fabric.sha256_json(
+                {key: data[key] for key in data if key != "snapshot_sha256"}
+            )
+            response["data"] = data
+        return remote_task_id, response
+
+    coord = coordinator(tmp_path, svc, rpc=drift_rpc)
+    with pytest.raises(fabric.FabricError) as exc:
+        coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert exc.value.code == "FABRIC_PROTOCOL_INCOMPATIBLE"
+
+
+def test_peer_unavailable_before_accept_does_not_create_ambiguous_submit(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch)
+
+    def unavailable_rpc(_target, request, _timeout):
+        if request["operation"] == "capabilities":
+            raise fabric.FabricError(
+                "FABRIC_PEER_UNAVAILABLE",
+                "peer unavailable",
+                ambiguous=False,
+            )
+        raise AssertionError("accept must not run after failed capability probe")
+
+    coord = coordinator(tmp_path, svc, rpc=unavailable_rpc)
+    with pytest.raises(fabric.FabricError) as exc:
+        coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    assert exc.value.code == "FABRIC_PEER_UNAVAILABLE"
+
+
+def test_timeout_after_remote_accept_recovers_same_attempt_after_coordinator_restart(
+    tmp_path,
+    monkeypatch,
+):
+    observed = []
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    calls = {"accept": 0}
+
+    def timeout_after_accept(target, request, timeout):
+        if request["operation"] == "accept":
+            calls["accept"] += 1
+            rpc_for(svc)(target, request, timeout)
+            raise fabric.FabricError(
+                "FABRIC_TRANSPORT_TIMEOUT",
+                "response lost after peer accepted",
+                ambiguous=True,
+            )
+        return rpc_for(svc)(target, request, timeout)
+
+    first = coordinator(tmp_path, svc, rpc=timeout_after_accept)
+    submitted = first.dispatch(
+        contract(tmp_path),
+        dry_run=False,
+        confirm=True,
+        timeout=10,
+    )
+    assert submitted["state"] == "SUBMISSION_AMBIGUOUS"
+    assert submitted["submission_may_have_succeeded"] is True
+    assert calls["accept"] == 1
+
+    restarted = coordinator(tmp_path, svc)
+    status = restarted.poll(submitted["attempt_id"], reconcile=True)
+    assert status["state"] == "RUNNING"
+    assert status["attempt_id"] == submitted["attempt_id"]
+    assert calls["accept"] == 1
+
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+            "error": "",
+        }
+    )
+    terminal = restarted.poll(submitted["attempt_id"], reconcile=True)
+    assert terminal["peer_state"] == "SUCCEEDED"
+    admitted = restarted.collect(submitted["attempt_id"])
+    assert admitted["state"] == "COMPLETED"
+
+
+def test_a2a_task_mapping_loss_does_not_erase_fabric_identity(tmp_path, monkeypatch):
+    observed = []
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    with fabric._connect(coord.db_path) as db:
+        db.execute(
+            "UPDATE attempts SET remote_task_id=NULL WHERE attempt_id=?",
+            (result["attempt_id"],),
+        )
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+            "error": "",
+        }
+    )
+    status = coord.poll(result["attempt_id"], reconcile=True)
+    assert status["peer_state"] == "SUCCEEDED"
+    assert coord.collect(result["attempt_id"])["state"] == "COMPLETED"
+
+
+def test_legacy_fleet_completion_bundle_is_not_fabric_evidence(tmp_path, monkeypatch):
+    svc = service(tmp_path, monkeypatch)
+    coord = coordinator(tmp_path, svc)
+    result = coord.dispatch(contract(tmp_path), dry_run=False, confirm=True, timeout=10)
+    attempt, _dispatch, target = coord._attempt(result["attempt_id"])
+    attempt_map = dict(attempt)
+    attempt_map["_coordinator_db"] = str(coord.db_path)
+    with pytest.raises(fabric.FabricError) as exc:
+        fabric._validate_evidence(
+            {"completion_bundle": {"status": "completed", "task_id": "task-fabric-1"}},
+            attempt=attempt_map,
+            node=target,
+            allowed_provenance=("managed_peer_structured",),
+        )
+    assert exc.value.code == "FABRIC_SCHEMA_INVALID"
+
+
+def test_existing_contract_validator_consumes_only_pre_admitted_fabric_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    observed = []
+    svc = service(tmp_path, monkeypatch, observed=observed)
+    coord = coordinator(tmp_path, svc)
+
+    raw = contract(tmp_path)
+    canonical, normalized = op_contract._canonical_contract(raw)
+    result = coord.dispatch(normalized, dry_run=False, confirm=True, timeout=10)
+    observed.append(
+        {
+            "status": "completed",
+            "outcome": "completed",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:01:00Z",
+            "error": "",
+        }
+    )
+    coord.poll(result["attempt_id"], reconcile=True)
+    coord.collect(result["attempt_id"])
+
+    previous = op_runners.get_backend("fabric")
+    op_runners.register_backend(
+        fabric.FabricBackend(coordinator_factory=lambda **_kwargs: coord),
+        replace=True,
+    )
+    before = {
+        path.relative_to(tmp_path): path.stat().st_mtime_ns
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    try:
+        payload = json.loads(
+            op_contract.hermes_contract_validate(
+                canonical,
+                hermes_root=tmp_path,
+            )
+        )
+    finally:
+        op_runners.register_backend(previous, replace=True)
+    after = {
+        path.relative_to(tmp_path): path.stat().st_mtime_ns
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert payload["verdict"] == "SATISFIED"
+    assert payload["satisfied"] is True
+    assert any(run.get("scope") == "fabric:node-a" for run in payload["evidence"]["run"])
+    # Contract validation may append its existing operator audit record, but it
+    # must not mutate either Fabric SQLite journal while merely observing proof.
+    for relative, mtime in before.items():
+        if relative.name in {"coord.db", "peer.db", "coord.db-wal", "peer.db-wal"}:
+            assert after.get(relative) == mtime
+
+
+def test_peer_policy_identity_and_node_binding_cannot_be_self_widened(tmp_path, monkeypatch):
+    alternate = policy(tmp_path)
+    envelope = fabric._build_envelope(
+        contract(tmp_path),
+        node(),
+        remote_backend="fake",
+        logical_workspace="repo",
+        remote_options={},
+        evidence_policy={"run_state": ("managed_peer_structured",)},
+        capability_sha="0" * 64,
+    )
+    envelope["target_node"] = "node-b"
+    svc = service(tmp_path, monkeypatch, policy_loader=lambda: alternate)
+    with pytest.raises(fabric.FabricError) as exc:
+        svc.handle(
+            accept_request(envelope),
+            "Bearer 0123456789abcdef0123456789abcdef",
+        )
+    assert exc.value.code == "FABRIC_NODE_IDENTITY_MISMATCH"

--- a/test_operator_fabric_control.py
+++ b/test_operator_fabric_control.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+
+import operator_fabric as fabric
+import operator_fabric_control as control
+
+
+class Policy:
+    level = "workspace"
+    apply_mode = "direct"
+
+    def require_level(self, _required):
+        return None
+
+    def require_mutation(self, _dry_run):
+        return None
+
+    def effective_dry_run(self, dry_run):
+        return bool(dry_run)
+
+
+class Coordinator:
+    def __init__(self):
+        self.calls = []
+
+    def poll(self, attempt_id, *, reconcile, timeout):
+        self.calls.append(("poll", attempt_id, reconcile, timeout))
+        return {
+            "success": True,
+            "backend": "fabric",
+            "node": "node-a",
+            "dispatch_id": "fabd-" + "1" * 32,
+            "attempt_id": attempt_id,
+            "task_id": "task-a",
+            "state": "TERMINAL_REPORTED",
+            "peer_state": "SUCCEEDED",
+        }
+
+    def collect(self, attempt_id, *, timeout):
+        self.calls.append(("collect", attempt_id, timeout))
+        return {
+            "success": True,
+            "backend": "fabric",
+            "node": "node-a",
+            "dispatch_id": "fabd-" + "1" * 32,
+            "attempt_id": attempt_id,
+            "state": "COMPLETED",
+            "evidence": {"schema": fabric.EVIDENCE_SCHEMA},
+        }
+
+    def cancel(self, attempt_id, *, timeout):
+        self.calls.append(("cancel", attempt_id, timeout))
+        return {
+            "success": True,
+            "changed": True,
+            "backend": "fabric",
+            "node": "node-a",
+            "dispatch_id": "fabd-" + "1" * 32,
+            "attempt_id": attempt_id,
+            "task_id": "task-a",
+            "state": "CANCELLED",
+        }
+
+
+def test_reconcile_emits_recovery_and_terminal_audit(monkeypatch):
+    monkeypatch.setattr(control.op, "OperatorPolicy", Policy)
+    coordinator = Coordinator()
+    audit = []
+    payload = json.loads(
+        control.hermes_fabric_status(
+            "faba-" + "a" * 32,
+            reconcile=True,
+            coordinator=coordinator,
+            audit=lambda **kwargs: audit.append(kwargs),
+        )
+    )
+    assert payload["state"] == "TERMINAL_REPORTED"
+    assert [entry["tool"] for entry in audit] == [
+        "hermes_fabric_reconcile",
+        "hermes_fabric_terminal",
+    ]
+    assert coordinator.calls == [("poll", "faba-" + "a" * 32, True, 15)]
+
+
+def test_evidence_receipt_emits_evidence_and_terminal_audit(monkeypatch):
+    monkeypatch.setattr(control.op, "OperatorPolicy", Policy)
+    coordinator = Coordinator()
+    audit = []
+    payload = json.loads(
+        control.hermes_fabric_evidence(
+            "faba-" + "b" * 32,
+            coordinator=coordinator,
+            audit=lambda **kwargs: audit.append(kwargs),
+        )
+    )
+    assert payload["state"] == "COMPLETED"
+    assert [entry["tool"] for entry in audit] == [
+        "hermes_fabric_evidence_receipt",
+        "hermes_fabric_terminal",
+    ]
+
+
+def test_cancel_is_dry_run_first_and_attempt_specific(monkeypatch):
+    monkeypatch.setattr(control.op, "OperatorPolicy", Policy)
+    coordinator = Coordinator()
+    audit = []
+    attempt = "faba-" + "c" * 32
+    plan = json.loads(
+        control.hermes_fabric_cancel(
+            attempt,
+            dry_run=True,
+            coordinator=coordinator,
+            audit=lambda **kwargs: audit.append(kwargs),
+        )
+    )
+    assert plan["dry_run"] is True
+    assert coordinator.calls == []
+
+    result = json.loads(
+        control.hermes_fabric_cancel(
+            attempt,
+            confirm=True,
+            dry_run=False,
+            coordinator=coordinator,
+            audit=lambda **kwargs: audit.append(kwargs),
+        )
+    )
+    assert result["state"] == "CANCELLED"
+    assert coordinator.calls == [("cancel", attempt, 15)]
+    assert audit[-2]["tool"] == "hermes_fabric_cancel"
+    assert audit[-1]["tool"] == "hermes_fabric_terminal"
+
+
+def test_invalid_attempt_id_fails_closed_without_coordinator_call(monkeypatch):
+    monkeypatch.setattr(control.op, "OperatorPolicy", Policy)
+    coordinator = Coordinator()
+    payload = json.loads(
+        control.hermes_fabric_status(
+            "not-an-attempt",
+            coordinator=coordinator,
+            audit=lambda **_kwargs: None,
+        )
+    )
+    assert payload["success"] is False
+    assert payload["code"] == "FABRIC_STATUS_ERROR"
+    assert coordinator.calls == []
+
+
+def test_fabric_error_code_is_preserved(monkeypatch):
+    monkeypatch.setattr(control.op, "OperatorPolicy", Policy)
+
+    class Broken(Coordinator):
+        def poll(self, attempt_id, *, reconcile, timeout):
+            raise fabric.FabricError("FABRIC_PEER_JOURNAL_MISSING", "peer journal missing")
+
+    payload = json.loads(
+        control.hermes_fabric_status(
+            "faba-" + "d" * 32,
+            reconcile=True,
+            coordinator=Broken(),
+            audit=lambda **_kwargs: None,
+        )
+    )
+    assert payload["success"] is False
+    assert payload["code"] == "FABRIC_PEER_JOURNAL_MISSING"


### PR DESCRIPTION
Implements Hermes GPT v0.8 Fabric G4-A (#32) from merged G3 security baseline `0dc34eb7068ed034ef2a47fc20a3ae61dcd1730e` while preserving frozen runtime evidence baseline `4bb85d1eb7abf0974077b63c131013613793bb72`.

## Scope

- additive `operator_fabric.py` core with deterministic managed A2A peer endpoint;
- registry-only node selection through configured Hermes A2A peers;
- unique coordinator-principal bearer authentication;
- HTTPS required for non-loopback verified Fabric;
- closed security schemas with duplicate-key rejection;
- durable coordinator and peer SQLite journals;
- deterministic dispatch/attempt identities and idempotent replay;
- timeout ambiguity without blind resubmit;
- peer-side authority/workspace/backend enforcement and immediate pre-start policy revalidation;
- conservative write conflict-domain claims that fail closed pending G4-C release/reconciliation semantics;
- bounded status/reconcile/cancel/evidence operations;
- exact evidence lineage and explicit run-state provenance;
- remote self-certification fields rejected;
- `FabricBackend` feeds coordinator-admitted remote run state into the existing runner observation path used by Work Contract validation;
- Work Contract validation remains observational and does not create/reconcile Fabric state;
- packaged `hermes-gpt-fabric-peer` daemon;
- packaged `operator_fabric_control` façade for explicit status/reconcile/evidence/cancel with policy gates and audit events for recovery, evidence receipt, cancellation, and terminal/blocked state;
- core backend registration during operator runtime bootstrap;
- expanded adversarial Fabric regression matrix in CI.

## Acceptance coverage

The G4-A suite covers read-only and authorized-write remote execution, unknown nodes, caller credential/network-target rejection, malformed/oversized payloads, protocol/feature mismatch, generic A2A text downgrade rejection, authority/profile widening, identity drift, exact replay and conflicting replay, timeout after peer acceptance, coordinator restart recovery with the same Fabric attempt, peer restart durable journal recovery, loss of A2A task mapping, wrong-lineage/self-certifying evidence, worker-statement provenance rejection, legacy Fleet bundle rejection, attempt-specific cancellation, and real integration through `hermes_contract_validate` using only pre-admitted Fabric evidence.

## Explicit non-scope

No automatic placement/router (#33), artifact byte transfer (#34), safe process-tree/container-unit write-claim release (#34), or Flight Deck UI (#35). G4-A deliberately does not auto-release write claims because G3-S04 requires stronger terminal proof owned by G4-C.

The packaged Fabric control façade is the G4-A internal/operator seam; wiring new dedicated Fabric buttons/read models into Flight Deck remains #35.

## G3 controls exercised here

G3-S01 unique principal auth, G3-S02 secure transport, G3-S03 conservative server-defined write conflict domains, G3-S06 pre-start policy revalidation, G3-S07 closed schemas, G3-S08 evidence provenance, and G3-S10 structured bounded audit lineage. G3-S04 terminal proof is deliberately fail-closed/deferred to #34 rather than weakened.

Merge only after exact current-head CI is green and no unresolved review blocker exists.