### PR TITLE
release: Hermes GPT v0.8.0 Fabric

### DIFF
--- a/.github/release-body.md
+++ b/.github/release-body.md
@@ -1,32 +1,45 @@
-# Hermes GPT v0.7.0 — Flight Deck
+# Hermes GPT v0.8.0 - Fabric
 
-Hermes GPT v0.7.0 "Flight Deck" makes durable autonomy legible: every long-running task, event, evidence record, and authority grant is visible, inspectable, and gated — without giving the operator a bypass. The release is additive; no existing tool name, schema, or authority class changes.
+Hermes GPT v0.8.0 turns the v0.7 control plane into a local-first distributed execution fabric. A bounded Swarm stage can now execute on another authenticated Hermes machine while the coordinator keeps authority, evidence admission, Work Contract validation, independent review, and final human approval on the trusted side of the boundary.
 
-## Production review evidence (`hermes_review_accept`)
+Remote worker self-report is still transport data, never proof of completion.
 
-Owner-gated write of review-acceptance records with distinct-reviewer enforcement **in code** at write time and re-checked at validate time (`reviewer != assignee`; self-review rejected both ways). Bounded verdict vocabulary (`SATISFIED` / `NOT_SATISFIED`), referenced-not-copied evidence (no raw prompts or transcripts in the store), and a durable append-only store read by `hermes_contract_validate` alongside the v0.6 audit + human-approval paths.
+## Cross-machine execution
 
-## Structured event history (`hermes_events_query` / `hermes_events_tail`)
+- Packaged `hermes-gpt-fabric-peer` A2A/Fabric runtime.
+- `execution.backend=auto` can choose eligible local or remote runtimes from current node capabilities.
+- Non-loopback Fabric peers require direct TLS with `--cert` and `--key`.
+- Placement preserves profile, logical workspace, backend, and server-controlled authority ceilings.
 
-A unified, queryable, redacted timeline across audit, swarm, codex, cron, and kanban stores. Read-only by construction, with a per-source allowlist (`HERMES_GPT_EVENTS_ALLOWED_SOURCES`), retention window (`HERMES_GPT_EVENTS_MAX_AGE_DAYS`, default 90), and the same Mission Control redaction invariants: no raw messages, memory bodies, transcripts, request dumps, credentials, or profile-secret bodies.
+## Evidence, artifacts, and recovery
 
-## Durable encrypted token storage + trusted-client OAuth
+- Remote evidence feeds the existing observed-state Work Contract validator.
+- Required missing/unavailable Fabric evidence fails closed.
+- Remote artifacts are admitted through immutable manifests and coordinator-side content hashing.
+- Restart/timeout/cancel reconciliation preserves the original attempt when recovery is possible.
+- Write-ownership/write-epoch guards prevent ambiguous or duplicate remote writers.
 
-OAuth access/refresh tokens persist through an AES-256-GCM envelope at `<hermes_data>/secrets/hermes_gpt_tokens.json` (0600) with keyring → key file → env key precedence, so server restarts no longer invalidate issued credentials. Added `hermes_oauth_status` (presence/expiry only — no token material on any surface) and `hermes_oauth_revoke` (owner-gated). OAuth is promoted from Unreleased to shipped and documented in `docs/oauth.md`.
+## Fabric Flight Deck
 
-## Restart-safe continuity (`hermes_swarm_reconcile`)
+Flight Deck now exposes read-only Fabric nodes, placement, attempts, evidence, and routing history. The final v0.8 repair preserves the authoritative selected-route health, capability-freshness, eligibility, transport-backend, and authority-ceiling fields instead of fabricating negative state for older/missing receipt fields.
 
-Marks swarm stages stuck in `running` as `blocked` with `reason: interrupted_by_restart` — never auto-advances — and reloads the durable token envelope. `hermes_swarm_stage_advance` is now idempotent for already-validated/done stages. Dry-run by default; apply requires workspace/owner + direct.
+## Two-machine acceptance
 
-## MCP compatibility manifest
+The final Fabric implementation target `4953c5f23db8d356365af8e18148e63d3c80125c` passed fresh real two-machine G6 acceptance. The authoritative acceptance evidence and independent-review result are recorded on [issue #37](https://github.com/asimons81/hermes-gpt/issues/37). The acceptance exercised authenticated remote Fabric -> Pi RPC execution, `execution.backend=auto`, an induced live transport interruption, same-attempt reconciliation, artifact admission plus independent re-hash, fail-closed missing evidence, Work Contract `SATISFIED`, non-owner approval denial, explicit Owner approval, and an independent final review.
 
-`docs/mcp-compatibility.md` pins the minimum supported MCP protocol revision (2024-11-05) through the installed SDK's latest (2025-11-25), the transport matrix (stdio, streamable HTTP, SSE), and trusted-client auth metadata, with compatibility tests against the installed SDK.
+Independent review: **PASS**. G6 closure blocked: **NO**. G7 Owner ship authorization is recorded on [issue #27](https://github.com/asimons81/hermes-gpt/issues/27).
 
-## Also in this release
+## Also included
 
-- Cross-machine seam interfaces (`seams.py`: `DispatchAdapter` / `EvidenceProvider` protocols) validated by a two-process-one-host fake over loopback — interfaces only, no remote implementation shipped.
-- CI hermeticity fix: `_call_skill_manager` no longer fails when the Hermes Agent source tree is absent from `sys.path`; profile-scoping tests skip only when `hermes_constants` is unavailable.
+- `hermes_export_file` bounded binary export.
+- OpenAI Secure MCP Tunnel deployment path.
+- FastMCP-compatible MCP 1.x dependency pin.
+- Fleet timeout recovery with pollable task identity.
+- Safer proxy trust and OIDC discovery behavior.
+- Stricter Operator doctor gateway health and Hermes source-root detection.
 
-## Verification
+## Known non-blocking presentation limitation
 
-Full test suite green: 646 tests collected — 643 passed, 3 skipped — covering MCP compat, recovery, review, events, token store, and seams. CI green on Python 3.10–3.12. See the [v0.7.0 release notes](docs/release-notes-v0.7.0.md) and [retention policy](docs/retention-policy.md).
+A reconciled attempt that ultimately reaches `COMPLETED` can still retain historical `FABRIC_TRANSPORT_TIMEOUT` data in the Flight Deck blocker/error presentation. Independent G6 review classified this as non-blocking because terminal peer evidence, artifact admission, coordinator validation, and workflow state independently establish completion.
+
+Full details: [v0.8.0 release notes](docs/release-notes-v0.8.0.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## 0.8.0 - 2026-08-21
+
+Fabric: authenticated cross-machine Swarm execution with capability-aware routing, remote evidence/artifacts, reconciliation, and Flight Deck visibility.
+
+- Added the packaged `hermes-gpt-fabric-peer` A2A/Fabric runtime for authenticated remote execution. Non-loopback serving requires direct TLS.
+- Added durable node capabilities, health/freshness tracking, deterministic `execution.backend=auto` routing, explicit route exclusions, and authority-ceiling preservation.
+- Added remote evidence collection and immutable artifact admission. Required missing/unavailable evidence fails closed, and admitted artifacts are hash-verified by the coordinator.
+- Added restart/timeout/cancel reconciliation that preserves the original distributed attempt plus write-ownership/write-epoch guards for mutation-capable paths.
+- Added read-only Flight Deck Fabric nodes, placement, attempts, evidence, and routing views, including truthful selected-route health/freshness/eligibility/authority fields.
+- Completed fresh real two-machine G6 acceptance on final Fabric implementation target `4953c5f23db8d356365af8e18148e63d3c80125c`, including induced transport loss, same-attempt recovery, artifact re-hash, fail-closed validation, approval gating, and independent review.
+- Known non-blocking presentation limitation: a completed reconciled attempt may retain a historical `FABRIC_TRANSPORT_TIMEOUT` as a current-looking Flight Deck blocker.
 - Added `hermes_export_file`, a workspace-authorized MCP-native binary export surface with mandatory allowed-path confinement, denied-secret-path enforcement, symlink escape refusal, a 4 MiB default / 16 MiB hard size cap, optional extension allowlisting, safe audit metadata, and no base64 text fallback. Client attachment rendering remains client-controlled.
 - Added a first-class OpenAI Secure MCP Tunnel deployment path for private ChatGPT/Codex/OpenAI access while Hermes GPT stays bound to loopback. Added a canonical guide, supervised Windows launcher, tunnel-aware status example, package wiring, and cross-links from the README, MCP compatibility, Cloudflare, and Windows Codex docs.
 - Documented the tunnel security boundary: no public `HERMES_GPT_ALLOWED_HOSTS` entry is required for the private loopback path, static bearer remains optional defense in depth, and built-in OAuth still requires separately reachable browser-facing authorization-server endpoints.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ include docs/release-notes-v0.5.0b2.md
 include docs/release-notes-v0.5.0.md
 include docs/release-notes-v0.6.0.md
 include docs/release-notes-v0.7.0.md
+include docs/release-notes-v0.8.0.md
 include docs/retention-policy.md
 include docs/updating.md
 include docs/windows-chatgpt-codex.md

--- a/README.md
+++ b/README.md
@@ -9,17 +9,29 @@
 
 ## Current status
 
-- **Repository version:** 0.7.0
-- **Latest GitHub release:** v0.7.0
-- **Latest PyPI release:** 0.4.0 (PyPI has lagged GitHub since v0.5.0; check the badge for the current value)
+- **Repository version:** 0.8.0
+- **GitHub release target:** v0.8.0
+- **Latest PyPI release:** check the badge above; PyPI is published independently from GitHub
 - **Python requirement:** 3.10+
 - **Deployment posture:** local-dev / trusted-machine only
 - **Remote public hosting:** unsupported without a real authenticated private boundary
 
 > [!IMPORTANT]
-> GitHub releases and PyPI can temporarily be on different versions. The PyPI badge above is the source of truth for what `pip install hermes-gpt` installs. Do not assume a PyPI install contains v0.7 features unless the badge reports v0.7.0 or newer.
+> GitHub releases and PyPI can temporarily be on different versions. The PyPI badge above is the source of truth for what `pip install hermes-gpt` installs. Do not assume a PyPI install contains v0.8 features unless the badge reports v0.8.0 or newer.
 
 For the current documentation map and source-of-truth rules, start with [docs/README.md](docs/README.md). Agents working in this repository should also read [AGENTS.md](AGENTS.md).
+
+## What v0.8.0 adds
+
+v0.8.0 "Fabric" turns the v0.7 control plane into a local-first distributed execution fabric:
+
+1. **Cross-machine Swarm execution** - bounded stages can execute through an authenticated `hermes-gpt-fabric-peer` while the coordinator remains authoritative.
+2. **Capability-aware `auto` routing** - placement uses current node health/freshness, backend capability, profile/workspace policy, and authority ceilings, with explicit overrides preserved.
+3. **Remote evidence and artifacts** - remote evidence is admitted into the existing Work Contract boundary; missing required evidence fails closed and artifact bytes are hash-verified.
+4. **Restart/timeout/cancel reconciliation** - recoverable ambiguity reconciles the original attempt, with single-writer/write-epoch protections for mutation-capable paths.
+5. **Fabric Flight Deck visibility** - read-only node, placement, attempt, evidence, and routing views expose the authoritative selected-route fields.
+
+The final Fabric implementation passed fresh real two-machine G6 acceptance and independent review; the authoritative acceptance record is on [issue #37](https://github.com/asimons81/hermes-gpt/issues/37). G7 Owner ship authorization is recorded on [issue #27](https://github.com/asimons81/hermes-gpt/issues/27). See the [v0.8.0 release notes](docs/release-notes-v0.8.0.md) for the acceptance boundary, known presentation limitation, and additional changes included since v0.7.0.
 
 ## What v0.7.0 adds
 
@@ -54,6 +66,7 @@ See the [v0.6.0 release notes](docs/release-notes-v0.6.0.md) and [retention poli
 | Verify the MCP protocol surface | [MCP compatibility manifest](docs/mcp-compatibility.md) |
 | Use Codex as an MCP client | [Codex guide](docs/codex.md) |
 | Use ChatGPT or another trusted client to operate Hermes | [Operator Mode](docs/operator-mode.md) |
+| Understand cross-machine Fabric execution and its release boundary | [v0.8.0 Fabric release notes](docs/release-notes-v0.8.0.md) |
 | Let ChatGPT dispatch bounded work to the Codex CLI on Windows | [Windows ChatGPT -> Codex guide](docs/windows-chatgpt-codex.md) |
 | Update an install safely | [Updating](docs/updating.md) |
 | Review v0.6 data cleanup rules | [Retention policy](docs/retention-policy.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ A design document describes intended architecture. It does not override implemen
 
 ## Current version context
 
-Repository version: **0.7.0**. The matching GitHub release `v0.7.0` is published.
+Repository version: **0.8.0**. The GitHub release target is `v0.8.0`; verify the public GitHub Releases and PyPI channels independently.
 
-The latest PyPI release is **0.4.0**: PyPI is an independent distribution channel and has lagged GitHub since v0.5.0. Check the PyPI badge in the root README before assuming `pip install hermes-gpt` contains a particular feature set; v0.5+ features require the GitHub distribution until PyPI catches up.
+PyPI is an independent distribution channel. Check the PyPI badge in the root README before assuming `pip install hermes-gpt` contains a particular feature set; v0.8 Fabric behavior requires a published PyPI version of 0.8.0 or newer.
 
 ## Current operational docs
 
@@ -30,7 +30,7 @@ The latest PyPI release is **0.4.0**: PyPI is an independent distribution channe
 | [`file-export.md`](file-export.md) | current | bounded binary file transfer, workspace/denied-path gates, size/extension limits, MCP embedded-resource semantics |
 | [`openai-secure-mcp-tunnel.md`](openai-secure-mcp-tunnel.md) | current | outbound-only private access from supported OpenAI products to loopback Hermes GPT |
 | [`cloudflare-tunnel.md`](cloudflare-tunnel.md) | current | public Cloudflare HTTPS proxy deployment and Host allowlist behavior |
-| [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, Flight Deck v0.7 surfaces |
+| [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, v0.8 Fabric execution, and Flight Deck surfaces |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |
 | [`updating.md`](updating.md) | current | check-first Git and PyPI update behavior |
@@ -39,7 +39,8 @@ The latest PyPI release is **0.4.0**: PyPI is an independent distribution channe
 | [`session-control.md`](session-control.md) | current | gated asynchronous session continue/send jobs |
 | [`ui-security-boundary.md`](ui-security-boundary.md) | current | conversational UI browser security boundary and opt-in UI mount |
 | [`flight-deck-coverage.md`](flight-deck-coverage.md) | current | Flight Deck browser coverage and mutation safety decisions |
-| [`release-notes-v0.7.0.md`](release-notes-v0.7.0.md) | current release record | shipped v0.7 behavior and gates |
+| [`release-notes-v0.8.0.md`](release-notes-v0.8.0.md) | current release record | shipped v0.8 Fabric behavior, G6 acceptance boundary, and known limitation |
+| [`release-notes-v0.7.0.md`](release-notes-v0.7.0.md) | historical release record | shipped v0.7 behavior and gates |
 | [`release-notes-v0.6.0.md`](release-notes-v0.6.0.md) | current release record | shipped v0.6 behavior and known limitations |
 | [`../RELEASE_CHECKLIST.md`](../RELEASE_CHECKLIST.md) | maintainer | release verification and publication gates |
 | [`../CHANGELOG.md`](../CHANGELOG.md) | historical/current | concise version history |

--- a/docs/mcp-compatibility.md
+++ b/docs/mcp-compatibility.md
@@ -1,6 +1,6 @@
 # MCP Compatibility
 
-- Status: current (v0.7.0, Flight Deck)
+- Status: current (v0.8.0, Fabric)
 - Owner: default (implementation: developer profile)
 - Verified: 2026-08-15 against `mcp` 1.28.1 (`mcp.shared.version`)
 
@@ -73,7 +73,7 @@ The MCP specification leaves rendering of embedded resources to the client. Herm
 ## Version advertisement
 
 The `initialize` handshake advertises the hermes-gpt app version in
-`serverInfo.version` (from `versioning.VERSION`, currently `0.7.0`) — not the
+`serverInfo.version` (from `versioning.VERSION`, currently `0.8.0`) — not the
 MCP SDK version. This lets a client detect a stale process that is still
 exposing an old schema. `test_mcp_compat.py::test_initialize_advertises_server_version`
 asserts the handshake reports `versioning.VERSION` and that the pinned floor

--- a/docs/operator-mode.md
+++ b/docs/operator-mode.md
@@ -1,6 +1,6 @@
 # Operator Mode for Hermes GPT
 
-Operator Mode is the policy-gated control plane for trusted MCP clients such as ChatGPT. This document describes the current v0.7.0 behavior.
+Operator Mode is the policy-gated control plane for trusted MCP clients such as ChatGPT. This document describes the current v0.8.0 behavior, including Fabric-backed cross-machine Swarm execution.
 
 For documentation authority and historical-artifact rules, see [docs/README.md](README.md).
 
@@ -245,12 +245,23 @@ Failed validation can return a stage for one bounded rework retry. A second fail
 
 Codex may provide a bounded review verdict, but Codex is never an implementation owner. Final workflow approval is human and Owner-gated.
 
-## Flight Deck (v0.7)
+## Fabric execution (v0.8)
 
-Flight Deck adds four coordinated v0.7 capabilities on top of the v0.6
-control plane: production review evidence, structured event history, durable
-encrypted token storage, and restart reconciliation. All new surfaces are
-additive; no existing tool name, schema, or authority class changes.
+v0.8 extends Swarm execution across authenticated Hermes machines without moving completion authority to the worker. A stage using `execution.backend=auto` can be placed on an eligible local or remote runtime from the current capability snapshot; explicit backend/placement choices remain available where the workflow supports them.
+
+The packaged remote endpoint is `hermes-gpt-fabric-peer`. Loopback HTTP is permitted for same-machine development. Non-loopback peer serving requires both `--cert` and `--key`; the peer refuses insecure remote transport.
+
+Fabric routing is fail-closed. Placement considers node health and capability freshness, backend support, profile/workspace policy, and the server-controlled authority ceiling. A remote peer cannot widen the coordinator's authority. Remote worker self-report is transport data, not Work Contract completion evidence.
+
+Remote evidence and artifacts are admitted through coordinator-controlled paths. Required unavailable evidence cannot become `SATISFIED`; artifact bytes are verified before admission. Restart, timeout, and cancellation reconciliation preserve the original attempt where recovery is possible rather than silently creating a replacement writer.
+
+Flight Deck adds read-only Fabric node, placement, attempt, evidence, and routing views. The selected-route record carries the authoritative health, capability-freshness, eligibility, transport-backend, and authority-ceiling fields used to explain placement.
+
+See [v0.8.0 release notes](release-notes-v0.8.0.md) for the two-machine acceptance boundary and the known historical-timeout presentation limitation.
+
+## Flight Deck (v0.7 foundation, v0.8 Fabric views)
+
+Flight Deck began in v0.7 with production review evidence, structured event history, durable encrypted token storage, and restart reconciliation. v0.8 layers read-only Fabric nodes, placement, attempts, evidence, and routing visibility onto that foundation. Existing authority classes and final human approval remain authoritative.
 
 ### Review evidence (`hermes_review_accept`)
 
@@ -517,6 +528,7 @@ $env:HERMES_GPT_OWNER_ACK="I_UNDERSTAND_THIS_CAN_MUTATE_MY_MACHINE"
 - [Windows ChatGPT -> Codex](windows-chatgpt-codex.md)
 - [Updating](updating.md)
 - [Retention policy](retention-policy.md)
+- [v0.8.0 release notes](release-notes-v0.8.0.md)
 - [v0.7.0 release notes](release-notes-v0.7.0.md)
 - [v0.6.0 release notes](release-notes-v0.6.0.md)
 

--- a/docs/release-notes-v0.8.0.md
+++ b/docs/release-notes-v0.8.0.md
@@ -1,0 +1,69 @@
+# Hermes GPT v0.8.0 - Fabric
+
+G7 Owner ship authorization: 2026-08-21, recorded on [issue #27](https://github.com/asimons81/hermes-gpt/issues/27).
+
+Hermes GPT v0.8.0 turns the v0.7 control plane into a local-first distributed execution fabric. A bounded Swarm stage can execute on another authenticated Hermes machine while the coordinator preserves Work Contract semantics, server-controlled authority, observed-state evidence, review independence, and final human approval.
+
+Remote worker self-report remains transport data. It is never sufficient proof of completion.
+
+## Cross-machine Fabric execution
+
+- Added the packaged `hermes-gpt-fabric-peer` runtime for authenticated A2A/Fabric peers.
+- Swarm execution can use `execution.backend=auto` to select a local or remote runtime from current node capabilities while preserving explicit operator overrides.
+- Non-loopback Fabric peer serving requires direct TLS with both `--cert` and `--key`; insecure remote transport fails closed.
+- Remote placement preserves the selected profile, logical workspace, execution backend, and authority ceiling rather than trusting the peer to widen them.
+
+## Capability-aware routing
+
+- Added durable node capability manifests, health and freshness tracking, deterministic ranking, and exclusion reasons.
+- Automatic routing respects capability freshness, backend availability, remote/local placement, profile policy, workspace constraints, and authority ceilings.
+- Final routing receipts retain the authoritative selected-node fields used by Flight Deck, including health, capability freshness, eligibility, transport backend, and authority ceiling.
+
+## Remote evidence and artifacts
+
+- Added remote evidence collection and admission paths that feed the existing Work Contract validator.
+- Missing or unavailable required Fabric evidence fails closed and cannot become `SATISFIED`.
+- Added immutable remote artifact transfer/admission with manifest and content hashing. Coordinator-side admission verifies the received bytes rather than accepting a worker claim.
+- Verified remote artifacts can satisfy contract artifact requirements without bypassing the existing observed-state validation boundary.
+
+## Reconciliation and single-writer safety
+
+- Added restart, timeout, and cancellation reconciliation for distributed attempts.
+- Recoverable transport ambiguity reconciles the original attempt instead of silently creating a replacement attempt.
+- Added write-ownership and write-epoch protections for remote mutation-capable execution paths.
+- Duplicate-writer and ambiguous-attempt conditions fail closed.
+
+## Flight Deck Fabric visibility
+
+- Added read-only Fabric views for nodes, placement, attempts, evidence, and routing history.
+- Flight Deck surfaces the selected node/backend/transport and the route fields that made the placement eligible.
+- v0.8 includes the final route-truthfulness repair so a selected healthy/fresh/eligible route is no longer rendered as unhealthy merely because older receipt fields were absent.
+
+## G6 two-machine acceptance
+
+The final Fabric implementation target `4953c5f23db8d356365af8e18148e63d3c80125c` passed fresh real two-machine acceptance. The authoritative G6 evidence packet and independent-review result are recorded on [issue #37](https://github.com/asimons81/hermes-gpt/issues/37). The acceptance used distinct Linux machines, an authenticated remote Fabric peer, `execution.backend=auto`, real remote Pi RPC execution, an induced live transport interruption, same-attempt reconciliation, remote artifact admission with an independent coordinator re-hash, fail-closed missing-evidence behavior, Work Contract validation, the approval gate, and an independent final review.
+
+Independent review verdict: `PASS`; G6 closure blocked: `NO`. G7 Owner ship authorization is recorded on [issue #27](https://github.com/asimons81/hermes-gpt/issues/27).
+
+## Additional changes since v0.7.0
+
+- Added `hermes_export_file`, a bounded workspace-authorized binary export surface with denied-path enforcement, symlink escape refusal, size caps, optional extension allowlisting, and safe audit metadata.
+- Added the OpenAI Secure MCP Tunnel deployment path for private ChatGPT/Codex/OpenAI access while Hermes GPT stays loopback-bound.
+- Pinned the MCP SDK to the FastMCP-compatible 1.x line because MCP 2.x removes `mcp.server.fastmcp`.
+- Hardened fleet dispatch timeout recovery so submitted work remains pollable when the initial request times out.
+- Removed wildcard proxy trust from the curated Codex MCP HTTP runner.
+- Made disabled OIDC discovery return a public 404 instead of an auth challenge.
+- Hardened Operator doctor gateway health so a heartbeat without a live gateway PID fails closed.
+- Hardened Hermes Agent source-root detection against stray namespace `tools/` directories.
+
+## Known presentation limitation
+
+A reconciled Fabric attempt that ultimately reaches `COMPLETED` can still retain the historical `FABRIC_TRANSPORT_TIMEOUT` in the Flight Deck blocker/error presentation. The timeout is real historical evidence, but presenting it as a current blocker after successful reconciliation is misleading. Independent G6 review classified this as non-blocking because terminal peer evidence, artifact admission, coordinator validation, and workflow state independently establish successful completion.
+
+## Safety and compatibility
+
+- Hermes GPT remains local-first and intended for trusted-machine/private-boundary deployment.
+- Server-controlled authority remains authoritative across remote execution.
+- Work Contract validation remains observed-state based and fail-closed.
+- Final workflow approval remains explicitly human/Owner gated.
+- A GitHub release and a PyPI release are separate distribution channels; verify the published version on each channel.

--- a/operator_diagnostics.py
+++ b/operator_diagnostics.py
@@ -788,25 +788,34 @@ def _find_secret_files(workdir: Path) -> list[str]:
     """Return relative paths of secret-looking files under workdir."""
     secret_names = op.DEFAULT_DENIED_BASENAMES | op.DEFAULT_DENIED_DIR_NAMES
     secret_substrings = op.SECRET_PATH_SUBSTRINGS
+    allowed_source_paths = {
+        Path("web/src/shared/tokens.ts"),
+        Path("web/src/shared/tokens.css"),
+    }
     found: list[str] = []
     for root, dirs, files in os.walk(workdir):
         root_path = Path(root)
         # Skip git internals, caches, and local virtualenvs (dev artifacts
         # that are never shipped; third-party packages inside them can contain
         # secret-like filenames, e.g. keyring/credentials.py).
-        dirs[:] = [d for d in dirs if d not in {".git", "__pycache__", ".pytest_cache", "node_modules", ".venv", "venv", ".tox", ".nox"}]
+        dirs[:] = [d for d in dirs if d not in {".git", ".worktrees", "__pycache__", ".pytest_cache", "node_modules", ".venv", "venv", ".tox", ".nox"}]
         for name in files:
             lower = name.lower()
             if name in secret_names or lower.startswith(".env.") or name == ".env":
                 found.append(str(root_path / name))
                 continue
+            candidate = root_path / name
+            try:
+                rel_candidate = candidate.relative_to(workdir)
+            except ValueError:
+                rel_candidate = None
             # The substring heuristic targets secret-bearing data files
-            # (tokens.json, oauth-store.json, credentials.yaml, ...). Source
-            # modules and markdown docs are legitimate even when their names
-            # contain "oauth"/"token"/"secret" (oauth_auth.py, token_store.py,
-            # docs/oauth.md), so they are exempt from the substring scan —
-            # exact-name checks above still apply to them.
-            if lower.endswith((".py", ".md")):
+            # (tokens.json, oauth-store.json, credentials.yaml, ...). Python
+            # source and markdown docs are legitimate even when their names
+            # contain "oauth"/"token"/"secret". The two known web design-token
+            # source assets are separately allowlisted by exact repository path;
+            # similarly named files elsewhere remain subject to the scan.
+            if lower.endswith((".py", ".md")) or rel_candidate in allowed_source_paths:
                 continue
             for sub in secret_substrings:
                 if sub in lower:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-gpt"
-version = "0.7.0"
+version = "0.8.0"
 description = "Local-dev MCP sidecar for exposing selected Hermes Agent capabilities."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -107,6 +107,7 @@ py-modules = [
   "docs/release-notes-v0.5.0.md",
   "docs/release-notes-v0.6.0.md",
   "docs/release-notes-v0.7.0.md",
+  "docs/release-notes-v0.8.0.md",
   "docs/retention-policy.md",
   "docs/windows-chatgpt-codex.md",
   "docs/ui-security-boundary.md",

--- a/test_operator_diagnostics.py
+++ b/test_operator_diagnostics.py
@@ -328,6 +328,47 @@ def test_release_doctor_allows_source_modules_with_secret_like_names(tmp_path, m
     assert not any("oauth" in issue.lower() or "token" in issue.lower() for issue in parsed["blocking_issues"])
 
 
+def test_release_doctor_allows_web_source_files_with_secret_like_names(tmp_path, monkeypatch):
+    """Design-token source files are code/assets, not secret-bearing data files."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    shared = repo / "web" / "src" / "shared"
+    shared.mkdir(parents=True)
+    (shared / "tokens.ts").write_text("export const spacing = 8;\n", encoding="utf-8")
+    (shared / "tokens.css").write_text(":root { --spacing: 8px; }\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(f'version = "{od.VERSION}"\n', encoding="utf-8")
+    out = od.hermes_release_doctor(workdir=str(repo), full_tests=False)
+    parsed = json.loads(out)
+    assert parsed["success"] is True
+    assert not any("tokens.ts" in issue or "tokens.css" in issue for issue in parsed["blocking_issues"])
+
+
+def test_release_doctor_blocks_secret_like_web_source_outside_allowlist(tmp_path, monkeypatch):
+    """A similarly named source file outside the exact design-token paths stays blocked."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "tokens.ts").write_text("export const value = 'fixture';\n", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(f'version = "{od.VERSION}"\n', encoding="utf-8")
+    out = od.hermes_release_doctor(workdir=str(repo), full_tests=False)
+    parsed = json.loads(out)
+    assert parsed["status"] == "BLOCKED"
+    assert any("tokens.ts" in issue for issue in parsed["blocking_issues"])
+
+
+def test_release_doctor_ignores_local_worktree_container(tmp_path, monkeypatch):
+    """Nested local worktrees are dev artifacts and are never release payloads."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    local_tree = repo / ".worktrees" / "scratch"
+    local_tree.mkdir(parents=True)
+    (local_tree / "tokens.json").write_text("{}", encoding="utf-8")
+    (repo / "pyproject.toml").write_text(f'version = "{od.VERSION}"\n', encoding="utf-8")
+    out = od.hermes_release_doctor(workdir=str(repo), full_tests=False)
+    parsed = json.loads(out)
+    assert parsed["success"] is True
+    assert not any(".worktrees" in issue for issue in parsed["blocking_issues"])
+
+
 def test_release_doctor_warns_on_dirty_tree(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/test_package_hygiene.py
+++ b/test_package_hygiene.py
@@ -218,12 +218,13 @@ def test_sdist_does_not_ship_internal_docs(built_artifacts):
     )
     assert any("docs/release-notes-v0.6.0.md" in n for n in names), "sdist missing public release notes"
     assert any("docs/release-notes-v0.7.0.md" in n for n in names), "sdist missing v0.7 public release notes"
+    assert any("docs/release-notes-v0.8.0.md" in n for n in names), "sdist missing v0.8 public release notes"
     assert any("docs/retention-policy.md" in n for n in names), "sdist missing public retention policy"
     assert any("docs/mcp-compatibility.md" in n for n in names), "sdist missing public MCP compatibility manifest"
 
 
 def test_wheel_contains_public_docs_and_all_py_modules(built_artifacts):
-    """Proof 10: wheel ships v0.7 docs and every declared top-level module."""
+    """Proof 10: wheel ships current public docs and every declared top-level module."""
     try:
         import tomllib
     except ModuleNotFoundError:
@@ -237,6 +238,7 @@ def test_wheel_contains_public_docs_and_all_py_modules(built_artifacts):
     for suffix in (
         "share/hermes-gpt/docs/mcp-compatibility.md",
         "share/hermes-gpt/docs/release-notes-v0.7.0.md",
+        "share/hermes-gpt/docs/release-notes-v0.8.0.md",
     ):
         assert any(n.endswith(suffix) for n in names), f"wheel missing data file: {suffix}"
     with open(REPO_ROOT / "pyproject.toml", "rb") as fh:

--- a/test_ui_security.py
+++ b/test_ui_security.py
@@ -276,7 +276,7 @@ def test_me_endpoint_loopback_ok(ui_root, monkeypatch):
     assert data["accountStatus"] == "ok"
     assert data["operatorLevel"] == "read_only"
     assert data["profile"] == "default"
-    assert data["serverVersion"] == "0.7.0"
+    assert data["serverVersion"] == server.VERSION
     assert data["allowedSurfaces"] == sorted(op_mission.MISSION_SURFACES)
     assert data["uiCapabilities"][:3] == ["chat", "flight", "events"]
     assert "approvals" not in data["uiCapabilities"]  # read_only level gate


### PR DESCRIPTION
## Hermes GPT v0.8.0 - Fabric release prep

Release-only delta on top of independently certified Fabric implementation target 4953c5f23db8d356365af8e18148e63d3c80125c.

- bumps package/runtime version to 0.8.0
- adds public v0.8 Fabric release notes and release body
- updates current operational docs
- wires v0.8 notes into wheel and source distribution
- fixes release-doctor false positives for the two known web design-source files while retaining strict scanning elsewhere
- updates release-version and package-hygiene regressions

G6 evidence: #37 PASS, independently reviewed, closed.
G7 Owner ship approval: #27 explicitly authorized 2026-08-21.
Full pytest PASS with two skips. Release doctor PASS with no warnings or blockers. Twine check PASS. Package hygiene CLEAN. Independent release-prep review PASS and does not block release.

No Fabric runtime, Work Contract, authority, evidence, Swarm, or reconciliation semantics are changed by this PR.