### PR TITLE
feat(v0.9): add first-class durable Missions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           operator_runners.py test_operator_runners.py
           runner_confinement.py test_runner_confinement.py test_runner_confinement_policy.py
           operator_export.py test_operator_export.py test_server_export.py
+          operator_mission_runtime.py test_operator_mission_runtime.py
           tools/check_package_hygiene.py test_package_hygiene.py
           ui_api.py ui_fabric.py
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ PyPI is an independent distribution channel. Check the PyPI badge in the root RE
 | [`openai-secure-mcp-tunnel.md`](openai-secure-mcp-tunnel.md) | current | outbound-only private access from supported OpenAI products to loopback Hermes GPT |
 | [`cloudflare-tunnel.md`](cloudflare-tunnel.md) | current | public Cloudflare HTTPS proxy deployment and Host allowlist behavior |
 | [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, v0.8 Fabric execution, and Flight Deck surfaces |
+| [`missions.md`](missions.md) | current | v0.9 first-class Mission lifecycle, bounded context/skills manifests, attachments, reconciliation, and Owner approval |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |
 | [`updating.md`](updating.md) | current | check-first Git and PyPI update behavior |

--- a/docs/missions.md
+++ b/docs/missions.md
@@ -14,7 +14,7 @@ A Mission can contain:
 - an explicit skills manifest;
 - attachments to Swarm workflows and delegation/run identifiers;
 - lifecycle state and audit history;
-- an optional final Owner approval requirement.
+- a final Owner approval requirement that defaults on; disabling it is an Owner-only creation-time decision and cannot be weakened later.
 
 The implementation lives in `operator_mission_runtime.py`. Existing `hermes_mission_*` Mission Control overview tools remain available and backward compatible; the new lifecycle tools are additional surfaces.
 
@@ -24,9 +24,9 @@ Mission states are durable and restart-safe. The normal progression is:
 
 `draft -> running -> awaiting_approval -> completed`
 
-A Mission can also be paused or blocked when attached execution state requires it. Reconciliation observes attached Swarm workflow state; it does not trust worker self-report as proof of completion.
+A Mission can also be paused or blocked when attached execution state requires it. Reconciliation observes attached Swarm workflow state and only accepts non-workflow success from lifecycle adapters that mark the attachment as verified with an evidence reference. Public attachment calls cannot assert `succeeded`.
 
-If `final_approval_required` is true, completion is Owner-gated. A Mission cannot bypass the existing Operator/Owner authority model.
+`final_approval_required` defaults to true and is immutable after creation. Creating a Mission with that boundary disabled requires Owner authority. Approval-required Missions enter `awaiting_approval` through reconciliation and can complete only through `hermes_mission_approve`. A Mission cannot bypass the existing Operator/Owner authority model.
 
 ## Tool surface
 
@@ -37,12 +37,11 @@ The v0.9 Mission lifecycle tools are:
 - `hermes_mission_list`
 - `hermes_mission_update`
 - `hermes_mission_attach`
-- `hermes_mission_start`
-- `hermes_mission_pause`
+- `hermes_mission_transition`
 - `hermes_mission_reconcile`
 - `hermes_mission_approve`
 
-Read operations are read-only. Mutating operations preserve Hermes GPT's normal workspace/direct/confirm gates, and final approval uses Owner authority when required.
+Read operations are read-only. Mutating operations preserve Hermes GPT's normal workspace/direct/confirm gates. Direct completion is Owner-gated, and approval-required Missions complete only through explicit Owner approval. Workflow references use the canonical `sw-*` identifier grammar and are confined to the durable workflow directory.
 
 ## Context and skills
 
@@ -60,4 +59,4 @@ Missions do not replace Work Contracts, Swarms, runners, or Fabric. They provide
 
 `Mission -> Swarm/work -> Work Contract -> runner/Fabric -> observed evidence -> Mission reconciliation`
 
-Completion remains based on coordinator-observed evidence and explicit approval boundaries, preserving the v0.8 Fabric safety model.
+Completion remains based on coordinator-observed evidence and explicit approval boundaries, preserving the v0.8 Fabric safety model. A terminal backend self-report is not sufficient: Mission-facing success must come from a verified lifecycle adapter, and unverified legacy success is reconciled fail-closed to `blocked`.

--- a/docs/missions.md
+++ b/docs/missions.md
@@ -1,0 +1,63 @@
+# Missions (v0.9)
+
+Hermes GPT v0.9 adds a first-class durable Mission object for grouping work, context, skills, workflows, delegated execution, evidence, and final approval under one bounded lifecycle.
+
+## What a Mission is
+
+A Mission is the durable parent record for a larger objective. It stores bounded metadata and references only; it is not a transcript or raw-source archive.
+
+A Mission can contain:
+
+- a title and objective;
+- acceptance criteria;
+- bounded context references with optional SHA-256 digests;
+- an explicit skills manifest;
+- attachments to Swarm workflows and delegation/run identifiers;
+- lifecycle state and audit history;
+- an optional final Owner approval requirement.
+
+The implementation lives in `operator_mission_runtime.py`. Existing `hermes_mission_*` Mission Control overview tools remain available and backward compatible; the new lifecycle tools are additional surfaces.
+
+## Lifecycle
+
+Mission states are durable and restart-safe. The normal progression is:
+
+`draft -> running -> awaiting_approval -> completed`
+
+A Mission can also be paused or blocked when attached execution state requires it. Reconciliation observes attached Swarm workflow state; it does not trust worker self-report as proof of completion.
+
+If `final_approval_required` is true, completion is Owner-gated. A Mission cannot bypass the existing Operator/Owner authority model.
+
+## Tool surface
+
+The v0.9 Mission lifecycle tools are:
+
+- `hermes_mission_create`
+- `hermes_mission_get`
+- `hermes_mission_list`
+- `hermes_mission_update`
+- `hermes_mission_attach`
+- `hermes_mission_start`
+- `hermes_mission_pause`
+- `hermes_mission_reconcile`
+- `hermes_mission_approve`
+
+Read operations are read-only. Mutating operations preserve Hermes GPT's normal workspace/direct/confirm gates, and final approval uses Owner authority when required.
+
+## Context and skills
+
+Mission context is represented as references rather than copied source bodies. References are bounded and may include a digest for immutable identification. Mission skill entries are explicit manifests containing a skill name and optional version/ref/digest metadata.
+
+This prevents Missions from becoming an unbounded prompt store and keeps sensitive raw content in the source system that owns it.
+
+## Persistence and audit
+
+Mission state is stored durably under the Hermes data root in a SQLite database. Mission lifecycle changes produce durable Mission events and Operator audit records. Reads do not create Mission state when no Mission database exists.
+
+## Relationship to Swarm and Fabric
+
+Missions do not replace Work Contracts, Swarms, runners, or Fabric. They provide the durable parent lifecycle above those existing execution and evidence layers:
+
+`Mission -> Swarm/work -> Work Contract -> runner/Fabric -> observed evidence -> Mission reconciliation`
+
+Completion remains based on coordinator-observed evidence and explicit approval boundaries, preserving the v0.8 Fabric safety model.

--- a/operator_mission_runtime.py
+++ b/operator_mission_runtime.py
@@ -27,13 +27,14 @@ from typing import Any
 
 import operator_policy as op
 
-SCHEMA_VERSION = "0.9-mission.1"
+SCHEMA_VERSION = "0.9-mission.2"
 MISSION_SPEC_SCHEMA = "hermes.mission-spec/v1"
 MISSION_SCHEMA = "hermes.mission/v1"
 MISSION_EVENT_SCHEMA = "hermes.mission-event/v1"
 
 MISSION_ID_RE = re.compile(r"^msn-[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+WORKFLOW_REF_RE = re.compile(r"^sw-[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 
 STATUSES = (
@@ -49,6 +50,13 @@ STATUSES = (
 TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
 ATTACHMENT_KINDS = {"workflow", "contract", "delegation", "evidence", "artifact"}
 ATTACHMENT_STATES = {"unknown", "pending", "running", "blocked", "succeeded", "failed", "cancelled"}
+MISSION_TRANSITIONS = {
+    "draft": {"running", "paused", "blocked", "failed", "cancelled"},
+    "running": {"paused", "blocked", "failed", "cancelled"},
+    "paused": {"running", "blocked", "failed", "cancelled"},
+    "blocked": {"running", "paused", "failed", "cancelled"},
+    "awaiting_approval": {"running", "blocked", "failed", "cancelled"},
+}
 
 MAX_TITLE = 200
 MAX_OBJECTIVE = 8_000
@@ -77,7 +85,6 @@ _ALLOWED_PATCH_KEYS = {
     "acceptance_criteria",
     "context_refs",
     "skills",
-    "final_approval_required",
 }
 _ALLOWED_CONTEXT_KEYS = {"kind", "ref", "label", "sha256"}
 _ALLOWED_SKILL_KEYS = {"name", "version", "ref", "sha256"}
@@ -136,6 +143,7 @@ def _init_db(db: sqlite3.Connection) -> None:
             relationship TEXT NOT NULL,
             state TEXT NOT NULL,
             evidence_ref TEXT NOT NULL DEFAULT '',
+            verified INTEGER NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
             PRIMARY KEY (mission_id, kind, ref),
@@ -157,7 +165,14 @@ def _init_db(db: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_events_mission ON mission_events(mission_id, seq);
         """
     )
+    columns = {str(row[1]) for row in db.execute("PRAGMA table_info(attachments)").fetchall()}
+    if "verified" not in columns:
+        db.execute("ALTER TABLE attachments ADD COLUMN verified INTEGER NOT NULL DEFAULT 0")
     db.commit()
+
+
+def _begin_write(db: sqlite3.Connection) -> None:
+    db.execute("BEGIN IMMEDIATE")
 
 
 def _closed(value: dict[str, Any], allowed: set[str], name: str) -> None:
@@ -276,7 +291,7 @@ def _row_to_mission(db: sqlite3.Connection, row: sqlite3.Row, *, include_events:
     attachments = [
         dict(r)
         for r in db.execute(
-            "SELECT kind,ref,relationship,state,evidence_ref,created_at,updated_at "
+            "SELECT kind,ref,relationship,state,evidence_ref,verified,created_at,updated_at "
             "FROM attachments WHERE mission_id=? ORDER BY kind,ref",
             (row["mission_id"],),
         ).fetchall()
@@ -370,6 +385,8 @@ def hermes_mission_create(
         if not isinstance(raw, dict):
             raise TypeError("mission_json must contain an object")
         spec = _normalize_spec(raw)
+        if not spec["final_approval_required"]:
+            policy.require_owner(dry_run)
         effective_dry = policy.effective_dry_run(dry_run)
         if not effective_dry and not confirm:
             raise PermissionError("direct mission creation requires confirm=true")
@@ -387,6 +404,7 @@ def hermes_mission_create(
             return json.dumps(plan)
         path = _db_path(hermes_root)
         with _connect(path, write=True) as db:
+            _begin_write(db)
             if db.execute("SELECT 1 FROM missions WHERE mission_id=?", (spec["mission_id"],)).fetchone():
                 raise ValueError("mission already exists")
             now = _now()
@@ -401,7 +419,6 @@ def hermes_mission_create(
     except (ValueError, TypeError, json.JSONDecodeError, PermissionError, OSError, sqlite3.Error) as exc:
         _audit("hermes_mission_create", policy, dry_run=dry_run, success=False, changed=False, summary="mission create rejected")
         return _error(exc, "MISSION_CREATE_REJECTED", "Check mission schema and Operator workspace/direct policy.")
-
 
 def hermes_mission_get(mission_id: str, hermes_root: Path | None = None) -> str:
     policy = op.OperatorPolicy()
@@ -457,28 +474,37 @@ def hermes_mission_update(
         if not effective_dry and not confirm:
             raise PermissionError("direct mission update requires confirm=true")
         path = _db_path(hermes_root)
-        with _connect(path, write=False) as db:
-            row = _get_row(db, mission_id)
+
+        def validate(row: sqlite3.Row, db: sqlite3.Connection) -> dict[str, Any]:
             if row["status"] in TERMINAL_STATUSES:
                 raise ValueError("terminal missions cannot be edited")
+            if any(key in patch for key in ("acceptance_criteria", "owner_profile")):
+                attached = db.execute("SELECT 1 FROM attachments WHERE mission_id=? LIMIT 1", (mission_id,)).fetchone()
+                if row["status"] != "draft" or attached:
+                    raise ValueError("acceptance criteria and owner_profile freeze once mission work is attached or started")
             old_spec = json.loads(row["spec_json"])
-        candidate = dict(old_spec)
-        candidate.update(patch)
-        candidate["mission_id"] = mission_id
-        spec = _normalize_spec(candidate, mission_id=mission_id)
+            candidate = dict(old_spec)
+            candidate.update(patch)
+            candidate["mission_id"] = mission_id
+            return _normalize_spec(candidate, mission_id=mission_id)
+
         if effective_dry:
-            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_update", "mission_id": mission_id, "changed": False, "dry_run": True})
+            with _connect(path, write=False) as db:
+                spec = validate(_get_row(db, mission_id), db)
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_update", "mission_id": mission_id, "changed": False, "dry_run": True, "spec": spec})
         with _connect(path, write=True) as db:
+            _begin_write(db)
             row = _get_row(db, mission_id)
+            spec = validate(row, db)
             version = int(row["version"]) + 1
-            db.execute("UPDATE missions SET spec_json=?,version=?,updated_at=? WHERE mission_id=?", (json.dumps(spec, sort_keys=True), version, _now(), mission_id))
+            now = _now()
+            db.execute("UPDATE missions SET spec_json=?,version=?,updated_at=? WHERE mission_id=?", (json.dumps(spec, sort_keys=True), version, now, mission_id))
             _event(db, mission_id, "mission.updated", details={"version": version, "fields": sorted(patch)})
             db.commit()
         _audit("hermes_mission_update", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary="mission updated")
         return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_update", "mission_id": mission_id, "version": version, "changed": True})
     except (ValueError, LookupError, TypeError, json.JSONDecodeError, PermissionError, OSError, sqlite3.Error) as exc:
         return _error(exc, "MISSION_UPDATE_REJECTED", "Check patch schema and mission lifecycle state.")
-
 
 def hermes_mission_attach(
     mission_id: str,
@@ -500,37 +526,48 @@ def hermes_mission_attach(
         ref = _bounded_text(ref, "attachment ref", 256, required=True)
         if not REF_RE.fullmatch(ref):
             raise ValueError("attachment ref contains unsupported characters")
+        if kind == "workflow" and not WORKFLOW_REF_RE.fullmatch(ref):
+            raise ValueError("workflow attachment ref must be a canonical workflow id")
         relationship = _bounded_text(relationship, "relationship", 64, required=True)
         if state not in ATTACHMENT_STATES:
             raise ValueError("attachment state is invalid")
+        if state == "succeeded":
+            raise PermissionError("public mission attachment cannot assert succeeded state")
         evidence_ref = _bounded_text(evidence_ref, "evidence_ref", 256)
         effective_dry = policy.effective_dry_run(dry_run)
         if not effective_dry and not confirm:
             raise PermissionError("direct mission attachment requires confirm=true")
         path = _db_path(hermes_root)
-        with _connect(path, write=False) as db:
-            _get_row(db, mission_id)
+
+        def validate(db: sqlite3.Connection) -> None:
+            mission_row = _get_row(db, mission_id)
+            if mission_row["status"] in TERMINAL_STATUSES:
+                raise ValueError("terminal missions cannot be modified")
             count = int(db.execute("SELECT COUNT(*) FROM attachments WHERE mission_id=?", (mission_id,)).fetchone()[0])
-            if count >= MAX_ATTACHMENTS and not db.execute("SELECT 1 FROM attachments WHERE mission_id=? AND kind=? AND ref=?", (mission_id, kind, ref)).fetchone():
+            exists = db.execute("SELECT 1 FROM attachments WHERE mission_id=? AND kind=? AND ref=?", (mission_id, kind, ref)).fetchone()
+            if count >= MAX_ATTACHMENTS and not exists:
                 raise ValueError("mission attachment cap reached")
+
         if effective_dry:
+            with _connect(path, write=False) as db:
+                validate(db)
             return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_attach", "mission_id": mission_id, "kind": kind, "ref": ref, "changed": False, "dry_run": True})
         now = _now()
         with _connect(path, write=True) as db:
-            _get_row(db, mission_id)
+            _begin_write(db)
+            validate(db)
             db.execute(
-                "INSERT INTO attachments(mission_id,kind,ref,relationship,state,evidence_ref,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?) "
-                "ON CONFLICT(mission_id,kind,ref) DO UPDATE SET relationship=excluded.relationship,state=excluded.state,evidence_ref=excluded.evidence_ref,updated_at=excluded.updated_at",
-                (mission_id, kind, ref, relationship, state, evidence_ref, now, now),
+                "INSERT INTO attachments(mission_id,kind,ref,relationship,state,evidence_ref,verified,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?) "
+                "ON CONFLICT(mission_id,kind,ref) DO UPDATE SET relationship=excluded.relationship,state=excluded.state,evidence_ref=excluded.evidence_ref,verified=0,updated_at=excluded.updated_at",
+                (mission_id, kind, ref, relationship, state, evidence_ref, 0, now, now),
             )
             db.execute("UPDATE missions SET version=version+1,updated_at=? WHERE mission_id=?", (now, mission_id))
             _event(db, mission_id, "mission.attachment", details={"kind": kind, "ref": ref, "relationship": relationship, "state": state})
             db.commit()
-        _audit("hermes_mission_attach", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary=f"attached {kind}")
+        _audit("hermes_mission_attach", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary="mission attachment updated")
         return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_attach", "mission_id": mission_id, "kind": kind, "ref": ref, "changed": True})
     except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
         return _error(exc, "MISSION_ATTACH_REJECTED", "Check attachment kind/ref, cap, and mutation policy.")
-
 
 def record_attachment_state(
     mission_id: str,
@@ -539,36 +576,42 @@ def record_attachment_state(
     state: str,
     *,
     evidence_ref: str = "",
+    verified: bool = False,
     hermes_root: Path | None = None,
 ) -> bool:
-    """Internal trusted bridge used by lifecycle adapters.
-
-    This helper deliberately does not bypass public authority: callers must have
-    already passed their own mutation gate.  It only updates an existing link.
-    """
+    """Internal lifecycle bridge; successful state requires verified evidence."""
     if kind not in ATTACHMENT_KINDS or state not in ATTACHMENT_STATES:
+        return False
+    if kind == "workflow" and not WORKFLOW_REF_RE.fullmatch(ref):
+        return False
+    evidence_ref = evidence_ref[:256]
+    if state == "succeeded" and (not verified or not evidence_ref):
         return False
     path = _db_path(hermes_root)
     if not path.is_file():
         return False
     try:
         with _connect(path, write=True) as db:
+            _begin_write(db)
             row = db.execute("SELECT 1 FROM attachments WHERE mission_id=? AND kind=? AND ref=?", (mission_id, kind, ref)).fetchone()
             if row is None:
                 return False
             now = _now()
-            db.execute("UPDATE attachments SET state=?,evidence_ref=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (state, evidence_ref[:256], now, mission_id, kind, ref))
-            db.execute("UPDATE missions SET updated_at=? WHERE mission_id=?", (now, mission_id))
-            _event(db, mission_id, "mission.attachment_state", details={"kind": kind, "ref": ref, "state": state})
+            verified_value = 1 if verified and state == "succeeded" else 0
+            db.execute("UPDATE attachments SET state=?,evidence_ref=?,verified=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (state, evidence_ref, verified_value, now, mission_id, kind, ref))
+            db.execute("UPDATE missions SET version=version+1,updated_at=? WHERE mission_id=?", (now, mission_id))
+            _event(db, mission_id, "mission.attachment_state", details={"kind": kind, "ref": ref, "state": state, "verified": bool(verified_value)})
             db.commit()
         return True
     except (OSError, sqlite3.Error):
         return False
 
-
 def _workflow_state(root: Path, ref: str) -> str:
-    path = root / "swarm-workflows" / f"{ref}.json"
-    if not path.is_file():
+    if not WORKFLOW_REF_RE.fullmatch(ref):
+        return "unknown"
+    base = (root / "swarm-workflows").resolve()
+    path = (base / f"{ref}.json").resolve()
+    if path.parent != base or not path.is_file():
         return "unknown"
     try:
         raw = json.loads(path.read_text(encoding="utf-8"))
@@ -582,6 +625,37 @@ def _workflow_state(root: Path, ref: str) -> str:
         "done": "succeeded",
     }.get(status, "unknown")
 
+
+def _observe_attachments(root: Path, mission: dict[str, Any]) -> list[dict[str, Any]]:
+    observed: list[dict[str, Any]] = []
+    for att in mission["attachments"]:
+        state = str(att["state"])
+        verified = bool(att.get("verified"))
+        if att["kind"] == "workflow":
+            state = _workflow_state(root, str(att["ref"]))
+            verified = state == "succeeded"
+        elif state == "succeeded" and not verified:
+            state = "blocked"
+        observed.append({"kind": att["kind"], "ref": att["ref"], "state": state, "verified": verified})
+    return observed
+
+
+def _desired_mission_status(mission: dict[str, Any], observed: list[dict[str, Any]]) -> str:
+    current = str(mission["status"])
+    if current in TERMINAL_STATUSES:
+        return current
+    states = {str(item["state"]) for item in observed}
+    if "failed" in states:
+        return "failed"
+    if "blocked" in states or "unknown" in states:
+        return "blocked"
+    if "running" in states or "pending" in states:
+        return "running"
+    if observed and states <= {"succeeded", "cancelled"} and "succeeded" in states:
+        if mission["final_approval_required"] and not mission["approval"].get("approved"):
+            return "awaiting_approval"
+        return "completed"
+    return current
 
 def hermes_mission_reconcile(
     mission_id: str,
@@ -598,44 +672,34 @@ def hermes_mission_reconcile(
             raise PermissionError("direct mission reconciliation requires confirm=true")
         path = _db_path(hermes_root)
         root = _root(hermes_root)
-        with _connect(path, write=False) as db:
-            row = _get_row(db, mission_id)
-            mission = _row_to_mission(db, row)
-        observed: list[dict[str, str]] = []
-        for att in mission["attachments"]:
-            state = att["state"]
-            if att["kind"] == "workflow":
-                state = _workflow_state(root, att["ref"])
-            observed.append({"kind": att["kind"], "ref": att["ref"], "state": state})
-        states = {item["state"] for item in observed}
-        current = mission["status"]
-        desired = current
-        if current not in TERMINAL_STATUSES:
-            if "failed" in states:
-                desired = "failed"
-            elif "blocked" in states:
-                desired = "blocked"
-            elif "running" in states or "pending" in states:
-                desired = "running"
-            elif observed and states <= {"succeeded", "cancelled"} and "succeeded" in states:
-                desired = "awaiting_approval" if mission["final_approval_required"] and not mission["approval"].get("approved") else "completed"
         if effective_dry:
-            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": current, "desired_status": desired, "observed": observed, "changed": False, "dry_run": True})
+            with _connect(path, write=False) as db:
+                mission = _row_to_mission(db, _get_row(db, mission_id))
+            observed = _observe_attachments(root, mission)
+            desired = _desired_mission_status(mission, observed)
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": mission["status"], "desired_status": desired, "observed": observed, "changed": False, "dry_run": True})
+
         with _connect(path, write=True) as db:
-            _get_row(db, mission_id)
-            for item in observed:
-                db.execute("UPDATE attachments SET state=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (item["state"], _now(), mission_id, item["kind"], item["ref"]))
-            if desired != current:
-                db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (desired, _now(), mission_id))
+            _begin_write(db)
+            mission = _row_to_mission(db, _get_row(db, mission_id))
+            current = str(mission["status"])
+            observed = _observe_attachments(root, mission)
+            desired = _desired_mission_status(mission, observed)
+            original = {(a["kind"], a["ref"]): (a["state"], bool(a.get("verified"))) for a in mission["attachments"]}
+            attachment_changed = any(original.get((item["kind"], item["ref"])) != (item["state"], bool(item["verified"])) for item in observed)
+            status_changed = desired != current
+            changed = attachment_changed or status_changed
+            if changed:
+                now = _now()
+                for item in observed:
+                    db.execute("UPDATE attachments SET state=?,verified=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (item["state"], 1 if item["verified"] else 0, now, mission_id, item["kind"], item["ref"]))
+                db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (desired, now, mission_id))
                 _event(db, mission_id, "mission.reconciled", from_status=current, to_status=desired, details={"observed": observed})
-            else:
-                _event(db, mission_id, "mission.reconciled", from_status=current, to_status=current, details={"observed": observed})
             db.commit()
-        _audit("hermes_mission_reconcile", policy, dry_run=False, success=True, changed=desired != current, mission_id=mission_id, summary=f"mission reconciled {current}->{desired}")
-        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": desired, "observed": observed, "changed": desired != current})
+        _audit("hermes_mission_reconcile", policy, dry_run=False, success=True, changed=changed, mission_id=mission_id, summary=f"mission reconciled {current}->{desired}")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": desired, "observed": observed, "changed": changed})
     except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
         return _error(exc, "MISSION_RECONCILE_FAILED", "Check mission attachments and lifecycle state.")
-
 
 def hermes_mission_transition(
     mission_id: str,
@@ -653,30 +717,49 @@ def hermes_mission_transition(
         policy.require_mutation(dry_run)
         reason = _bounded_text(reason, "reason", 1000)
         effective_dry = policy.effective_dry_run(dry_run)
+        if status == "completed":
+            policy.require_owner(dry_run)
+        if status == "awaiting_approval":
+            raise ValueError("awaiting_approval is entered only by reconciliation")
         if not effective_dry and not confirm:
             raise PermissionError("direct mission transition requires confirm=true")
         path = _db_path(hermes_root)
-        with _connect(path, write=False) as db:
-            row = _get_row(db, mission_id)
-            mission = _row_to_mission(db, row)
-        current = mission["status"]
-        if current in TERMINAL_STATUSES:
-            raise ValueError("terminal mission status cannot transition")
-        if status == "completed" and mission["final_approval_required"]:
-            policy.require_owner(dry_run)
-            if not mission["approval"].get("approved") and not effective_dry:
-                raise PermissionError("mission requires explicit Owner approval before completion")
+
+        def validate(mission: dict[str, Any]) -> tuple[str, bool]:
+            current = str(mission["status"])
+            if current in TERMINAL_STATUSES:
+                raise ValueError("terminal mission status cannot transition")
+            if status == current:
+                return current, False
+            allowed = MISSION_TRANSITIONS.get(current, set())
+            if status != "completed" and status not in allowed:
+                raise ValueError(f"mission transition {current}->{status} is not allowed")
+            if status == "completed":
+                if mission["final_approval_required"]:
+                    raise PermissionError("approval-required missions complete only through hermes_mission_approve")
+                observed = _observe_attachments(_root(hermes_root), mission)
+                if _desired_mission_status(mission, observed) != "completed":
+                    raise ValueError("mission children do not justify completion")
+            return current, True
+
         if effective_dry:
-            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": False, "dry_run": True})
+            with _connect(path, write=False) as db:
+                mission = _row_to_mission(db, _get_row(db, mission_id))
+            current, would_change = validate(mission)
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": False, "would_change": would_change, "dry_run": True})
         with _connect(path, write=True) as db:
-            db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (status, _now(), mission_id))
-            _event(db, mission_id, "mission.transition", from_status=current, to_status=status, reason=reason)
+            _begin_write(db)
+            mission = _row_to_mission(db, _get_row(db, mission_id))
+            current, changed = validate(mission)
+            if changed:
+                now = _now()
+                db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (status, now, mission_id))
+                _event(db, mission_id, "mission.transition", from_status=current, to_status=status, reason=reason)
             db.commit()
-        _audit("hermes_mission_transition", policy, dry_run=False, success=True, changed=current != status, mission_id=mission_id, summary=f"mission {current}->{status}")
-        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": current != status})
+        _audit("hermes_mission_transition", policy, dry_run=False, success=True, changed=changed, mission_id=mission_id, summary=f"mission {current}->{status}")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": changed})
     except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
         return _error(exc, "MISSION_TRANSITION_REJECTED", "Check mission lifecycle and Owner approval requirements.")
-
 
 def hermes_mission_approve(
     mission_id: str,
@@ -693,24 +776,33 @@ def hermes_mission_approve(
         if not effective_dry and not confirm:
             raise PermissionError("direct mission approval requires confirm=true")
         path = _db_path(hermes_root)
-        with _connect(path, write=False) as db:
-            row = _get_row(db, mission_id)
-            mission = _row_to_mission(db, row)
-        if mission["status"] in TERMINAL_STATUSES:
-            raise ValueError("terminal mission cannot be approved")
-        nonterminal_children = [a for a in mission["attachments"] if a["state"] in {"unknown", "pending", "running", "blocked"}]
-        if nonterminal_children:
-            raise ValueError("mission has nonterminal child attachments; reconcile them before approval")
+
+        def validate(mission: dict[str, Any]) -> None:
+            if mission["status"] != "awaiting_approval":
+                raise ValueError("mission must be awaiting_approval before Owner approval")
+            attachments = mission["attachments"]
+            succeeded = [a for a in attachments if a["state"] == "succeeded" and bool(a.get("verified"))]
+            invalid = [a for a in attachments if a["state"] not in {"succeeded", "cancelled"} or (a["state"] == "succeeded" and not bool(a.get("verified")))]
+            if invalid or not succeeded:
+                raise ValueError("mission children are not all terminal with at least one verified success")
+
         approval = {"approved": True, "approved_by": "owner", "approval_reference": approval_reference, "approved_at": _now()}
         target = "completed"
         if effective_dry:
+            with _connect(path, write=False) as db:
+                mission = _row_to_mission(db, _get_row(db, mission_id))
+            validate(mission)
             return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_approve", "mission_id": mission_id, "status": target, "approval": approval, "changed": False, "dry_run": True})
         with _connect(path, write=True) as db:
-            current = _get_row(db, mission_id)["status"]
-            db.execute("UPDATE missions SET status=?,approval_json=?,version=version+1,updated_at=? WHERE mission_id=?", (target, json.dumps(approval, sort_keys=True), _now(), mission_id))
+            _begin_write(db)
+            mission = _row_to_mission(db, _get_row(db, mission_id))
+            validate(mission)
+            current = str(mission["status"])
+            now = _now()
+            db.execute("UPDATE missions SET status=?,approval_json=?,version=version+1,updated_at=? WHERE mission_id=?", (target, json.dumps(approval, sort_keys=True), now, mission_id))
             _event(db, mission_id, "mission.approved", from_status=current, to_status=target, details={"approval_reference": approval_reference})
             db.commit()
         _audit("hermes_mission_approve", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary="mission Owner-approved")
         return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_approve", "mission_id": mission_id, "status": target, "approval": approval, "changed": True})
     except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
-        return _error(exc, "MISSION_APPROVAL_REJECTED", "Reconcile child work and use Owner direct mode with confirm=true.")
+        return _error(exc, "MISSION_APPROVAL_REJECTED", "Reconcile verified child work and use Owner direct mode with confirm=true.")

--- a/operator_mission_runtime.py
+++ b/operator_mission_runtime.py
@@ -1,0 +1,716 @@
+"""First-class durable Mission runtime for Hermes GPT v0.9.
+
+A Mission is the durable parent object for coordinated work.  It does not
+replace Work Contracts, Swarms, Fabric, or delegation runners; it binds those
+objects together under one bounded lifecycle while preserving their existing
+authority/evidence semantics.
+
+Security properties:
+- reads require Operator read_only; mutations require workspace + direct + confirm;
+- final approval is Owner-gated when ``final_approval_required`` is true;
+- context is reference-only and bounded (no fetched source bodies are persisted);
+- skills are explicit bounded manifests;
+- child evidence is referenced, never copied;
+- restart reconciliation is fail-closed and never fabricates child success.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import operator_policy as op
+
+SCHEMA_VERSION = "0.9-mission.1"
+MISSION_SPEC_SCHEMA = "hermes.mission-spec/v1"
+MISSION_SCHEMA = "hermes.mission/v1"
+MISSION_EVENT_SCHEMA = "hermes.mission-event/v1"
+
+MISSION_ID_RE = re.compile(r"^msn-[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+-]{0,255}$")
+SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+
+STATUSES = (
+    "draft",
+    "running",
+    "paused",
+    "blocked",
+    "awaiting_approval",
+    "completed",
+    "failed",
+    "cancelled",
+)
+TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+ATTACHMENT_KINDS = {"workflow", "contract", "delegation", "evidence", "artifact"}
+ATTACHMENT_STATES = {"unknown", "pending", "running", "blocked", "succeeded", "failed", "cancelled"}
+
+MAX_TITLE = 200
+MAX_OBJECTIVE = 8_000
+MAX_ACCEPTANCE = 32
+MAX_ACCEPTANCE_ITEM = 500
+MAX_CONTEXT = 64
+MAX_SKILLS = 64
+MAX_ATTACHMENTS = 512
+MAX_LIST = 200
+
+_ALLOWED_SPEC_KEYS = {
+    "schema",
+    "mission_id",
+    "title",
+    "objective",
+    "owner_profile",
+    "acceptance_criteria",
+    "context_refs",
+    "skills",
+    "final_approval_required",
+}
+_ALLOWED_PATCH_KEYS = {
+    "title",
+    "objective",
+    "owner_profile",
+    "acceptance_criteria",
+    "context_refs",
+    "skills",
+    "final_approval_required",
+}
+_ALLOWED_CONTEXT_KEYS = {"kind", "ref", "label", "sha256"}
+_ALLOWED_SKILL_KEYS = {"name", "version", "ref", "sha256"}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _root(hermes_root: Path | None) -> Path:
+    if hermes_root is not None:
+        return Path(hermes_root)
+    env_home = os.environ.get("HERMES_HOME")
+    if env_home:
+        normalized = op.normalize_hermes_data_root(Path(env_home).expanduser())
+        if normalized is not None:
+            return normalized
+    return Path.home() / ".hermes"
+
+
+def _db_path(hermes_root: Path | None) -> Path:
+    return _root(hermes_root) / "missions" / "missions.db"
+
+
+def _connect(path: Path, *, write: bool) -> sqlite3.Connection:
+    if write:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        db = sqlite3.connect(path)
+        _init_db(db)
+    else:
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        db = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA foreign_keys=ON")
+    return db
+
+
+def _init_db(db: sqlite3.Connection) -> None:
+    db.executescript(
+        """
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE IF NOT EXISTS missions (
+            mission_id TEXT PRIMARY KEY,
+            spec_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            approval_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS attachments (
+            mission_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            ref TEXT NOT NULL,
+            relationship TEXT NOT NULL,
+            state TEXT NOT NULL,
+            evidence_ref TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (mission_id, kind, ref),
+            FOREIGN KEY (mission_id) REFERENCES missions(mission_id) ON DELETE CASCADE
+        );
+        CREATE TABLE IF NOT EXISTS mission_events (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            from_status TEXT NOT NULL DEFAULT '',
+            to_status TEXT NOT NULL DEFAULT '',
+            reason_sha256 TEXT NOT NULL DEFAULT '',
+            details_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            FOREIGN KEY (mission_id) REFERENCES missions(mission_id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_missions_status ON missions(status, updated_at);
+        CREATE INDEX IF NOT EXISTS idx_attachments_mission ON attachments(mission_id, kind, state);
+        CREATE INDEX IF NOT EXISTS idx_events_mission ON mission_events(mission_id, seq);
+        """
+    )
+    db.commit()
+
+
+def _closed(value: dict[str, Any], allowed: set[str], name: str) -> None:
+    unknown = set(value) - allowed
+    if unknown:
+        raise ValueError(f"{name} contains unknown fields: {', '.join(sorted(unknown))}")
+
+
+def _bounded_text(value: Any, field: str, maximum: int, *, required: bool = False) -> str:
+    if value is None:
+        value = ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    value = value.strip()
+    if required and not value:
+        raise ValueError(f"{field} is required")
+    if len(value) > maximum:
+        raise ValueError(f"{field} exceeds {maximum} characters")
+    return value
+
+
+def _normalize_acceptance(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or len(raw) > MAX_ACCEPTANCE:
+        raise ValueError(f"acceptance_criteria must be a list with at most {MAX_ACCEPTANCE} items")
+    return [_bounded_text(v, "acceptance_criteria item", MAX_ACCEPTANCE_ITEM, required=True) for v in raw]
+
+
+def _normalize_context(raw: Any) -> list[dict[str, str]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or len(raw) > MAX_CONTEXT:
+        raise ValueError(f"context_refs must be a list with at most {MAX_CONTEXT} items")
+    out: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("context_refs items must be objects")
+        _closed(item, _ALLOWED_CONTEXT_KEYS, "context ref")
+        kind = _bounded_text(item.get("kind"), "context kind", 64, required=True)
+        ref = _bounded_text(item.get("ref"), "context ref", 256, required=True)
+        if not REF_RE.fullmatch(ref):
+            raise ValueError("context ref contains unsupported characters")
+        normalized = {"kind": kind, "ref": ref}
+        label = _bounded_text(item.get("label"), "context label", 160)
+        if label:
+            normalized["label"] = label
+        sha = _bounded_text(item.get("sha256"), "context sha256", 64)
+        if sha:
+            if not SHA_RE.fullmatch(sha):
+                raise ValueError("context sha256 must be lowercase SHA-256")
+            normalized["sha256"] = sha
+        out.append(normalized)
+    return out
+
+
+def _normalize_skills(raw: Any) -> list[dict[str, str]]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or len(raw) > MAX_SKILLS:
+        raise ValueError(f"skills must be a list with at most {MAX_SKILLS} items")
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("skills items must be objects")
+        _closed(item, _ALLOWED_SKILL_KEYS, "skill")
+        name = _bounded_text(item.get("name"), "skill name", 128, required=True)
+        if name in seen:
+            raise ValueError(f"duplicate skill {name!r}")
+        seen.add(name)
+        normalized = {"name": name}
+        for key, limit in (("version", 64), ("ref", 256), ("sha256", 64)):
+            value = _bounded_text(item.get(key), f"skill {key}", limit)
+            if value:
+                if key == "ref" and not REF_RE.fullmatch(value):
+                    raise ValueError("skill ref contains unsupported characters")
+                if key == "sha256" and not SHA_RE.fullmatch(value):
+                    raise ValueError("skill sha256 must be lowercase SHA-256")
+                normalized[key] = value
+        out.append(normalized)
+    return out
+
+
+def _normalize_spec(raw: dict[str, Any], *, mission_id: str | None = None) -> dict[str, Any]:
+    _closed(raw, _ALLOWED_SPEC_KEYS, "mission spec")
+    schema = raw.get("schema", MISSION_SPEC_SCHEMA)
+    if schema != MISSION_SPEC_SCHEMA:
+        raise ValueError(f"mission spec schema must be {MISSION_SPEC_SCHEMA!r}")
+    mid = mission_id or _bounded_text(raw.get("mission_id"), "mission_id", 68)
+    if not mid:
+        digest = hashlib.sha256(
+            (str(raw.get("title") or "") + "\0" + str(raw.get("objective") or "") + "\0" + _now()).encode()
+        ).hexdigest()[:20]
+        mid = f"msn-{digest}"
+    if not MISSION_ID_RE.fullmatch(mid):
+        raise ValueError("mission_id is invalid")
+    final_approval = raw.get("final_approval_required", True)
+    if not isinstance(final_approval, bool):
+        raise ValueError("final_approval_required must be boolean")
+    return {
+        "schema": MISSION_SPEC_SCHEMA,
+        "mission_id": mid,
+        "title": _bounded_text(raw.get("title"), "title", MAX_TITLE, required=True),
+        "objective": _bounded_text(raw.get("objective"), "objective", MAX_OBJECTIVE, required=True),
+        "owner_profile": _bounded_text(raw.get("owner_profile") or "default", "owner_profile", 128, required=True),
+        "acceptance_criteria": _normalize_acceptance(raw.get("acceptance_criteria")),
+        "context_refs": _normalize_context(raw.get("context_refs")),
+        "skills": _normalize_skills(raw.get("skills")),
+        "final_approval_required": final_approval,
+    }
+
+
+def _row_to_mission(db: sqlite3.Connection, row: sqlite3.Row, *, include_events: bool = False) -> dict[str, Any]:
+    spec = json.loads(row["spec_json"])
+    attachments = [
+        dict(r)
+        for r in db.execute(
+            "SELECT kind,ref,relationship,state,evidence_ref,created_at,updated_at "
+            "FROM attachments WHERE mission_id=? ORDER BY kind,ref",
+            (row["mission_id"],),
+        ).fetchall()
+    ]
+    approval = json.loads(row["approval_json"] or "{}")
+    value: dict[str, Any] = {
+        "schema": MISSION_SCHEMA,
+        "schema_version": SCHEMA_VERSION,
+        **spec,
+        "status": row["status"],
+        "version": int(row["version"]),
+        "approval": approval,
+        "attachments": attachments,
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+    }
+    if include_events:
+        value["events"] = [
+            {
+                "schema": MISSION_EVENT_SCHEMA,
+                **dict(r),
+                "details": json.loads(r["details_json"] or "{}"),
+            }
+            for r in db.execute(
+                "SELECT seq,event_type,from_status,to_status,reason_sha256,details_json,created_at "
+                "FROM mission_events WHERE mission_id=? ORDER BY seq DESC LIMIT 200",
+                (row["mission_id"],),
+            ).fetchall()
+        ]
+    return value
+
+
+def _get_row(db: sqlite3.Connection, mission_id: str) -> sqlite3.Row:
+    if not MISSION_ID_RE.fullmatch(mission_id):
+        raise ValueError("mission_id is invalid")
+    row = db.execute("SELECT * FROM missions WHERE mission_id=?", (mission_id,)).fetchone()
+    if row is None:
+        raise LookupError(f"mission {mission_id!r} not found")
+    return row
+
+
+def _event(
+    db: sqlite3.Connection,
+    mission_id: str,
+    event_type: str,
+    *,
+    from_status: str = "",
+    to_status: str = "",
+    reason: str = "",
+    details: dict[str, Any] | None = None,
+) -> None:
+    reason_sha = hashlib.sha256(reason.encode()).hexdigest() if reason else ""
+    db.execute(
+        "INSERT INTO mission_events(mission_id,event_type,from_status,to_status,reason_sha256,details_json,created_at) "
+        "VALUES(?,?,?,?,?,?,?)",
+        (mission_id, event_type, from_status, to_status, reason_sha, json.dumps(details or {}, sort_keys=True), _now()),
+    )
+
+
+def _audit(tool: str, policy: op.OperatorPolicy, *, dry_run: bool, success: bool, changed: bool, mission_id: str = "", summary: str = "") -> None:
+    try:
+        op.audit_record(
+            tool=tool,
+            level=policy.level,
+            apply_mode=policy.apply_mode,
+            dry_run=dry_run,
+            success=success,
+            changed=changed,
+            summary=summary,
+            extra={"mission_id": mission_id},
+        )
+    except Exception:
+        pass
+
+
+def _error(exc: Exception, code: str, action: str) -> str:
+    return json.dumps(op.error_from_exception(exc, layer="operator", code=code, suggested_action=action))
+
+
+def hermes_mission_create(
+    mission_json: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        raw = json.loads(mission_json)
+        if not isinstance(raw, dict):
+            raise ValueError("mission_json must contain an object")
+        spec = _normalize_spec(raw)
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission creation requires confirm=true")
+        plan = {
+            "success": True,
+            "schema_version": SCHEMA_VERSION,
+            "tool": "hermes_mission_create",
+            "mission_id": spec["mission_id"],
+            "status": "draft",
+            "changed": not effective_dry,
+            "dry_run": effective_dry,
+        }
+        if effective_dry:
+            _audit("hermes_mission_create", policy, dry_run=True, success=True, changed=False, mission_id=spec["mission_id"], summary="mission create planned")
+            return json.dumps(plan)
+        path = _db_path(hermes_root)
+        with _connect(path, write=True) as db:
+            if db.execute("SELECT 1 FROM missions WHERE mission_id=?", (spec["mission_id"],)).fetchone():
+                raise ValueError("mission already exists")
+            now = _now()
+            db.execute(
+                "INSERT INTO missions(mission_id,spec_json,status,version,approval_json,created_at,updated_at) VALUES(?,?,?,?,?,?,?)",
+                (spec["mission_id"], json.dumps(spec, sort_keys=True), "draft", 1, "{}", now, now),
+            )
+            _event(db, spec["mission_id"], "mission.created", to_status="draft")
+            db.commit()
+        _audit("hermes_mission_create", policy, dry_run=False, success=True, changed=True, mission_id=spec["mission_id"], summary="mission created")
+        return json.dumps(plan)
+    except (ValueError, TypeError, json.JSONDecodeError, PermissionError, OSError, sqlite3.Error) as exc:
+        _audit("hermes_mission_create", policy, dry_run=dry_run, success=False, changed=False, summary="mission create rejected")
+        return _error(exc, "MISSION_CREATE_REJECTED", "Check mission schema and Operator workspace/direct policy.")
+
+
+def hermes_mission_get(mission_id: str, hermes_root: Path | None = None) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("read_only")
+        with _connect(_db_path(hermes_root), write=False) as db:
+            value = _row_to_mission(db, _get_row(db, mission_id), include_events=True)
+        _audit("hermes_mission_get", policy, dry_run=True, success=True, changed=False, mission_id=mission_id, summary="mission read")
+        return json.dumps({"success": True, **value})
+    except FileNotFoundError:
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "mission_id": mission_id, "found": False})
+    except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_READ_FAILED", "Check mission id and Operator read access.")
+
+
+def hermes_mission_list(status: str = "", limit: int = 50, hermes_root: Path | None = None) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("read_only")
+        if status and status not in STATUSES:
+            raise ValueError("status filter is invalid")
+        limit = max(1, min(int(limit), MAX_LIST))
+        path = _db_path(hermes_root)
+        if not path.is_file():
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "missions": [], "count": 0})
+        with _connect(path, write=False) as db:
+            if status:
+                rows = db.execute("SELECT * FROM missions WHERE status=? ORDER BY updated_at DESC LIMIT ?", (status, limit)).fetchall()
+            else:
+                rows = db.execute("SELECT * FROM missions ORDER BY updated_at DESC LIMIT ?", (limit,)).fetchall()
+            missions = [_row_to_mission(db, row) for row in rows]
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "missions": missions, "count": len(missions)})
+    except (ValueError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_LIST_FAILED", "Check status/limit and Operator read access.")
+
+
+def hermes_mission_update(
+    mission_id: str,
+    patch_json: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        patch = json.loads(patch_json)
+        if not isinstance(patch, dict):
+            raise ValueError("patch_json must contain an object")
+        _closed(patch, _ALLOWED_PATCH_KEYS, "mission patch")
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission update requires confirm=true")
+        path = _db_path(hermes_root)
+        with _connect(path, write=False) as db:
+            row = _get_row(db, mission_id)
+            if row["status"] in TERMINAL_STATUSES:
+                raise ValueError("terminal missions cannot be edited")
+            old_spec = json.loads(row["spec_json"])
+        candidate = dict(old_spec)
+        candidate.update(patch)
+        candidate["mission_id"] = mission_id
+        spec = _normalize_spec(candidate, mission_id=mission_id)
+        if effective_dry:
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_update", "mission_id": mission_id, "changed": False, "dry_run": True})
+        with _connect(path, write=True) as db:
+            row = _get_row(db, mission_id)
+            version = int(row["version"]) + 1
+            db.execute("UPDATE missions SET spec_json=?,version=?,updated_at=? WHERE mission_id=?", (json.dumps(spec, sort_keys=True), version, _now(), mission_id))
+            _event(db, mission_id, "mission.updated", details={"version": version, "fields": sorted(patch)})
+            db.commit()
+        _audit("hermes_mission_update", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary="mission updated")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_update", "mission_id": mission_id, "version": version, "changed": True})
+    except (ValueError, LookupError, TypeError, json.JSONDecodeError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_UPDATE_REJECTED", "Check patch schema and mission lifecycle state.")
+
+
+def hermes_mission_attach(
+    mission_id: str,
+    kind: str,
+    ref: str,
+    relationship: str = "contains",
+    state: str = "unknown",
+    evidence_ref: str = "",
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        if kind not in ATTACHMENT_KINDS:
+            raise ValueError("attachment kind is invalid")
+        ref = _bounded_text(ref, "attachment ref", 256, required=True)
+        if not REF_RE.fullmatch(ref):
+            raise ValueError("attachment ref contains unsupported characters")
+        relationship = _bounded_text(relationship, "relationship", 64, required=True)
+        if state not in ATTACHMENT_STATES:
+            raise ValueError("attachment state is invalid")
+        evidence_ref = _bounded_text(evidence_ref, "evidence_ref", 256)
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission attachment requires confirm=true")
+        path = _db_path(hermes_root)
+        with _connect(path, write=False) as db:
+            _get_row(db, mission_id)
+            count = int(db.execute("SELECT COUNT(*) FROM attachments WHERE mission_id=?", (mission_id,)).fetchone()[0])
+            if count >= MAX_ATTACHMENTS and not db.execute("SELECT 1 FROM attachments WHERE mission_id=? AND kind=? AND ref=?", (mission_id, kind, ref)).fetchone():
+                raise ValueError("mission attachment cap reached")
+        if effective_dry:
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_attach", "mission_id": mission_id, "kind": kind, "ref": ref, "changed": False, "dry_run": True})
+        now = _now()
+        with _connect(path, write=True) as db:
+            _get_row(db, mission_id)
+            db.execute(
+                "INSERT INTO attachments(mission_id,kind,ref,relationship,state,evidence_ref,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?) "
+                "ON CONFLICT(mission_id,kind,ref) DO UPDATE SET relationship=excluded.relationship,state=excluded.state,evidence_ref=excluded.evidence_ref,updated_at=excluded.updated_at",
+                (mission_id, kind, ref, relationship, state, evidence_ref, now, now),
+            )
+            db.execute("UPDATE missions SET version=version+1,updated_at=? WHERE mission_id=?", (now, mission_id))
+            _event(db, mission_id, "mission.attachment", details={"kind": kind, "ref": ref, "relationship": relationship, "state": state})
+            db.commit()
+        _audit("hermes_mission_attach", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary=f"attached {kind}")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_attach", "mission_id": mission_id, "kind": kind, "ref": ref, "changed": True})
+    except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_ATTACH_REJECTED", "Check attachment kind/ref, cap, and mutation policy.")
+
+
+def record_attachment_state(
+    mission_id: str,
+    kind: str,
+    ref: str,
+    state: str,
+    *,
+    evidence_ref: str = "",
+    hermes_root: Path | None = None,
+) -> bool:
+    """Internal trusted bridge used by lifecycle adapters.
+
+    This helper deliberately does not bypass public authority: callers must have
+    already passed their own mutation gate.  It only updates an existing link.
+    """
+    if kind not in ATTACHMENT_KINDS or state not in ATTACHMENT_STATES:
+        return False
+    path = _db_path(hermes_root)
+    if not path.is_file():
+        return False
+    try:
+        with _connect(path, write=True) as db:
+            row = db.execute("SELECT 1 FROM attachments WHERE mission_id=? AND kind=? AND ref=?", (mission_id, kind, ref)).fetchone()
+            if row is None:
+                return False
+            now = _now()
+            db.execute("UPDATE attachments SET state=?,evidence_ref=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (state, evidence_ref[:256], now, mission_id, kind, ref))
+            db.execute("UPDATE missions SET updated_at=? WHERE mission_id=?", (now, mission_id))
+            _event(db, mission_id, "mission.attachment_state", details={"kind": kind, "ref": ref, "state": state})
+            db.commit()
+        return True
+    except (OSError, sqlite3.Error):
+        return False
+
+
+def _workflow_state(root: Path, ref: str) -> str:
+    path = root / "swarm-workflows" / f"{ref}.json"
+    if not path.is_file():
+        return "unknown"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return "unknown"
+    status = raw.get("status")
+    return {
+        "running": "running",
+        "blocked": "blocked",
+        "awaiting_approval": "blocked",
+        "done": "succeeded",
+    }.get(status, "unknown")
+
+
+def hermes_mission_reconcile(
+    mission_id: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission reconciliation requires confirm=true")
+        path = _db_path(hermes_root)
+        root = _root(hermes_root)
+        with _connect(path, write=False) as db:
+            row = _get_row(db, mission_id)
+            mission = _row_to_mission(db, row)
+        observed: list[dict[str, str]] = []
+        for att in mission["attachments"]:
+            state = att["state"]
+            if att["kind"] == "workflow":
+                state = _workflow_state(root, att["ref"])
+            observed.append({"kind": att["kind"], "ref": att["ref"], "state": state})
+        states = {item["state"] for item in observed}
+        current = mission["status"]
+        desired = current
+        if current not in TERMINAL_STATUSES:
+            if "failed" in states:
+                desired = "failed"
+            elif "blocked" in states:
+                desired = "blocked"
+            elif "running" in states or "pending" in states:
+                desired = "running"
+            elif observed and states <= {"succeeded", "cancelled"} and "succeeded" in states:
+                desired = "awaiting_approval" if mission["final_approval_required"] and not mission["approval"].get("approved") else "completed"
+        if effective_dry:
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": current, "desired_status": desired, "observed": observed, "changed": False, "dry_run": True})
+        with _connect(path, write=True) as db:
+            _get_row(db, mission_id)
+            for item in observed:
+                db.execute("UPDATE attachments SET state=?,updated_at=? WHERE mission_id=? AND kind=? AND ref=?", (item["state"], _now(), mission_id, item["kind"], item["ref"]))
+            if desired != current:
+                db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (desired, _now(), mission_id))
+                _event(db, mission_id, "mission.reconciled", from_status=current, to_status=desired, details={"observed": observed})
+            else:
+                _event(db, mission_id, "mission.reconciled", from_status=current, to_status=current, details={"observed": observed})
+            db.commit()
+        _audit("hermes_mission_reconcile", policy, dry_run=False, success=True, changed=desired != current, mission_id=mission_id, summary=f"mission reconciled {current}->{desired}")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_reconcile", "mission_id": mission_id, "status": desired, "observed": observed, "changed": desired != current})
+    except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_RECONCILE_FAILED", "Check mission attachments and lifecycle state.")
+
+
+def hermes_mission_transition(
+    mission_id: str,
+    status: str,
+    reason: str = "",
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        if status not in STATUSES:
+            raise ValueError("target mission status is invalid")
+        policy.require_level("workspace")
+        policy.require_mutation(dry_run)
+        reason = _bounded_text(reason, "reason", 1000)
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission transition requires confirm=true")
+        path = _db_path(hermes_root)
+        with _connect(path, write=False) as db:
+            row = _get_row(db, mission_id)
+            mission = _row_to_mission(db, row)
+        current = mission["status"]
+        if current in TERMINAL_STATUSES:
+            raise ValueError("terminal mission status cannot transition")
+        if status == "completed" and mission["final_approval_required"]:
+            policy.require_owner(dry_run)
+            if not mission["approval"].get("approved") and not effective_dry:
+                raise PermissionError("mission requires explicit Owner approval before completion")
+        if effective_dry:
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": False, "dry_run": True})
+        with _connect(path, write=True) as db:
+            db.execute("UPDATE missions SET status=?,version=version+1,updated_at=? WHERE mission_id=?", (status, _now(), mission_id))
+            _event(db, mission_id, "mission.transition", from_status=current, to_status=status, reason=reason)
+            db.commit()
+        _audit("hermes_mission_transition", policy, dry_run=False, success=True, changed=current != status, mission_id=mission_id, summary=f"mission {current}->{status}")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_transition", "mission_id": mission_id, "from_status": current, "to_status": status, "changed": current != status})
+    except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_TRANSITION_REJECTED", "Check mission lifecycle and Owner approval requirements.")
+
+
+def hermes_mission_approve(
+    mission_id: str,
+    approval_reference: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+    hermes_root: Path | None = None,
+) -> str:
+    policy = op.OperatorPolicy()
+    try:
+        policy.require_owner(dry_run)
+        approval_reference = _bounded_text(approval_reference, "approval_reference", 256, required=True)
+        effective_dry = policy.effective_dry_run(dry_run)
+        if not effective_dry and not confirm:
+            raise PermissionError("direct mission approval requires confirm=true")
+        path = _db_path(hermes_root)
+        with _connect(path, write=False) as db:
+            row = _get_row(db, mission_id)
+            mission = _row_to_mission(db, row)
+        if mission["status"] in TERMINAL_STATUSES:
+            raise ValueError("terminal mission cannot be approved")
+        nonterminal_children = [a for a in mission["attachments"] if a["state"] in {"unknown", "pending", "running", "blocked"}]
+        if nonterminal_children:
+            raise ValueError("mission has nonterminal child attachments; reconcile them before approval")
+        approval = {"approved": True, "approved_by": "owner", "approval_reference": approval_reference, "approved_at": _now()}
+        target = "completed"
+        if effective_dry:
+            return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_approve", "mission_id": mission_id, "status": target, "approval": approval, "changed": False, "dry_run": True})
+        with _connect(path, write=True) as db:
+            current = _get_row(db, mission_id)["status"]
+            db.execute("UPDATE missions SET status=?,approval_json=?,version=version+1,updated_at=? WHERE mission_id=?", (target, json.dumps(approval, sort_keys=True), _now(), mission_id))
+            _event(db, mission_id, "mission.approved", from_status=current, to_status=target, details={"approval_reference": approval_reference})
+            db.commit()
+        _audit("hermes_mission_approve", policy, dry_run=False, success=True, changed=True, mission_id=mission_id, summary="mission Owner-approved")
+        return json.dumps({"success": True, "schema_version": SCHEMA_VERSION, "tool": "hermes_mission_approve", "mission_id": mission_id, "status": target, "approval": approval, "changed": True})
+    except (ValueError, LookupError, PermissionError, OSError, sqlite3.Error) as exc:
+        return _error(exc, "MISSION_APPROVAL_REJECTED", "Reconcile child work and use Owner direct mode with confirm=true.")

--- a/operator_mission_runtime.py
+++ b/operator_mission_runtime.py
@@ -170,7 +170,7 @@ def _bounded_text(value: Any, field: str, maximum: int, *, required: bool = Fals
     if value is None:
         value = ""
     if not isinstance(value, str):
-        raise ValueError(f"{field} must be a string")
+        raise TypeError(f"{field} must be a string")
     value = value.strip()
     if required and not value:
         raise ValueError(f"{field} is required")
@@ -195,7 +195,7 @@ def _normalize_context(raw: Any) -> list[dict[str, str]]:
     out: list[dict[str, str]] = []
     for item in raw:
         if not isinstance(item, dict):
-            raise ValueError("context_refs items must be objects")
+            raise TypeError("context_refs items must be objects")
         _closed(item, _ALLOWED_CONTEXT_KEYS, "context ref")
         kind = _bounded_text(item.get("kind"), "context kind", 64, required=True)
         ref = _bounded_text(item.get("ref"), "context ref", 256, required=True)
@@ -223,7 +223,7 @@ def _normalize_skills(raw: Any) -> list[dict[str, str]]:
     seen: set[str] = set()
     for item in raw:
         if not isinstance(item, dict):
-            raise ValueError("skills items must be objects")
+            raise TypeError("skills items must be objects")
         _closed(item, _ALLOWED_SKILL_KEYS, "skill")
         name = _bounded_text(item.get("name"), "skill name", 128, required=True)
         if name in seen:
@@ -257,7 +257,7 @@ def _normalize_spec(raw: dict[str, Any], *, mission_id: str | None = None) -> di
         raise ValueError("mission_id is invalid")
     final_approval = raw.get("final_approval_required", True)
     if not isinstance(final_approval, bool):
-        raise ValueError("final_approval_required must be boolean")
+        raise TypeError("final_approval_required must be boolean")
     return {
         "schema": MISSION_SPEC_SCHEMA,
         "mission_id": mid,
@@ -348,8 +348,8 @@ def _audit(tool: str, policy: op.OperatorPolicy, *, dry_run: bool, success: bool
             summary=summary,
             extra={"mission_id": mission_id},
         )
-    except Exception:
-        pass
+    except (OSError, TypeError, ValueError):
+        return
 
 
 def _error(exc: Exception, code: str, action: str) -> str:
@@ -368,7 +368,7 @@ def hermes_mission_create(
         policy.require_mutation(dry_run)
         raw = json.loads(mission_json)
         if not isinstance(raw, dict):
-            raise ValueError("mission_json must contain an object")
+            raise TypeError("mission_json must contain an object")
         spec = _normalize_spec(raw)
         effective_dry = policy.effective_dry_run(dry_run)
         if not effective_dry and not confirm:
@@ -451,7 +451,7 @@ def hermes_mission_update(
         policy.require_mutation(dry_run)
         patch = json.loads(patch_json)
         if not isinstance(patch, dict):
-            raise ValueError("patch_json must contain an object")
+            raise TypeError("patch_json must contain an object")
         _closed(patch, _ALLOWED_PATCH_KEYS, "mission patch")
         effective_dry = policy.effective_dry_run(dry_run)
         if not effective_dry and not confirm:

--- a/operator_mission_runtime.py
+++ b/operator_mission_runtime.py
@@ -777,14 +777,16 @@ def hermes_mission_approve(
             raise PermissionError("direct mission approval requires confirm=true")
         path = _db_path(hermes_root)
 
+        root = _root(hermes_root)
+
         def validate(mission: dict[str, Any]) -> None:
             if mission["status"] != "awaiting_approval":
                 raise ValueError("mission must be awaiting_approval before Owner approval")
-            attachments = mission["attachments"]
-            succeeded = [a for a in attachments if a["state"] == "succeeded" and bool(a.get("verified"))]
-            invalid = [a for a in attachments if a["state"] not in {"succeeded", "cancelled"} or (a["state"] == "succeeded" and not bool(a.get("verified")))]
+            observed = _observe_attachments(root, mission)
+            succeeded = [a for a in observed if a["state"] == "succeeded" and bool(a.get("verified"))]
+            invalid = [a for a in observed if a["state"] not in {"succeeded", "cancelled"} or (a["state"] == "succeeded" and not bool(a.get("verified")))]
             if invalid or not succeeded:
-                raise ValueError("mission children are not all terminal with at least one verified success")
+                raise ValueError("mission children are not currently terminal with at least one verified success")
 
         approval = {"approved": True, "approved_by": "owner", "approval_reference": approval_reference, "approved_at": _now()}
         target = "completed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ py-modules = [
   "docs/README.md",
   "docs/oauth.md",
   "docs/operator-mode.md",
+  "docs/missions.md",
   "docs/mcp-compatibility.md",
   "docs/file-export.md",
   "docs/openai-secure-mcp-tunnel.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ py-modules = [
   "operator_codex",
   "operator_session",
   "operator_mission",
+  "operator_mission_runtime",
   "operator_contract",
   "operator_runners",
   "runner_confinement",

--- a/server.py
+++ b/server.py
@@ -32,6 +32,7 @@ import operator_codex as op_codex
 import operator_fleet as op_fleet
 import operator_session as op_session
 import operator_mission as op_mission
+import operator_mission_runtime as op_mission_runtime
 import operator_contract as op_contract
 import operator_runners as op_runners
 import operator_review as op_review
@@ -1407,6 +1408,14 @@ def hermes_operator_status() -> str:
             "hermes_mission_vault",
             "hermes_mission_usage",
             "hermes_mission_audit",
+            "hermes_mission_create",
+            "hermes_mission_get",
+            "hermes_mission_list",
+            "hermes_mission_update",
+            "hermes_mission_attach",
+            "hermes_mission_reconcile",
+            "hermes_mission_transition",
+            "hermes_mission_approve",
             "hermes_contract_define",
             "hermes_contract_dispatch",
             "hermes_contract_validate",
@@ -1988,6 +1997,75 @@ def hermes_mission_usage(force_refresh: bool = False) -> str:
     return op_mission.hermes_mission_usage_tool(hermes_root=_default_hermes_root(), force_refresh=force_refresh)
 
 
+# --- First-class Mission runtime (v0.9) -----------------------------------
+
+
+def hermes_mission_create(mission_json: str, confirm: bool = False, dry_run: bool = True) -> str:
+    return op_mission_runtime.hermes_mission_create(mission_json, confirm, dry_run, _default_hermes_root())
+
+
+def hermes_mission_get(mission_id: str) -> str:
+    return op_mission_runtime.hermes_mission_get(mission_id, _default_hermes_root())
+
+
+def hermes_mission_list(status: str = "", limit: int = 50) -> str:
+    return op_mission_runtime.hermes_mission_list(status, limit, _default_hermes_root())
+
+
+def hermes_mission_update(mission_id: str, patch_json: str, confirm: bool = False, dry_run: bool = True) -> str:
+    return op_mission_runtime.hermes_mission_update(mission_id, patch_json, confirm, dry_run, _default_hermes_root())
+
+
+def hermes_mission_attach(
+    mission_id: str,
+    kind: str,
+    ref: str,
+    relationship: str = "contains",
+    state: str = "unknown",
+    evidence_ref: str = "",
+    confirm: bool = False,
+    dry_run: bool = True,
+) -> str:
+    return op_mission_runtime.hermes_mission_attach(
+        mission_id,
+        kind,
+        ref,
+        relationship,
+        state,
+        evidence_ref,
+        confirm,
+        dry_run,
+        _default_hermes_root(),
+    )
+
+
+def hermes_mission_reconcile(mission_id: str, confirm: bool = False, dry_run: bool = True) -> str:
+    return op_mission_runtime.hermes_mission_reconcile(mission_id, confirm, dry_run, _default_hermes_root())
+
+
+def hermes_mission_transition(
+    mission_id: str,
+    status: str,
+    reason: str = "",
+    confirm: bool = False,
+    dry_run: bool = True,
+) -> str:
+    return op_mission_runtime.hermes_mission_transition(
+        mission_id, status, reason, confirm, dry_run, _default_hermes_root()
+    )
+
+
+def hermes_mission_approve(
+    mission_id: str,
+    approval_reference: str,
+    confirm: bool = False,
+    dry_run: bool = True,
+) -> str:
+    return op_mission_runtime.hermes_mission_approve(
+        mission_id, approval_reference, confirm, dry_run, _default_hermes_root()
+    )
+
+
 # --- Work Contracts (v0.6 M1) ----------------------------------------------
 
 
@@ -2410,6 +2488,21 @@ def register_tools(server: FastMCP) -> None:
         hermes_mission_audit,
     ):
         server.add_tool(_mission_tool, meta=tool_meta())
+
+    # First-class durable Mission runtime (v0.9). Authority is enforced by
+    # operator_mission_runtime; list/get are read-only, mutations are
+    # workspace/direct and final approval is Owner-gated.
+    for _mission_runtime_tool in (
+        hermes_mission_create,
+        hermes_mission_get,
+        hermes_mission_list,
+        hermes_mission_update,
+        hermes_mission_attach,
+        hermes_mission_reconcile,
+        hermes_mission_transition,
+        hermes_mission_approve,
+    ):
+        server.add_tool(_mission_runtime_tool, meta=tool_meta())
 
     # Event history (v0.7 S4): read-only normalized timeline over durable
     # stores. Registered unconditionally; each tool enforces the per-client

--- a/test_operator_mission_runtime.py
+++ b/test_operator_mission_runtime.py
@@ -109,7 +109,18 @@ def test_attach_and_workflow_reconcile_is_fail_closed(hermes_root: Path):
 
 def test_owner_approval_is_required_for_final_completion(hermes_root: Path, monkeypatch):
     assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
-    assert _j(mission.hermes_mission_attach("msn-test", "evidence", "ev-final", state="succeeded", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "evidence", "ev-final", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert mission.record_attachment_state(
+        "msn-test",
+        "evidence",
+        "ev-final",
+        "succeeded",
+        evidence_ref="evidence:verified-final",
+        verified=True,
+        hermes_root=hermes_root,
+    )
+    reconciled = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert reconciled["status"] == "awaiting_approval"
 
     denied = _j(mission.hermes_mission_transition("msn-test", "completed", confirm=True, dry_run=False, hermes_root=hermes_root))
     assert denied["success"] is False
@@ -133,7 +144,155 @@ def test_internal_attachment_state_bridge_updates_existing_only(hermes_root: Pat
     assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
     assert mission.record_attachment_state("msn-test", "delegation", "dlg-missing", "running", hermes_root=hermes_root) is False
     assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-1", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
-    assert mission.record_attachment_state("msn-test", "delegation", "dlg-1", "succeeded", evidence_ref="evidence:1", hermes_root=hermes_root) is True
+    assert mission.record_attachment_state("msn-test", "delegation", "dlg-1", "succeeded", evidence_ref="evidence:1", verified=True, hermes_root=hermes_root) is True
     got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
     assert got["attachments"][0]["state"] == "succeeded"
     assert got["attachments"][0]["evidence_ref"] == "evidence:1"
+
+
+def test_workspace_cannot_weaken_final_approval_boundary(hermes_root: Path):
+    raw = json.loads(_spec("msn-no-approval"))
+    raw["final_approval_required"] = False
+    denied_create = _j(
+        mission.hermes_mission_create(
+            json.dumps(raw),
+            confirm=True,
+            dry_run=False,
+            hermes_root=hermes_root,
+        )
+    )
+    assert denied_create["success"] is False
+
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    denied_update = _j(
+        mission.hermes_mission_update(
+            "msn-test",
+            json.dumps({"final_approval_required": False}),
+            confirm=True,
+            dry_run=False,
+            hermes_root=hermes_root,
+        )
+    )
+    assert denied_update["success"] is False
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    assert got["final_approval_required"] is True
+
+
+def test_owner_can_explicitly_create_no_final_approval_mission(hermes_root: Path, monkeypatch):
+    _owner(monkeypatch)
+    raw = json.loads(_spec("msn-owner-optout"))
+    raw["final_approval_required"] = False
+    created = _j(mission.hermes_mission_create(json.dumps(raw), confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert created["success"] is True
+
+
+def test_workflow_attachment_rejects_traversal_and_noncanonical_ids(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    bad = _j(
+        mission.hermes_mission_attach(
+            "msn-test",
+            "workflow",
+            "sw-child/../../escape",
+            state="pending",
+            confirm=True,
+            dry_run=False,
+            hermes_root=hermes_root,
+        )
+    )
+    assert bad["success"] is False
+    assert mission._workflow_state(hermes_root, "sw-child/../../escape") == "unknown"
+
+
+def test_public_attach_cannot_assert_success_and_bridge_requires_verification(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    denied = _j(
+        mission.hermes_mission_attach(
+            "msn-test",
+            "delegation",
+            "dlg-verified",
+            state="succeeded",
+            evidence_ref="evidence:claimed",
+            confirm=True,
+            dry_run=False,
+            hermes_root=hermes_root,
+        )
+    )
+    assert denied["success"] is False
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-verified", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert mission.record_attachment_state(
+        "msn-test",
+        "delegation",
+        "dlg-verified",
+        "succeeded",
+        evidence_ref="evidence:not-enough",
+        verified=False,
+        hermes_root=hermes_root,
+    ) is False
+    assert mission.record_attachment_state(
+        "msn-test",
+        "delegation",
+        "dlg-verified",
+        "succeeded",
+        evidence_ref="evidence:verified",
+        verified=True,
+        hermes_root=hermes_root,
+    ) is True
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    attached = next(item for item in got["attachments"] if item["ref"] == "dlg-verified")
+    assert attached["state"] == "succeeded"
+    assert bool(attached["verified"]) is True
+
+
+def test_reconcile_fails_closed_on_unverified_legacy_success(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-legacy", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    with mission._connect(mission._db_path(hermes_root), write=True) as db:
+        db.execute(
+            "UPDATE attachments SET state='succeeded',verified=0,evidence_ref='legacy:claim' WHERE mission_id=? AND kind='delegation' AND ref='dlg-legacy'",
+            ("msn-test",),
+        )
+        db.commit()
+    out = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert out["status"] == "blocked"
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    attached = next(item for item in got["attachments"] if item["ref"] == "dlg-legacy")
+    assert attached["state"] == "blocked"
+    assert bool(attached["verified"]) is False
+
+
+def test_approval_requires_awaiting_approval_and_verified_success(hermes_root: Path, monkeypatch):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-failed", state="failed", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    _owner(monkeypatch)
+    denied = _j(mission.hermes_mission_approve("msn-test", "approval:bad", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert denied["success"] is False
+
+
+def test_noop_reconcile_does_not_append_events(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "workflow", "sw-child", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    wf_dir = hermes_root / "swarm-workflows"
+    wf_dir.mkdir()
+    (wf_dir / "sw-child.json").write_text(json.dumps({"status": "running"}), encoding="utf-8")
+    first = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert first["changed"] is True
+    before = len(_j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))["events"])
+    second = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    after = len(_j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))["events"])
+    assert second["changed"] is False
+    assert after == before
+
+
+def test_acceptance_and_owner_profile_freeze_after_work_attached(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-1", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    denied = _j(
+        mission.hermes_mission_update(
+            "msn-test",
+            json.dumps({"acceptance_criteria": ["weakened"]}),
+            confirm=True,
+            dry_run=False,
+            hermes_root=hermes_root,
+        )
+    )
+    assert denied["success"] is False

--- a/test_operator_mission_runtime.py
+++ b/test_operator_mission_runtime.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import operator_mission_runtime as mission
+import operator_policy as op
+
+
+@pytest.fixture
+def hermes_root(tmp_path: Path, monkeypatch) -> Path:
+    root = tmp_path / "hermes"
+    root.mkdir()
+    op.set_audit_log_override(tmp_path / "audit.jsonl")
+    monkeypatch.setenv(op.OPERATOR_ENABLED_ENV, "1")
+    monkeypatch.setenv(op.OPERATOR_LEVEL_ENV, "workspace")
+    monkeypatch.setenv(op.OPERATOR_APPLY_MODE_ENV, "direct")
+    monkeypatch.delenv(op.OWNER_ACTIVE_ENV, raising=False)
+    monkeypatch.delenv(op.OWNER_ACK_ENV, raising=False)
+    return root
+
+
+def _spec(mid: str = "msn-test") -> str:
+    return json.dumps(
+        {
+            "schema": mission.MISSION_SPEC_SCHEMA,
+            "mission_id": mid,
+            "title": "Implement v0.9",
+            "objective": "Coordinate durable mission work without weakening existing gates.",
+            "owner_profile": "default",
+            "acceptance_criteria": ["all child work is observed", "final Owner approval"],
+            "context_refs": [
+                {
+                    "kind": "document",
+                    "ref": "docs:v0.9-plan",
+                    "label": "v0.9 plan",
+                    "sha256": "a" * 64,
+                }
+            ],
+            "skills": [
+                {"name": "compound-engineering", "version": "1", "ref": "skill:compound-engineering"}
+            ],
+            "final_approval_required": True,
+        }
+    )
+
+
+def _j(value: str) -> dict:
+    return json.loads(value)
+
+
+def _owner(monkeypatch) -> None:
+    monkeypatch.setenv(op.OPERATOR_LEVEL_ENV, "owner")
+    monkeypatch.setenv(op.OWNER_ACTIVE_ENV, "1")
+    monkeypatch.setenv(op.OWNER_ACK_ENV, op.OWNER_ACK_REQUIRED_VALUE)
+
+
+def test_create_get_list_persists_bounded_manifests(hermes_root: Path):
+    created = _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert created["success"] is True
+    assert created["mission_id"] == "msn-test"
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    assert got["success"] is True
+    assert got["status"] == "draft"
+    assert got["context_refs"][0]["sha256"] == "a" * 64
+    assert got["skills"][0]["name"] == "compound-engineering"
+    listed = _j(mission.hermes_mission_list(hermes_root=hermes_root))
+    assert listed["count"] == 1
+    assert listed["missions"][0]["mission_id"] == "msn-test"
+
+
+def test_schema_is_closed_and_dry_run_does_not_create_state(hermes_root: Path):
+    bad = json.loads(_spec())
+    bad["raw_context_body"] = "do not persist me"
+    out = _j(mission.hermes_mission_create(json.dumps(bad), confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert out["success"] is False
+    plan = _j(mission.hermes_mission_create(_spec("msn-plan"), confirm=False, dry_run=True, hermes_root=hermes_root))
+    assert plan["success"] is True and plan["dry_run"] is True
+    assert not (hermes_root / "missions" / "missions.db").exists()
+
+
+def test_attach_and_workflow_reconcile_is_fail_closed(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    attached = _j(
+        mission.hermes_mission_attach(
+            "msn-test", "workflow", "sw-child", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root
+        )
+    )
+    assert attached["success"] is True
+
+    wf_dir = hermes_root / "swarm-workflows"
+    wf_dir.mkdir()
+    (wf_dir / "sw-child.json").write_text(json.dumps({"status": "running"}), encoding="utf-8")
+    running = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert running["status"] == "running"
+
+    (wf_dir / "sw-child.json").write_text(json.dumps({"status": "blocked"}), encoding="utf-8")
+    blocked = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert blocked["status"] == "blocked"
+
+    (wf_dir / "sw-child.json").write_text(json.dumps({"status": "done"}), encoding="utf-8")
+    done = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert done["status"] == "awaiting_approval"
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    assert got["attachments"][0]["state"] == "succeeded"
+
+
+def test_owner_approval_is_required_for_final_completion(hermes_root: Path, monkeypatch):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "evidence", "ev-final", state="succeeded", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+
+    denied = _j(mission.hermes_mission_transition("msn-test", "completed", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert denied["success"] is False
+
+    _owner(monkeypatch)
+    approved = _j(mission.hermes_mission_approve("msn-test", "approval:g7", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert approved["success"] is True
+    assert approved["status"] == "completed"
+    assert approved["approval"]["approved_by"] == "owner"
+
+
+def test_approval_refuses_nonterminal_children(hermes_root: Path, monkeypatch):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-1", state="running", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    _owner(monkeypatch)
+    denied = _j(mission.hermes_mission_approve("msn-test", "approval:nope", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert denied["success"] is False
+
+
+def test_internal_attachment_state_bridge_updates_existing_only(hermes_root: Path):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert mission.record_attachment_state("msn-test", "delegation", "dlg-missing", "running", hermes_root=hermes_root) is False
+    assert _j(mission.hermes_mission_attach("msn-test", "delegation", "dlg-1", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert mission.record_attachment_state("msn-test", "delegation", "dlg-1", "succeeded", evidence_ref="evidence:1", hermes_root=hermes_root) is True
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    assert got["attachments"][0]["state"] == "succeeded"
+    assert got["attachments"][0]["evidence_ref"] == "evidence:1"

--- a/test_operator_mission_runtime.py
+++ b/test_operator_mission_runtime.py
@@ -268,6 +268,28 @@ def test_approval_requires_awaiting_approval_and_verified_success(hermes_root: P
     assert denied["success"] is False
 
 
+@pytest.mark.parametrize("regression", ["blocked", "missing"])
+def test_approval_reobserves_child_evidence_and_fails_closed(hermes_root: Path, monkeypatch, regression: str):
+    assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    assert _j(mission.hermes_mission_attach("msn-test", "workflow", "sw-child", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
+    wf_dir = hermes_root / "swarm-workflows"
+    wf_dir.mkdir()
+    wf_path = wf_dir / "sw-child.json"
+    wf_path.write_text(json.dumps({"status": "done"}), encoding="utf-8")
+    reconciled = _j(mission.hermes_mission_reconcile("msn-test", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert reconciled["status"] == "awaiting_approval"
+    if regression == "blocked":
+        wf_path.write_text(json.dumps({"status": "blocked"}), encoding="utf-8")
+    else:
+        wf_path.unlink()
+    _owner(monkeypatch)
+    denied = _j(mission.hermes_mission_approve("msn-test", "approval:stale", confirm=True, dry_run=False, hermes_root=hermes_root))
+    assert denied["success"] is False
+    got = _j(mission.hermes_mission_get("msn-test", hermes_root=hermes_root))
+    assert got["status"] == "awaiting_approval"
+    assert not got["approval"].get("approved")
+
+
 def test_noop_reconcile_does_not_append_events(hermes_root: Path):
     assert _j(mission.hermes_mission_create(_spec(), confirm=True, dry_run=False, hermes_root=hermes_root))["success"]
     assert _j(mission.hermes_mission_attach("msn-test", "workflow", "sw-child", state="pending", confirm=True, dry_run=False, hermes_root=hermes_root))["success"]


### PR DESCRIPTION
## Summary

Introduces the first-class durable Mission runtime for v0.9 while preserving the existing read-only Mission Control aggregation surface.

This is a **Missions-only** PR and is now synchronized with finalized v0.8 `master` (`aa5d993e50bc1acc761074efca3fe5fde8ce6f98`). The published branch includes a merge of that finalized baseline because the execution safety layer disallows forced ref rewrites; the resulting tree is identical to the independently reviewed clean-rebase tree.

## What it adds

- durable `hermes.mission/v1` Mission objects backed by SQLite
- closed Mission spec schema with bounded objective, acceptance criteria, context references, and skill manifests
- Mission lifecycle tools:
  - `hermes_mission_create`
  - `hermes_mission_get`
  - `hermes_mission_list`
  - `hermes_mission_update`
  - `hermes_mission_attach`
  - `hermes_mission_reconcile`
  - `hermes_mission_transition`
  - `hermes_mission_approve`
- durable attachment relationships for workflows, delegations, artifacts, and evidence references
- restart/reconciliation support based on attached Swarm workflow state
- explicit verified-attachment state so unverified success cannot advance Mission completion
- bounded/audited mutation behavior using existing Operator/Owner policy gates
- operational documentation in `docs/missions.md`
- packaging and CI lint coverage for the runtime

## Security / authority hardening

The pre-revision independent review found one HIGH and two MEDIUM issues. The repaired tree closes them:

- `final_approval_required` defaults on, cannot be weakened after creation, and disabling it at creation requires Owner authority
- public attachment calls cannot assert `succeeded`
- successful non-workflow attachment state requires a verified lifecycle adapter plus evidence reference
- unverified legacy success reconciles fail-closed to `blocked`
- workflow refs use the canonical `sw-*` grammar and are containment-checked
- Mission mutation guards are re-read and applied in one `BEGIN IMMEDIATE` write transaction
- approval requires `awaiting_approval` plus at least one verified success and no failed/unverified child
- direct `completed` transitions are Owner-gated and must be justified by child state
- no-op reconciliation no longer appends journal events
- acceptance criteria / owner profile freeze once work is attached or started

## Validation

Repaired clean-rebase tree reviewed at `ba3d34ce3630e1795b363959402d53c0c3825fed`; published head `a70680843bd839d51db571981e2963e1ca1eecc9` has the **same Git tree** (`637388e92d6ad8c8165e1c31cb701b6301daae6f`).

Passed locally on this tree:

- dedicated Mission runtime tests: 14/14
- Mission/runtime/server regression suite: PASS
- full repository pytest: PASS with 2 skips
- exact CI Ruff scope: PASS
- `py_compile`: PASS
- `git diff --check`: PASS
- wheel + sdist build: PASS
- Twine: PASS
- package hygiene/private-pattern scan: CLEAN
- runtime and `docs/missions.md` present in wheel and sdist with zero backup files

Independent Pi security re-review (`cliproxyapi/glm-5.3`) of the repaired exact tree: **PASS**, with all prior HIGH/MEDIUM findings closed and no new blocking finding.

GitHub CI on the published head is the authoritative exact-head matrix check.

## v0.9 sequencing

This is the first v0.9 feature slice. Live Events (#49), Delegation Lifecycle (#50), and Flight Deck Missions (#51) remain separate stacked follow-ups and will be refreshed on top of the repaired Mission baseline.
