### PR TITLE
fleet: generic loopback Agent Card + admit unknown manifest peers

### DIFF
--- a/operator_fleet.py
+++ b/operator_fleet.py
@@ -11,6 +11,7 @@ fallback for registry listing only.
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import json
 import os
@@ -25,6 +26,19 @@ from typing import Any, Callable
 import operator_policy as op
 
 Runner = Callable[..., tuple[int, str, str]]
+
+# In-process Agent Card cache. When a fleet tool runs inside the same
+# hermes-gpt process that serves a peer's card on loopback, an HTTP fetch
+# back to that loopback would deadlock the single event loop. Peers may
+# register their own card here so loopback verification reads it directly
+# instead of round-tripping through the blocked loop.
+_LOCAL_AGENT_CARDS: dict[str, dict[str, Any]] = {}
+
+
+def register_local_agent_card(url: str, card: dict[str, Any]) -> None:
+    """Publish this process's own Agent Card for loopback fleet verification."""
+    _LOCAL_AGENT_CARDS[url.rstrip("/")] = card
+
 
 AUTHORITY_MANIFEST_ENV = "HERMES_GPT_FLEET_AUTHORITY_MANIFEST"
 A2A_REGISTRY_MODE_ENV = "HERMES_GPT_FLEET_A2A_MODE"
@@ -214,6 +228,18 @@ def _http_get_json(url: str, headers: dict[str, str], timeout: int) -> dict[str,
         return json.loads(data.decode("utf-8"))
 
 
+def _http_get_json_threaded(url: str, headers: dict[str, str], timeout: int) -> dict[str, Any]:
+    """Run the blocking GET off the caller's event loop.
+
+    When the fleet tool runs inside the same hermes-gpt process that also
+    serves the peer's Agent Card, a blocking same-loopback fetch would
+    deadlock (the inbound request can never be accepted while the loop is
+    blocked). Offloading to a worker thread lets the inbound request through.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        return ex.submit(_http_get_json, url, headers, timeout).result()
+
+
 def _http_post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: int) -> dict[str, Any]:
     data = json.dumps(body).encode("utf-8")
     hdrs = {"Content-Type": "application/json", "A2A-Version": "1.0", **headers}
@@ -227,12 +253,17 @@ def _card_url(base_url: str) -> str:
 
 
 def _fetch_card(base_url: str, headers: dict[str, str], timeout: int) -> dict[str, Any]:
+    # Short-circuit loopback fetches to avoid the same-process event-loop
+    # deadlock: the card is served by this very process, so read it directly.
+    key = base_url.rstrip("/")
+    if key in _LOCAL_AGENT_CARDS:
+        return _LOCAL_AGENT_CARDS[key]
     try:
-        return _http_get_json(_card_url(base_url), headers, timeout)
+        return _http_get_json_threaded(_card_url(base_url), headers, timeout)
     except urllib.error.HTTPError as e:
         if e.code != 404:
             raise
-    return _http_get_json(base_url.rstrip("/") + "/.well-known/agent.json", headers, timeout)
+    return _http_get_json_threaded(base_url.rstrip("/") + "/.well-known/agent.json", headers, timeout)
 
 
 def _jsonrpc_interface(card: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -561,7 +592,10 @@ def _load_authority(path: Path | None = None) -> dict[str, AuthorityPeer]:
         if not isinstance(name, str) or not _AGENT_RE.fullmatch(name) or name in peers:
             raise ValueError("authority peer name is invalid or duplicated")
         if name not in _BUILTIN_PROFILES:
-            raise ValueError("authority manifest contains an unsupported peer")
+            # Unknown manifest peer: admit it at the lowest profile ceiling instead of
+            # rejecting the whole manifest. A freshly enrolled machine is therefore valid
+            # but bounded to the default profile only (the ceiling check below still holds).
+            _BUILTIN_PROFILES[name] = frozenset({"default"})
         if not isinstance(role, str) or not _ROLE_RE.fullmatch(role):
             raise ValueError("expected_host_role is invalid")
         if (

--- a/server.py
+++ b/server.py
@@ -2412,6 +2412,96 @@ async def health_root(_request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok", "server": "hermes-gpt", "mcp_path": "/mcp"})
 
 
+def _fleet_peer_name() -> str:
+    return os.environ.get("HERMES_GPT_FLEET_PEER_NAME", "").strip() or "hermes-peer"
+
+
+def _fleet_peer_url() -> str:
+    return (
+        os.environ.get("HERMES_GPT_FLEET_PEER_URL", "").strip()
+        or f"http://{os.environ.get('HERMES_GPT_HOST', '127.0.0.1')}:{os.environ.get('HERMES_GPT_PORT', '4750')}"
+    )
+
+
+async def _fleet_agent_card(_request: Request) -> JSONResponse:
+    """Agent Card for this Fleet peer. The fleet authority manifest pins
+    expected_card_identity to HERMES_GPT_FLEET_PEER_NAME; this route attests
+    that identity. No secrets, tokens, or credentials are returned."""
+    peer_name = _fleet_peer_name()
+    peer_url = _fleet_peer_url()
+    return JSONResponse(
+        {
+            "protocolVersion": "1.0",
+            "name": peer_name,
+            "description": "Hermes Fleet peer",
+            "version": os.environ.get("HERMES_GPT_FLEET_PEER_VERSION", "0.20.5"),
+            "url": peer_url,
+            "capabilities": {},
+            "defaultInputModes": ["application/json"],
+            "defaultOutputModes": ["application/json"],
+            "skills": [
+                {
+                    "id": "hermes-agent-v1",
+                    "name": "Hermes Agent",
+                    "description": "Local-first Hermes Agent",
+                    "tags": ["hermes", "fleet"],
+                }
+            ],
+            "supportedInterfaces": [
+                {
+                    "url": peer_url,
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "1.0",
+                }
+            ],
+        }
+    )
+
+
+def _register_fleet_local_card() -> None:
+    """Publish this peer's own Agent Card for in-process loopback verification.
+
+    Keeps the fleet drift/status tools from deadlocking when they fetch the
+    card of a co-located peer over 127.0.0.1. The identity here must match the
+    fleet authority manifest entry (expected_card_identity = HERMES_GPT_FLEET_PEER_NAME).
+    """
+    try:
+        import operator_fleet as _op
+
+        peer_name = _fleet_peer_name()
+        peer_url = _fleet_peer_url()
+        _op.register_local_agent_card(
+            peer_url,
+            {
+                "protocolVersion": "1.0",
+                "name": peer_name,
+                "description": "Hermes Fleet peer",
+                "version": os.environ.get("HERMES_GPT_FLEET_PEER_VERSION", "0.20.5"),
+                "url": peer_url,
+                "capabilities": {},
+                "defaultInputModes": ["application/json"],
+                "defaultOutputModes": ["application/json"],
+                "skills": [
+                    {
+                        "id": "hermes-agent-v1",
+                        "name": "Hermes Agent",
+                        "description": "Local-first Hermes Agent",
+                        "tags": ["hermes", "fleet"],
+                    }
+                ],
+                "supportedInterfaces": [
+                    {
+                        "url": peer_url,
+                        "protocolBinding": "JSONRPC",
+                        "protocolVersion": "1.0",
+                    }
+                ],
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def build_asgi_app(server: FastMCP, *, http: bool) -> Any:
     oauth_state = getattr(server, "_hermes_oauth_state", None)
     if oauth_state is not None and not http:
@@ -2463,6 +2553,14 @@ def build_asgi_app(server: FastMCP, *, http: bool) -> Any:
         return admitted
 
     routes: list[BaseRoute] = [Route("/", health_root, methods=["GET", "POST", "OPTIONS"])]
+    # Fleet Agent Card (env-driven identity; generic across peers). Behind the
+    # same outer Bearer/OAuth middleware as MCP. No secret material returned.
+    routes.extend(
+        [
+            Route("/.well-known/agent-card.json", _fleet_agent_card, methods=["GET"]),
+            Route("/.well-known/agent.json", _fleet_agent_card, methods=["GET"]),
+        ]
+    )
     if oauth_state is not None:
         async def resource_metadata(request: Request) -> JSONResponse:
             return oauth_auth.protected_resource_metadata(request, oauth_state)
@@ -3031,6 +3129,7 @@ def _run_legacy_server(argv: list[str]) -> None:
         # local-only testing when cert/key are provided.
         import uvicorn
         app = build_asgi_app(server, http=args.http)
+        _register_fleet_local_card()
 
         uvicorn.run(
             app,


### PR DESCRIPTION
## Summary
- `operator_fleet.py`: add `register_local_agent_card()` + a loopback short-circuit in `_fetch_card` so co-located fleet tools no longer deadlock the single event loop when verifying a peer's own Agent Card over `127.0.0.1`.
- `server.py`: add `/.well-known/agent-card.json` (+ `/.well-known/agent.json`) route served behind the existing Bearer/OAuth middleware. Identity is env-driven (`HERMES_GPT_FLEET_PEER_NAME` / `HERMES_GPT_FLEET_PEER_URL` / `HERMES_GPT_FLEET_PEER_VERSION`), so the same code serves any peer — no hardcoded host names.
- `_load_authority`: an unknown manifest peer is now admitted at the lowest profile ceiling (`default` only) instead of rejecting the whole manifest. Profile-ceiling enforcement is unchanged, so a peer still cannot exceed built-in profiles (verified: a `rogue` peer requesting `admin` raises `PermissionError`).

## Why
A freshly enrolled machine was previously rejected by a hardcoded peer whitelist, forcing a code change to enroll. This makes enrollment a config/manifest action, and avoids the same-process card-fetch deadlock that produced spurious `CARD_UNAVAILABLE` drift for loopback peers.

## Test plan
- Hermetic logic checks (loopback short-circuit, unknown-peer admission, builtin peers, profile-ceiling enforcement) pass against the modified modules.
- Verified live on a macOS Fleet peer running the equivalent env-driven code: `hermes_fleet_status` → compatible, `hermes_fleet_authority_drift` → valid (0 findings), Agent Card route returns 401 without token and 200 with the bearer.

No secrets, tokens, or URLs-to-other-hosts are exposed by the Agent Card.
