### PR TITLE
fix(operator): handle JSON gateway.pid

### DIFF
--- a/operator_diagnostics.py
+++ b/operator_diagnostics.py
@@ -257,12 +257,15 @@ def _check_gateway_status(profile_home: Path) -> dict[str, Any]:
     pid_path = _gateway_pid_path(profile_home)
     heartbeat_path = _ticker_heartbeat_path(profile_home)
 
-    pid: int | None = None
-    if pid_path.exists():
-        try:
-            pid = int(pid_path.read_text(encoding="utf-8").strip())
-        except (OSError, ValueError):
-            pid = None
+    # Fix 2026-09-08 (see MEMORY.md / HANDOFF.md, hermes-gpt v0.8.0 @ fc1f68c):
+    # gateway.pid can hold JSON (newer gateway versions) instead of a plain
+    # int. Reuse the already-battle-tested fallback from operator_workspace
+    # (pid file -> gateway_state.json) instead of failing outright on
+    # ValueError, which previously caused false-negative GATEWAY_PID_MISSING.
+    pid: int | None = op_workspace._read_gateway_pid_from_pid_file(pid_path)
+    if pid is None:
+        _state = op_workspace._read_gateway_state(_gateway_state_path(profile_home))
+        pid = op_workspace._read_gateway_pid_from_state(_state)
 
     running = _is_process_alive(pid) if pid is not None else False
 

--- a/operator_mission.py
+++ b/operator_mission.py
@@ -45,6 +45,7 @@ import operator_policy as op
 import operator_diagnostics as op_diag
 import operator_cron as op_cron
 import operator_fleet as op_fleet
+import operator_workspace as op_workspace
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -871,12 +872,14 @@ def _profile_summary(profile: str, root: Path | None, warnings: list[str]) -> di
     gateway_running = False
     try:
         pid_path = home / "gateway.pid"
-        pid: int | None = None
-        if pid_path.exists():
-            try:
-                pid = int(pid_path.read_text(encoding="utf-8").strip())
-            except (OSError, ValueError):
-                pid = None
+        # Fix 2026-09-08 (see MEMORY.md / HANDOFF.md, hermes-gpt v0.8.0 @ fc1f68c):
+        # gateway.pid can hold JSON (newer gateway versions) instead of a plain
+        # int; fall back to gateway_state.json like operator_workspace does,
+        # instead of silently treating the gateway as not running.
+        pid: int | None = op_workspace._read_gateway_pid_from_pid_file(pid_path)
+        if pid is None:
+            _state = op_workspace._read_gateway_state(home / "gateway_state.json")
+            pid = op_workspace._read_gateway_pid_from_state(_state)
         gateway_running = op_diag._is_process_alive(pid) if pid is not None else False
     except Exception:
         gateway_running = False

--- a/test_operator_diagnostics.py
+++ b/test_operator_diagnostics.py
@@ -131,6 +131,30 @@ def test_doctor_passes_for_valid_hermes_root(hermes_root, clean_env, audit_overr
     assert parsed["trace_id"]
 
 
+def test_gateway_status_falls_back_to_json_gateway_state_pid(hermes_root):
+    (hermes_root / "gateway.pid").write_text(
+        json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+        }),
+        encoding="utf-8",
+    )
+    (hermes_root / "gateway_state.json").write_text(
+        json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+        }),
+        encoding="utf-8",
+    )
+    result = od._check_gateway_status(hermes_root)
+    assert result["status"] == od.STATUS_PASS
+    assert result["code"] == "GATEWAY_OK"
+    assert result["pid"] == os.getpid()
+    assert result["running"] is True
+
+
 def test_doctor_fails_for_dead_pid(hermes_root, clean_env, audit_override):
     pid_path = hermes_root / "gateway.pid"
     pid_path.write_text("99999999", encoding="utf-8")


### PR DESCRIPTION
## Problem

Newer Hermes gateway versions can write gateway.pid as a JSON record rather than a bare integer. hermes-gpt operator diagnostics and mission summary attempted int(pid_file_contents), causing ValueError and false GATEWAY_PID_MISSING even when the gateway was running.

## Fix

Reuse operator_workspace's existing gateway PID reader and runtime-state fallback in:
- operator_diagnostics._check_gateway_status
- operator_mission._profile_summary

This keeps gateway detection consistent with the existing workspace helper and supports both PID file formats.

## Regression coverage

- Added a regression test covering JSON-form gateway.pid.
- Existing gateway tests: 6/6 passed.
- Relevant operator tests: 67/67 passed.
- Hermes Agent was updated from 8aa219ef60 to b2aa855b62; gateway tests remained 6/6.
- git diff --check passes.

## Compatibility

No Hermes Agent source changes; hermes-gpt only.