### PR TITLE
feat(v0.9): integrate Flight Deck Missions on current master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           operator_mission_runtime.py test_operator_mission_runtime.py
           operator_live_events.py test_operator_live_events.py
           tools/check_package_hygiene.py test_package_hygiene.py
-          ui_api.py ui_fabric.py
+          ui_api.py ui_fabric.py ui_missions.py test_ui_missions.py
 
   web:
     runs-on: ubuntu-latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ PyPI is an independent distribution channel. Check the PyPI badge in the root RE
 | [`operator-mode.md`](operator-mode.md) | current | Operator / Owner policy, Mission Control, fleet routing, Work Contracts, Swarm Orchestration, v0.8 Fabric execution, and Flight Deck surfaces |
 | [`missions.md`](missions.md) | current | v0.9 first-class Mission lifecycle, bounded context/skills manifests, attachments, reconciliation, and Owner approval |
 | [`live-events.md`](live-events.md) | current | v0.9 durable event cursor/long-poll and authenticated WebSocket wake-up stream |
+| [`flight-deck-missions.md`](flight-deck-missions.md) | current | v0.9 read-only Mission/delegation Flight Deck views with durable live refresh |
 | [`delegations.md`](delegations.md) | current | v0.9 normalized delegation lifecycle across Pi/OpenCode/Codex/Fabric with durable lineage and reconciliation |
 | [`codex.md`](codex.md) | current | Codex-as-MCP-client setup and delegated Codex CLI jobs |
 | [`windows-chatgpt-codex.md`](windows-chatgpt-codex.md) | current | Windows ChatGPT -> Hermes GPT -> Codex CLI deployment |

--- a/docs/flight-deck-coverage.md
+++ b/docs/flight-deck-coverage.md
@@ -7,6 +7,10 @@ The current policy contract remains [Operator Mode](operator-mode.md).
 
 ## Reachable read surfaces
 
+- [x] v0.9 first-class Missions through `GET /api/ops/missions`, Mission detail,
+  Mission-filtered cursor/long-poll wakeups, and delegation detail. The browser
+  re-reads durable Mission state after a wakeup and exposes no Mission mutation
+  path.
 - [x] Mission Control: overview, health, profiles, fleet, Codex, cron,
   delegations, failures, approvals, vault, usage, and audit through
   `GET /api/ops/:surface`.

--- a/docs/flight-deck-missions.md
+++ b/docs/flight-deck-missions.md
@@ -1,0 +1,22 @@
+# Flight Deck Missions (v0.9)
+
+Flight Deck exposes first-class Missions as a read-only operational view. The browser does not gain Mission mutation, dispatch, cancellation, reconciliation, or approval authority.
+
+## Routes
+
+- `GET /api/ops/missions` — bounded Mission list with current durable state.
+- `GET /api/ops/missions/{mission_id}` — durable Mission detail plus linked delegation summaries.
+- `GET /api/ops/missions/{mission_id}/events` — bounded cursor/long-poll wake-up events filtered to one Mission.
+- `GET /api/ops/delegations/{delegation_id}` — one normalized delegation read model.
+
+All browser payloads pass through the existing Flight Deck redaction boundary. Mission and Delegation stores remain authoritative; live-event payloads are wake-up notices only. The detail screen responds to a wake-up by re-reading durable Mission state rather than treating the event payload as completion evidence.
+
+## Visible Mission state
+
+The Mission list/detail screens expose bounded title/objective metadata, owner profile, status/version, acceptance criteria, context references and digests, explicit skills manifests, approval presence/requirement, attachments, linked delegation state, and recent Mission events.
+
+The detail endpoint captures its live-event cursor before reading the Mission snapshot. This prevents a state transition racing with the snapshot from being skipped: the change is either already reflected in the durable snapshot or remains after the returned cursor and wakes the browser for another durable read.
+
+## Authority boundary
+
+The Mission UI contains no direct mutation controls. State transitions, attachment writes, reconciliation, delegation dispatch/cancel, and Owner approval continue through their existing operator surfaces and policy gates. Flight Deck is presentation and observation only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ py-modules = [
   "ui_chat",
   "ui_ops",
   "ui_fabric",
+  "ui_missions",
 ]
 
 [tool.setuptools.data-files]
@@ -118,6 +119,7 @@ py-modules = [
   "docs/windows-chatgpt-codex.md",
   "docs/ui-security-boundary.md",
   "docs/flight-deck-coverage.md",
+  "docs/flight-deck-missions.md",
 ]
 "share/hermes-gpt/examples" = [
   "examples/start-hermes-gpt.example.ps1",

--- a/test_ui_missions.py
+++ b/test_ui_missions.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+import operator_live_events as live_events
+import operator_mission_runtime as missions
+import operator_policy as op
+import ui_api
+import ui_missions
+
+
+def _spec(mission_id: str = "msn-ui-test") -> str:
+    return json.dumps(
+        {
+            "schema": missions.MISSION_SPEC_SCHEMA,
+            "mission_id": mission_id,
+            "title": "Flight Deck mission",
+            "objective": "Observe mission progress without adding browser authority.",
+            "owner_profile": "default",
+            "acceptance_criteria": ["mission state visible", "delegations visible"],
+            "context_refs": [
+                {
+                    "kind": "document",
+                    "ref": "docs:v0.9-plan",
+                    "label": "v0.9 plan",
+                    "sha256": "a" * 64,
+                }
+            ],
+            "skills": [
+                {
+                    "name": "compound-engineering",
+                    "version": "1",
+                    "ref": "skill:compound-engineering",
+                }
+            ],
+            "final_approval_required": True,
+        }
+    )
+
+
+@pytest.fixture
+def mission_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = tmp_path / "hermes"
+    root.mkdir()
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv(op.OPERATOR_ENABLED_ENV, "1")
+    monkeypatch.setenv(op.OPERATOR_LEVEL_ENV, "workspace")
+    monkeypatch.setenv(op.OPERATOR_APPLY_MODE_ENV, "direct")
+    monkeypatch.setenv(op.OPERATOR_ALLOWED_PATHS_ENV, str(workspace))
+    op.set_audit_log_override(tmp_path / "audit.jsonl")
+    created = json.loads(
+        missions.hermes_mission_create(
+            _spec(),
+            confirm=True,
+            dry_run=False,
+            hermes_root=root,
+        )
+    )
+    assert created["success"] is True
+    monkeypatch.setenv(op.OPERATOR_LEVEL_ENV, "read_only")
+    return root
+
+
+def _client() -> TestClient:
+    return TestClient(Starlette(routes=ui_missions.ui_missions_routes()))
+
+
+def test_mission_routes_are_get_only_and_composed(mission_root: Path):
+    routes = ui_missions.ui_missions_routes()
+    assert routes
+    assert all(route.methods == {"GET", "HEAD"} for route in routes)
+    composed_paths = {getattr(route, "path", "") for route in ui_api.routes()}
+    assert "/api/ops/missions" in composed_paths
+    assert "/api/ops/missions/{mission_id}" in composed_paths
+    assert "/api/ops/missions/{mission_id}/events" in composed_paths
+
+
+def test_mission_list_and_detail_surface_bounded_runtime_state(
+    mission_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        ui_missions.delegations,
+        "hermes_delegation_list",
+        lambda **kwargs: json.dumps(
+            {
+                "success": True,
+                "delegations": [
+                    {
+                        "delegation_id": "dlg-ui-test",
+                        "mission_id": "msn-ui-test",
+                        "task_id": "task-ui-test",
+                        "backend": "opencode",
+                        "state": "running",
+                    }
+                ],
+                "count": 1,
+            }
+        ),
+    )
+    client = _client()
+    listed = client.get("/api/ops/missions?limit=20")
+    assert listed.status_code == 200
+    list_body = listed.json()
+    assert list_body["ok"] is True
+    assert list_body["data"]["count"] == 1
+    assert list_body["data"]["missions"][0]["mission_id"] == "msn-ui-test"
+    assert list_body["data"]["read_only"] is True
+
+    detail = client.get("/api/ops/missions/msn-ui-test")
+    assert detail.status_code == 200
+    body = detail.json()
+    assert body["ok"] is True
+    assert body["data"]["mission"]["mission_id"] == "msn-ui-test"
+    assert body["data"]["mission"]["context_refs"][0]["sha256"] == "a" * 64
+    assert body["data"]["mission"]["skills"][0]["name"] == "compound-engineering"
+    assert body["data"]["delegations"][0]["backend"] == "opencode"
+    assert body["data"]["delegation_count"] == 1
+    assert body["data"]["read_only"] is True
+
+
+def test_mission_events_deliver_cursor_filtered_wakeup(mission_root: Path):
+    published = live_events.publish_event(
+        topic="mission",
+        kind="mission.test",
+        subject_type="mission",
+        subject_id="msn-ui-test",
+        mission_id="msn-ui-test",
+        source="test-ui-missions",
+        payload={"state": "running"},
+        hermes_root=mission_root,
+    )
+    assert published["mission_id"] == "msn-ui-test"
+    client = _client()
+    response = client.get("/api/ops/missions/msn-ui-test/events?cursor=0&limit=10")
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["count"] >= 1
+    assert any(event["mission_id"] == "msn-ui-test" for event in body["events"])
+    assert body["next_cursor"] >= 1
+    assert body["read_only"] is True
+
+
+def test_delegation_detail_uses_existing_read_surface(
+    mission_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        ui_missions.delegations,
+        "hermes_delegation_get",
+        lambda delegation_id, hermes_root=None: json.dumps(
+            {
+                "success": True,
+                "delegation": {
+                    "delegation_id": delegation_id,
+                    "task_id": "task-ui-test",
+                    "backend": "pi_rpc",
+                    "state": "succeeded",
+                },
+            }
+        ),
+    )
+    response = _client().get("/api/ops/delegations/dlg-ui-test")
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["delegation"]["state"] == "succeeded"
+    assert body["read_only"] is True
+
+
+def test_missing_mission_returns_not_found(mission_root: Path):
+    response = _client().get("/api/ops/missions/msn-missing")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "MISSION_NOT_FOUND"

--- a/ui_api.py
+++ b/ui_api.py
@@ -9,6 +9,7 @@ does not implement feature routes. Each feature card contributes a
 - ``ui_chat_routes()``     — sessions + chat SSE
 - ``ui_ops_routes()``      — operator adapters + gated mutations
 - ``ui_fabric_routes()``   — Fabric distributed read models, GET-only
+- ``ui_missions_routes()`` — v0.9 Mission/delegation live read models, GET-only
 
 The registry composes whatever sibling modules are present. In parallel
 worktrees a sibling module may be absent mid-build; a missing or broken
@@ -155,7 +156,7 @@ def routes() -> list[BaseRoute]:
     result: list[BaseRoute] = []
     # Security/boundary routes are the skeleton every card builds against;
     # chat, Flight Deck, and Fabric read models compose in as sibling modules.
-    for module_name in ("ui_security", "ui_chat", "ui_ops", "ui_fabric"):
+    for module_name in ("ui_security", "ui_chat", "ui_ops", "ui_fabric", "ui_missions"):
         result.extend(_sibling_routes(module_name))
     result.extend(_static_routes())
     return result

--- a/ui_missions.py
+++ b/ui_missions.py
@@ -1,0 +1,156 @@
+"""Read-only browser adapters for v0.9 first-class Missions.
+
+This module adds Flight Deck visibility only. It adapts the existing Mission,
+Delegation, and live-event read surfaces into browser JSON and does not add any
+mutation path or authority.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+import operator_delegations as delegations
+import operator_live_events as live_events
+import operator_mission_runtime as missions
+import ui_security
+
+_MAX_MISSIONS = 200
+_MAX_EVENTS = 100
+_MAX_WAIT_MS = 25_000
+
+
+def _root() -> Any:
+    return missions._root(None)
+
+
+def _decode(value: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("operator read surface returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise TypeError("operator read surface returned an invalid payload")
+    return payload
+
+
+def _success(payload: dict[str, Any]) -> bool:
+    return bool(payload.get("success"))
+
+
+def _error(payload: dict[str, Any], *, fallback: str, status: int = 400) -> JSONResponse:
+    code = str(payload.get("code") or fallback)[:96]
+    message = str(payload.get("safe_message") or payload.get("error") or "Mission read failed")[:500]
+    return ui_security.err(code, message, status_code=status)
+
+
+def _clamp(value: Any, default: int, low: int, high: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(low, min(parsed, high))
+
+
+def _mission_list(request: Request) -> JSONResponse:
+    limit = _clamp(request.query_params.get("limit"), 100, 1, _MAX_MISSIONS)
+    status = str(request.query_params.get("status") or "")[:64]
+    payload = _decode(missions.hermes_mission_list(status=status, limit=limit, hermes_root=_root()))
+    if not _success(payload):
+        return _error(payload, fallback="MISSION_LIST_FAILED")
+    data = {
+        "schema_version": payload.get("schema_version"),
+        "missions": payload.get("missions") if isinstance(payload.get("missions"), list) else [],
+        "count": int(payload.get("count") or 0),
+        "live_cursor": live_events.high_watermark(_root()),
+        "read_only": True,
+    }
+    return JSONResponse(ui_security.ok(data))
+
+
+def _mission_detail(request: Request) -> JSONResponse:
+    mission_id = str(request.path_params.get("mission_id") or "")[:128]
+    # Capture the event cursor before reading durable Mission state. An event
+    # racing with this read will therefore either already be represented in the
+    # snapshot or remain visible to the browser's next long-poll; it cannot be
+    # skipped by advancing the cursor after the snapshot.
+    start_cursor = live_events.high_watermark(_root())
+    payload = _decode(missions.hermes_mission_get(mission_id, hermes_root=_root()))
+    if not _success(payload):
+        message = str(payload.get("safe_message") or payload.get("error") or "")
+        if "not found" in message.lower():
+            return ui_security.err("MISSION_NOT_FOUND", "Mission was not found", status_code=404)
+        return _error(payload, fallback="MISSION_READ_FAILED")
+    if payload.get("found") is False:
+        return ui_security.err("MISSION_NOT_FOUND", "Mission was not found", status_code=404)
+
+    delegation_payload = _decode(
+        delegations.hermes_delegation_list(mission_id=mission_id, limit=200, hermes_root=_root())
+    )
+    delegation_rows = (
+        delegation_payload.get("delegations")
+        if _success(delegation_payload) and isinstance(delegation_payload.get("delegations"), list)
+        else []
+    )
+    data = {
+        "mission": {key: value for key, value in payload.items() if key != "success"},
+        "delegations": delegation_rows,
+        "delegation_count": len(delegation_rows),
+        "live_cursor": start_cursor,
+        "read_only": True,
+    }
+    return JSONResponse(ui_security.ok(data))
+
+
+async def _mission_events(request: Request) -> JSONResponse:
+    mission_id = str(request.path_params.get("mission_id") or "")[:128]
+    cursor = _clamp(request.query_params.get("cursor"), 0, 0, 2**63 - 1)
+    limit = _clamp(request.query_params.get("limit"), 100, 1, _MAX_EVENTS)
+    wait_ms = _clamp(request.query_params.get("wait_ms"), 0, 0, _MAX_WAIT_MS)
+    payload = await run_in_threadpool(
+        live_events.hermes_live_events_since,
+        cursor,
+        mission_id,
+        "",
+        "",
+        limit,
+        wait_ms,
+        _root(),
+    )
+    decoded = _decode(payload)
+    if not _success(decoded):
+        return _error(decoded, fallback="LIVE_EVENT_READ_FAILED")
+    data = {
+        "cursor": int(decoded.get("cursor") or 0),
+        "next_cursor": int(decoded.get("next_cursor") or cursor),
+        "high_watermark": int(decoded.get("high_watermark") or 0),
+        "events": decoded.get("events") if isinstance(decoded.get("events"), list) else [],
+        "count": int(decoded.get("count") or 0),
+        "read_only": True,
+    }
+    return JSONResponse(ui_security.ok(data))
+
+
+def _delegation_detail(request: Request) -> JSONResponse:
+    delegation_id = str(request.path_params.get("delegation_id") or "")[:128]
+    payload = _decode(delegations.hermes_delegation_get(delegation_id, hermes_root=_root()))
+    if not _success(payload):
+        return _error(payload, fallback="DELEGATION_GET_FAILED", status=404)
+    return JSONResponse(ui_security.ok({"delegation": payload.get("delegation"), "read_only": True}))
+
+
+def ui_missions_routes() -> list[Route]:
+    return [
+        Route("/api/ops/missions", _mission_list, methods=["GET"]),
+        Route("/api/ops/missions/{mission_id}/events", _mission_events, methods=["GET"]),
+        Route("/api/ops/missions/{mission_id}", _mission_detail, methods=["GET"]),
+        Route("/api/ops/delegations/{delegation_id}", _delegation_detail, methods=["GET"]),
+    ]
+
+
+__all__ = ["ui_missions_routes"]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { DeckOverview } from './flight/DeckOverview';
 import { EventHistoryPanel } from './flight/EventHistoryPanel';
 import { FabricAttemptDetail, FabricPanel } from './flight/FabricPanel';
 import { FleetPanel } from './flight/FleetPanel';
+import { MissionDetail, MissionsPanel } from './flight/MissionsPanel';
 import { SURFACE_SCHEMAS } from './flight/schemas';
 import { SurfacePanel } from './flight/SurfacePanel';
 import { SwarmDetail, SwarmMonitor } from './flight/SwarmMonitor';
@@ -19,7 +20,7 @@ function FlightNav() {
       <Link to="/chat" className="fd-nav-brand">HERMES</Link>
       <div className="fd-nav-links">
         <Link to="/chat">Chat</Link><Link to="/ops">Deck</Link><Link to="/events">Events</Link>
-        <Link to="/ops/contracts">Contracts</Link><Link to="/ops/swarm">Swarm</Link><Link to="/ops/fabric">Fabric</Link><Link to="/account">Account</Link>
+        <Link to="/ops/missions">Missions</Link><Link to="/ops/contracts">Contracts</Link><Link to="/ops/swarm">Swarm</Link><Link to="/ops/fabric">Fabric</Link><Link to="/account">Account</Link>
       </div>
     </nav>
   );
@@ -33,6 +34,7 @@ function OpsSurface() {
       const element = surface === 'approvals' ? <ApprovalsPanel /> : surface === 'fleet' ? <FleetPanel /> : schema ? <SurfacePanel schema={schema} /> : <DeckOverview />;
       return <Route key={surface} path={surface} element={element} />;
     })}
+    <Route path="missions" element={<MissionsPanel />} /><Route path="missions/:missionId" element={<MissionDetail />} />
     <Route path="contracts" element={<ContractsPanel />} /><Route path="contracts/:contractSha256" element={<ContractDetail />} />
     <Route path="swarm" element={<SwarmMonitor />} /><Route path="swarm/:workflowId" element={<SwarmDetail />} />
     <Route path="fabric" element={<FabricPanel />} /><Route path="fabric/:attemptId" element={<FabricAttemptDetail />} />

--- a/web/src/flight.css
+++ b/web/src/flight.css
@@ -289,6 +289,30 @@ body {
   flex-wrap: wrap;
 }
 
+.fd-row--subtle {
+  color: var(--fd-text-tertiary);
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.fd-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.fd-grid--2 {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.fd-label {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--fd-text-tertiary);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .fd-hint {
   margin: 4px 0 0;
   font-size: 12px;

--- a/web/src/flight/DeckOverview.tsx
+++ b/web/src/flight/DeckOverview.tsx
@@ -47,6 +47,9 @@ export function DeckOverview() {
       </div>
 
       <div className="fd-deck-links">
+        <Link className="fd-btn fd-btn--ghost" to="/ops/missions">
+          Missions
+        </Link>
         <Link className="fd-btn fd-btn--ghost" to="/events">
           Event History
         </Link>

--- a/web/src/flight/MissionsPanel.tsx
+++ b/web/src/flight/MissionsPanel.tsx
@@ -1,0 +1,161 @@
+// MissionsPanel — v0.9 first-class Mission visibility. Read-only by design.
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { api, ApiError } from '../api/client';
+import { EmptyState, ErrorState, LoadingState, PanelCard, StatusChip, safeText } from './ui';
+
+type Tone = 'ok' | 'review' | 'flight' | 'warn' | 'deny' | 'neutral';
+
+interface ContextRef { kind?: string; ref?: string; label?: string; sha256?: string }
+interface SkillRef { name?: string; version?: string; ref?: string; sha256?: string }
+interface Attachment { kind?: string; ref?: string; relationship?: string; state?: string; evidence_ref?: string; verified?: boolean | number; updated_at?: string }
+interface MissionEvent { seq?: number; event_type?: string; from_status?: string; to_status?: string; reason_sha256?: string; created_at?: string; details?: Record<string, unknown> }
+interface MissionRow {
+  mission_id: string;
+  title?: string;
+  objective?: string;
+  owner_profile?: string;
+  acceptance_criteria?: string[];
+  context_refs?: ContextRef[];
+  skills?: SkillRef[];
+  final_approval_required?: boolean;
+  status?: string;
+  version?: number;
+  approval?: Record<string, unknown>;
+  attachments?: Attachment[];
+  events?: MissionEvent[];
+  created_at?: string;
+  updated_at?: string;
+}
+interface DelegationRow {
+  delegation_id: string;
+  mission_id?: string;
+  task_id?: string;
+  contract_sha256?: string;
+  backend?: string;
+  state?: string;
+  backend_state?: string;
+  outcome?: string;
+  validation_verdict?: string;
+  cancel_requested?: boolean;
+  updated_at?: string;
+  terminal_at?: string;
+}
+interface MissionListPayload { missions?: MissionRow[]; count?: number; live_cursor?: number; read_only?: boolean }
+interface MissionDetailPayload { mission: MissionRow; delegations?: DelegationRow[]; delegation_count?: number; live_cursor?: number; read_only?: boolean }
+interface LiveEventsPayload { cursor: number; next_cursor: number; high_watermark: number; events?: Array<Record<string, unknown>>; count?: number }
+
+function tone(value: unknown): Tone {
+  const text = String(value ?? '').toLowerCase();
+  if (['succeeded', 'completed', 'approved', 'done'].includes(text)) return 'ok';
+  if (['failed', 'cancelled', 'denied'].includes(text)) return 'deny';
+  if (['blocked', 'reconciling', 'awaiting_approval'].includes(text)) return 'warn';
+  if (['running', 'queued', 'pending', 'active'].includes(text)) return 'flight';
+  if (['draft', 'paused', 'review'].includes(text)) return 'review';
+  return 'neutral';
+}
+function validationTone(value: unknown): Tone {
+  const text = String(value ?? '').toUpperCase();
+  if (text === 'SATISFIED') return 'ok';
+  if (['NOT_SATISFIED', 'UNSATISFIED', 'FAILED'].includes(text)) return 'deny';
+  return 'warn';
+}
+function compactHash(value: unknown): string { const text = String(value ?? ''); return text.length > 16 ? `${text.slice(0, 12)}…` : text; }
+function fmtTime(value: unknown): string { if (!value) return '—'; const date = new Date(String(value)); return Number.isNaN(date.getTime()) ? safeText(value, 80) : date.toLocaleString(); }
+function errorText(err: unknown, fallback: string): string { return err instanceof ApiError ? `${err.code}: ${err.message}` : fallback; }
+
+export function MissionsPanel() {
+  const [payload, setPayload] = useState<MissionListPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const load = async () => {
+    setError(null);
+    try { setPayload(await api.get<MissionListPayload>('/api/ops/missions?limit=100')); }
+    catch (err: unknown) { setError(errorText(err, 'Mission list failed')); }
+  };
+  useEffect(() => {
+    void load();
+    const timer = window.setInterval(() => void load(), 10_000);
+    return () => window.clearInterval(timer);
+  }, []);
+  const rows = payload?.missions ?? [];
+  return <section className="fd-surface" data-surface="missions" data-testid="missions-panel">
+    <header className="fd-surface-head"><h2>Missions</h2><p className="fd-surface-desc">First-class v0.9 Mission state and lineage. This screen is observational; execution and approval authority remain in gated operator tools.</p></header>
+    {!payload && !error ? <LoadingState label="Loading Missions…" /> : null}
+    {error ? <ErrorState message={error} onRetry={() => void load()} /> : null}
+    {payload ? <PanelCard title={`Missions (${rows.length})`}>
+      {rows.length === 0 ? <EmptyState label="No durable Missions" /> : <ul className="fd-list">{rows.map((mission) => <li className="fd-list-item" key={mission.mission_id}>
+        <div className="fd-row"><Link to={`/ops/missions/${encodeURIComponent(mission.mission_id)}`}><strong>{safeText(mission.title || mission.mission_id, 120)}</strong></Link><StatusChip tone={tone(mission.status)} label={safeText(mission.status || 'unknown', 40)} /></div>
+        <div className="fd-row fd-row--subtle"><span>{safeText(mission.mission_id, 96)}</span><span>owner {safeText(mission.owner_profile || 'default', 64)}</span><span>updated {fmtTime(mission.updated_at)}</span></div>
+        {mission.objective ? <p className="fd-hint">{safeText(mission.objective, 260)}</p> : null}
+      </li>)}</ul>}
+    </PanelCard> : null}
+  </section>;
+}
+
+export function MissionDetail() {
+  const { missionId = '' } = useParams();
+  const [payload, setPayload] = useState<MissionDetailPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [liveState, setLiveState] = useState<'connecting' | 'live' | 'retrying'>('connecting');
+  useEffect(() => {
+    let active = true;
+    let cursor = 0;
+    const snapshot = async (): Promise<number> => {
+      const data = await api.get<MissionDetailPayload>(`/api/ops/missions/${encodeURIComponent(missionId)}`);
+      if (active) { setPayload(data); setError(null); }
+      return Number(data.live_cursor ?? cursor);
+    };
+    const run = async () => {
+      try { cursor = await snapshot(); } catch (err: unknown) { if (active) setError(errorText(err, 'Mission detail failed')); return; }
+      if (active) setLiveState('live');
+      while (active) {
+        try {
+          const events = await api.get<LiveEventsPayload>(`/api/ops/missions/${encodeURIComponent(missionId)}/events?cursor=${cursor}&limit=100&wait_ms=15000`);
+          cursor = Number(events.next_cursor ?? cursor);
+          if (!active) return;
+          setLiveState('live');
+          if ((events.count ?? 0) > 0) cursor = Math.max(cursor, await snapshot());
+        } catch (err: unknown) {
+          if (!active) return;
+          setLiveState('retrying');
+          setError(errorText(err, 'Mission live update failed'));
+          await new Promise((resolve) => window.setTimeout(resolve, 1500));
+        }
+      }
+    };
+    void run();
+    return () => { active = false; };
+  }, [missionId]);
+  const mission = payload?.mission;
+  const attachments = mission?.attachments ?? [];
+  const delegations = payload?.delegations ?? [];
+  const events = mission?.events ?? [];
+  const context = mission?.context_refs ?? [];
+  const skills = mission?.skills ?? [];
+  const acceptance = mission?.acceptance_criteria ?? [];
+  return <section className="fd-surface" data-surface="mission-detail" data-testid="mission-detail">
+    <header className="fd-surface-head">
+      <div className="fd-row"><h2>{safeText(mission?.title || missionId, 140)}</h2>{mission ? <StatusChip tone={tone(mission.status)} label={safeText(mission.status || 'unknown', 40)} /> : null}<StatusChip tone={liveState === 'live' ? 'ok' : 'warn'} label={liveState === 'live' ? 'live updates' : liveState} /></div>
+      <p className="fd-surface-desc">Durable Mission snapshot with live wake-up refresh. Read-only presentation; state transitions and approvals remain gated elsewhere.</p>
+      <Link className="fd-btn fd-btn--ghost" to="/ops/missions">← Missions</Link>
+    </header>
+    {!payload && !error ? <LoadingState label="Loading Mission…" /> : null}
+    {error ? <ErrorState message={error} /> : null}
+    {mission ? <>
+      <PanelCard title="Mission">
+        <div className="fd-grid fd-grid--2"><div><span className="fd-label">Mission ID</span><div>{safeText(mission.mission_id, 120)}</div></div><div><span className="fd-label">Owner</span><div>{safeText(mission.owner_profile || 'default', 80)}</div></div><div><span className="fd-label">Version</span><div>{String(mission.version ?? '—')}</div></div><div><span className="fd-label">Updated</span><div>{fmtTime(mission.updated_at)}</div></div></div>
+        {mission.objective ? <><span className="fd-label">Objective</span><p>{safeText(mission.objective, 900)}</p></> : null}
+        <div className="fd-row fd-row--subtle"><span>final approval {mission.final_approval_required ? 'required' : 'not required'}</span>{mission.approval && Object.keys(mission.approval).length > 0 ? <span>approval record present</span> : null}</div>
+      </PanelCard>
+      <div className="fd-grid fd-grid--2">
+        <PanelCard title={`Acceptance criteria (${acceptance.length})`}>{acceptance.length ? <ul className="fd-list">{acceptance.map((item, index) => <li key={`${index}-${item}`} className="fd-list-item">{safeText(item, 500)}</li>)}</ul> : <EmptyState />}</PanelCard>
+        <PanelCard title={`Context (${context.length})`}>{context.length ? <ul className="fd-list">{context.map((item, index) => <li className="fd-list-item" key={`${item.ref ?? index}`}><strong>{safeText(item.label || item.ref || item.kind || 'context', 160)}</strong><div className="fd-row fd-row--subtle"><span>{safeText(item.kind || 'ref', 48)}</span><span>{safeText(item.ref || '', 180)}</span>{item.sha256 ? <span>sha {compactHash(item.sha256)}</span> : null}</div></li>)}</ul> : <EmptyState />}</PanelCard>
+      </div>
+      <PanelCard title={`Skills (${skills.length})`}>{skills.length ? <ul className="fd-list">{skills.map((skill, index) => <li className="fd-list-item" key={`${skill.name ?? index}-${skill.version ?? ''}`}><div className="fd-row"><strong>{safeText(skill.name || 'skill', 120)}</strong>{skill.version ? <span>v{safeText(skill.version, 40)}</span> : null}</div><div className="fd-row fd-row--subtle">{skill.ref ? <span>{safeText(skill.ref, 180)}</span> : null}{skill.sha256 ? <span>sha {compactHash(skill.sha256)}</span> : null}</div></li>)}</ul> : <EmptyState label="No explicit skills manifest" />}</PanelCard>
+      <PanelCard title={`Delegations (${delegations.length})`}>{delegations.length ? <ul className="fd-list">{delegations.map((delegation) => <li className="fd-list-item" key={delegation.delegation_id}><div className="fd-row"><strong>{safeText(delegation.delegation_id, 110)}</strong><span className="fd-label">Execution</span><StatusChip tone={tone(delegation.state)} label={safeText(delegation.state || 'unknown', 40)} /><span className="fd-label">Validation</span><StatusChip tone={validationTone(delegation.validation_verdict)} label={safeText(delegation.validation_verdict || 'UNVERIFIED', 64)} /><span>{safeText(delegation.backend || 'runner', 64)}</span></div><div className="fd-row fd-row--subtle">{delegation.task_id ? <span>task {safeText(delegation.task_id, 110)}</span> : null}{delegation.backend_state ? <span>backend {safeText(delegation.backend_state, 80)}</span> : null}<span>updated {fmtTime(delegation.updated_at)}</span></div></li>)}</ul> : <EmptyState label="No linked delegations" />}</PanelCard>
+      <PanelCard title={`Attachments (${attachments.length})`}>{attachments.length ? <ul className="fd-list">{attachments.map((attachment, index) => <li className="fd-list-item" key={`${attachment.kind ?? ''}-${attachment.ref ?? index}`}><div className="fd-row"><strong>{safeText(attachment.kind || 'attachment', 64)}</strong><StatusChip tone={tone(attachment.state)} label={safeText(attachment.state || 'unknown', 40)} />{attachment.state === 'succeeded' ? <StatusChip tone={Boolean(attachment.verified) ? 'ok' : 'warn'} label={Boolean(attachment.verified) ? 'verified evidence' : 'verification missing'} /> : null}<span>{safeText(attachment.ref || '', 180)}</span></div><div className="fd-row fd-row--subtle">{attachment.relationship ? <span>{safeText(attachment.relationship, 80)}</span> : null}{attachment.evidence_ref ? <span>evidence {safeText(attachment.evidence_ref, 160)}</span> : null}</div></li>)}</ul> : <EmptyState label="No Mission attachments" />}</PanelCard>
+      <PanelCard title={`Mission events (${events.length})`}>{events.length ? <ul className="fd-list">{events.slice(0, 50).map((event, index) => <li className="fd-list-item" key={`${event.seq ?? index}-${event.event_type ?? ''}`}><div className="fd-row"><strong>{safeText(event.event_type || 'mission.event', 100)}</strong><span>{fmtTime(event.created_at)}</span></div><div className="fd-row fd-row--subtle">{event.from_status ? <span>{safeText(event.from_status, 48)}</span> : null}{event.to_status ? <span>→ {safeText(event.to_status, 48)}</span> : null}{event.reason_sha256 ? <span>reason {compactHash(event.reason_sha256)}</span> : null}</div></li>)}</ul> : <EmptyState label="No Mission events" />}</PanelCard>
+    </> : null}
+  </section>;
+}

--- a/web/src/flight/__tests__/missions.test.tsx
+++ b/web/src/flight/__tests__/missions.test.tsx
@@ -1,0 +1,123 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { api } from '../../api/client';
+import { MissionDetail, MissionsPanel } from '../MissionsPanel';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const mission = {
+  mission_id: 'msn-ui-1',
+  title: 'Launch v0.9',
+  objective: 'Ship the bounded v0.9 Mission stack.',
+  owner_profile: 'default',
+  acceptance_criteria: ['all slices observed'],
+  context_refs: [{ kind: 'document', ref: 'docs:v0.9', label: 'v0.9 plan', sha256: 'a'.repeat(64) }],
+  skills: [{ name: 'compound-engineering', version: '1', ref: 'skill:compound-engineering' }],
+  final_approval_required: true,
+  status: 'running',
+  version: 3,
+  approval: {},
+  attachments: [{ kind: 'workflow', ref: 'sw-v09', relationship: 'contains', state: 'running' }],
+  events: [{ seq: 2, event_type: 'mission.transition', from_status: 'draft', to_status: 'running', created_at: '2026-08-21T19:00:00Z' }],
+  updated_at: '2026-08-21T19:00:00Z',
+};
+
+const delegation = {
+  delegation_id: 'dlg-v09',
+  mission_id: 'msn-ui-1',
+  task_id: 'task-v09',
+  backend: 'opencode',
+  state: 'running',
+  backend_state: 'running',
+  updated_at: '2026-08-21T19:00:00Z',
+};
+
+describe('Missions Flight Deck', () => {
+  it('renders the Mission list and links to durable detail', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ missions: [mission], count: 1, live_cursor: 4, read_only: true });
+    render(<MemoryRouter><MissionsPanel /></MemoryRouter>);
+
+    expect(await screen.findByText('Launch v0.9')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Launch v0.9' });
+    expect(link).toHaveAttribute('href', '/ops/missions/msn-ui-1');
+    expect(screen.getByText('running')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /approve|cancel|run/i })).not.toBeInTheDocument();
+  });
+
+  it('renders Mission lineage, manifests, delegations, attachments, and events read-only', async () => {
+    vi.spyOn(api, 'get').mockImplementation((path: string) => {
+      if (path.includes('/events?')) return new Promise(() => undefined);
+      return Promise.resolve({ mission, delegations: [delegation], delegation_count: 1, live_cursor: 4, read_only: true });
+    });
+    render(
+      <MemoryRouter initialEntries={['/ops/missions/msn-ui-1']}>
+        <Routes><Route path="/ops/missions/:missionId" element={<MissionDetail />} /></Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Launch v0.9')).toBeInTheDocument();
+    expect(screen.getByText('v0.9 plan')).toBeInTheDocument();
+    expect(screen.getByText('compound-engineering')).toBeInTheDocument();
+    expect(screen.getByText('dlg-v09')).toBeInTheDocument();
+    expect(screen.getByText('sw-v09')).toBeInTheDocument();
+    expect(screen.getByText('mission.transition')).toBeInTheDocument();
+    expect(await screen.findByText('live updates')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /approve|cancel|run/i })).not.toBeInTheDocument();
+  });
+
+  it('separates execution success from contract validation and warns on missing proof', async () => {
+    const unverifiedDelegation = { ...delegation, state: 'succeeded', backend_state: 'completed', validation_verdict: 'UNVERIFIED' };
+    const unverifiedMission = {
+      ...mission,
+      attachments: [{ kind: 'delegation', ref: 'dlg-v09', relationship: 'contains', state: 'succeeded', verified: 0, evidence_ref: 'delegation:dlg-v09' }],
+    };
+    vi.spyOn(api, 'get').mockImplementation((path: string) => {
+      if (path.includes('/events?')) return new Promise(() => undefined);
+      return Promise.resolve({ mission: unverifiedMission, delegations: [unverifiedDelegation], delegation_count: 1, live_cursor: 4, read_only: true });
+    });
+    render(
+      <MemoryRouter initialEntries={['/ops/missions/msn-ui-1']}>
+        <Routes><Route path="/ops/missions/:missionId" element={<MissionDetail />} /></Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('UNVERIFIED')).toHaveAttribute('data-status', 'warn');
+    expect(screen.getByText('verification missing')).toHaveAttribute('data-status', 'warn');
+    expect(screen.getByText('Execution')).toBeInTheDocument();
+    expect(screen.getByText('Validation')).toBeInTheDocument();
+  });
+
+  it('refreshes the durable Mission snapshot after a live wake-up', async () => {
+    let detailReads = 0;
+    let eventReads = 0;
+    vi.spyOn(api, 'get').mockImplementation((path: string) => {
+      if (path.includes('/events?')) {
+        eventReads += 1;
+        if (eventReads === 1) return Promise.resolve({ cursor: 4, next_cursor: 5, high_watermark: 5, count: 1, events: [{ kind: 'mission.transition' }] });
+        return new Promise(() => undefined);
+      }
+      detailReads += 1;
+      return Promise.resolve({
+        mission: { ...mission, status: detailReads === 1 ? 'running' : 'succeeded', version: detailReads + 2 },
+        delegations: [{ ...delegation, state: detailReads === 1 ? 'running' : 'succeeded' }],
+        delegation_count: 1,
+        live_cursor: detailReads === 1 ? 4 : 5,
+        read_only: true,
+      });
+    });
+    render(
+      <MemoryRouter initialEntries={['/ops/missions/msn-ui-1']}>
+        <Routes><Route path="/ops/missions/:missionId" element={<MissionDetail />} /></Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(detailReads).toBeGreaterThanOrEqual(2));
+    expect(screen.getAllByText('succeeded').length).toBeGreaterThanOrEqual(1);
+    expect(eventReads).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary

Integrates the independently reviewed PR #51 Flight Deck Missions slice onto the current v0.9 master after Missions, Live Events, and Delegation Lifecycle were merged.

This candidate is intentionally reconstructed from #51 head `12c5c755371ee0b2f912f05862de15ce1f1cdb7e` rather than merging the cumulative contributor stack directly.

## Why reconstruction was required

PR #51 carries older cumulative copies of the v0.9 backend stack. A direct merge would overwrite freshly integrated Mission, Live Events, Delegation, runner, Fabric, and confinement code.

This branch therefore starts at current master `13c00964ec07fc065f65d1885f4b6f58e0a63278` and transplants only the Flight Deck Missions UI/API/docs/test slice.

## Included from reviewed #51 head

- GET-only Mission list/detail browser adapters
- GET-only Mission-filtered live-event wakeup reads
- GET-only delegation detail adapter
- Flight Deck Missions list/detail React surfaces
- context, skills, acceptance criteria, attachments, delegations, approval, and event history presentation
- URI-encoded Mission navigation and bounded safe-text rendering
- docs, packaging, CI scope, and dedicated backend/frontend regression tests

## Preserved from current master

- Mission runtime and Owner/evidence semantics
- post-commit Live Events publication
- Delegation evidence-gated lifecycle
- runner/OpenCode credential relay and confinement
- Fabric authority and artifact admission
- server auth/middleware composition

## Authority boundary

This integration adds observation only. The browser receives no Mission approval, transition, attach, reconcile, delegation dispatch, cancel, or mutation endpoint. Live events are wakeup signals and the browser re-reads durable Mission state.

## Review provenance

Source #51 head `12c5c75` has an independent adversarial security review PASS covering GET/HEAD-only routes, auth inheritance, XSS handling, bounded IDs, wakeup-only events, and durable-state re-read behavior.

This PR requires fresh combined-tree CI and integration review before merge.

Source: #51
