### PR TITLE
Support MCP SDK 2 while retaining SDK 1 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,24 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.10', '3.11', '3.12']
+        sdk: ['mcp>=1.28.1,<2', 'mcp>=2,<3']
+        include:
+          - os: ubuntu-latest
+            python: '3.10'
+            sdk: 'mcp==1.28.1'
+          - os: ubuntu-latest
+            python: '3.10'
+            sdk: 'mcp==2.0.0'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - run: python -m pip install -e ".[dev]"
+      - run: python -m pip install -e ".[dev]" "${{ matrix.sdk }}"
       - name: Run full test suite
+        env:
+          HERMES_HTTP_TEST: "1"
         run: python -m pytest -q
       - name: Run runner regression tests
         run: >-
@@ -42,6 +52,7 @@ jobs:
           server.py
           codex_core.py
           codex_mcp.py
+          mcp_compat.py
           codex_config.py
           operator_codex.py
           operator_contract.py
@@ -95,6 +106,8 @@ jobs:
       - run: python -m pip install -e ".[dev]"
       - run: >-
           python -m ruff check
+          mcp_compat.py codex_mcp.py test_mcp_sdk_migration.py test_mcp_compat.py
+          test_mcp_transport_mode.py test_codex_mcp.py test_hermetic_environment.py test_operator_codex.py
           fabric_artifacts.py fabric_write_guard.py
           operator_fabric.py operator_fabric_control.py operator_fabric_router.py operator_fabric_g4c.py operator_fabric_view.py
           test_operator_fabric.py test_operator_fabric_adversarial.py test_operator_fabric_control.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Support MCP Python SDK 2.x alongside 1.28.1+, preserving local stdio, HTTP/SSE transport settings, authentication and Operator gates.
+- Correct the Codex Operator aliases' return signatures to describe normalized results, avoiding SDK 2 output-validation failures.
+- Test both SDK families and minimum versions in CI, with wire-level negotiation and result assertions.
+
 ## 0.10.0 - 2026-09-07
 
 vNext slice-1 derived mission views and the supervised mission controller (shadow): deterministic MissionPlan decomposition, read-only capability-manifest and mission-ledger views, a dry-run budget envelope, dry-run placement scoring, semantic failure classification with a smallest-first recovery matrix, and a shadow/observe controller reconciler — all additive and decision-only, preserving the existing read-only/dry-run, read-only, and shadow authority ladder. This slice adds ~27 new MCP tools; none of them can mutate a Mission, dispatch work, or approve anything in this release.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **GitHub release target:** v0.10.0
 - **Latest PyPI release:** check the badge above; PyPI is published independently from GitHub
 - **Python requirement:** 3.10+
+- **MCP SDK (current source):** 1.28.1+ or 2.x; see [compatibility](docs/mcp-compatibility.md).
 - **Deployment posture:** local-dev / trusted-machine only
 - **Remote public hosting:** unsupported without a real authenticated private boundary
 

--- a/codex_mcp.py
+++ b/codex_mcp.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
-
-from mcp.server.fastmcp import FastMCP
+from collections.abc import Callable
+from typing import Any
 
 from codex_core import CodexToolCore, codex_toolset
+from mcp_compat import HermesMCP as FastMCP
 from versioning import VERSION
-
 
 NOAUTH_META = {"securitySchemes": [{"type": "noauth"}]}
 
@@ -28,6 +27,7 @@ def build_codex_server(core: CodexToolCore, *, host: str = "127.0.0.1", port: in
                        operator_tools: dict[str, Callable[..., Any]] | None = None) -> FastMCP:
     server = FastMCP(
         "hermes-gpt",
+        version=VERSION,
         host=host,
         port=port,
         streamable_http_path="/mcp",
@@ -36,12 +36,6 @@ def build_codex_server(core: CodexToolCore, *, host: str = "127.0.0.1", port: in
         stateless_http=http,
         json_response=http,
     )
-    # Advertise the hermes-gpt app version in the initialize handshake so a
-    # client can detect a stale process exposing an old schema. mcp 1.28.x has
-    # no public FastMCP version hook; the low-level Server falls back to the
-    # SDK version when self.version is unset, so set it on the private instance
-    # (same documented seam as server.build_server()).
-    server._mcp_server.version = VERSION
 
     def hermes_status() -> dict[str, Any]:
         """Check the local Hermes GPT and Hermes Agent gateway state."""
@@ -96,6 +90,7 @@ def build_codex_server(core: CodexToolCore, *, host: str = "127.0.0.1", port: in
                 return _structured_redacted(__callback(*args, **kwargs))
             wrapper.__name__ = alias
             wrapper.__doc__ = callback.__doc__ or f"Hermes Operator tool alias for {callback.__name__}."
-            wrapper.__signature__ = __import__("inspect").signature(callback)  # type: ignore[attr-defined]
+            # The wrapper parses JSON strings; its result is not the callback's str.
+            wrapper.__signature__ = __import__("inspect").signature(callback).replace(return_annotation=Any)  # type: ignore[attr-defined]
             server.add_tool(wrapper, name=alias, meta=NOAUTH_META)
     return server

--- a/codex_mcp.py
+++ b/codex_mcp.py
@@ -92,5 +92,7 @@ def build_codex_server(core: CodexToolCore, *, host: str = "127.0.0.1", port: in
             wrapper.__doc__ = callback.__doc__ or f"Hermes Operator tool alias for {callback.__name__}."
             # The wrapper parses JSON strings; its result is not the callback's str.
             wrapper.__signature__ = __import__("inspect").signature(callback).replace(return_annotation=Any)  # type: ignore[attr-defined]
-            server.add_tool(wrapper, name=alias, meta=NOAUTH_META)
+            # Do not rely on how a Python version classifies typing.Any when
+            # inferring a schema: these callbacks can also return plain text.
+            server.add_tool(wrapper, name=alias, meta=NOAUTH_META, structured_output=False)
     return server

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pytest
 
-
 _ISOLATED_ENV_VARS = (
     "HERMES_GPT_OPERATOR_ENABLED",
     "HERMES_GPT_OPERATOR_LEVEL",
@@ -33,6 +32,7 @@ _ISOLATED_ENV_VARS = (
     "HERMES_GPT_OAUTH_REDIRECT_URI",
     "HERMES_GPT_OAUTH_SCOPE",
     "HERMES_GPT_BEARER_TOKEN",
+    "HERMES_GPT_TOKEN_MASTER_KEY",
     # Hermes-side identity env: never inherit the invoking shell's profile or
     # data root during tests. Cleared at import time so collection-time module
     # imports resolve against the sandbox, not the real machine.
@@ -64,6 +64,20 @@ for _name in _ISOLATED_ENV_VARS:
 # import time). An explicit sandbox config.yaml with no a2a_agents keeps the
 # official A2A registry empty so injected test runners stay authoritative.
 os.environ["HERMES_HOME"] = str(_hermes_sandbox())
+
+# Tests and their subprocesses must never read or rotate the user's OS
+# keychain entry. The failing backend makes token_store use its real,
+# per-test key-file fallback. A null/no-op backend would falsely report
+# successful key writes without retaining them and corrupt round trips.
+os.environ["PYTHON_KEYRING_BACKEND"] = "keyring.backends.fail.Keyring"
+try:
+    import keyring as _keyring
+    from keyring.backends.fail import Keyring as _TestKeyring
+except ImportError:
+    pass  # keyring is optional; token_store already falls back to key files.
+else:
+    # A pytest plugin may have initialized the backend before conftest loads.
+    _keyring.set_keyring(_TestKeyring())
 
 # Deterministic MIME type database. The minimal Arch/Python mimetypes DB does
 # not map common office MIME types (e.g. .xlsx), which makes

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ PyPI is an independent distribution channel. Check the PyPI badge in the root RE
 | [`../README.md`](../README.md) | current | project overview, current release, quickstart, safety invariants, entry-point selection |
 | [`runtime-checkout.md`](runtime-checkout.md) | host deployment provenance | which checkout the live `hermes-gpt-server.service` serves, and a caution that it is not the branch you happened to inspect |
 | [`oauth.md`](oauth.md) | current | static bearer and confidential-client OAuth configuration, token lifecycle, refresh rotation, and remote authentication limits |
-| [`mcp-compatibility.md`](mcp-compatibility.md) | current | pinned MCP protocol revisions, transport matrix, trusted-client auth metadata |
+| [`mcp-compatibility.md`](mcp-compatibility.md) | current | SDK 1/2 support, protocol regression checks, transport matrix, trusted-client auth metadata |
 | [`file-export.md`](file-export.md) | current | bounded binary file transfer, workspace/denied-path gates, size/extension limits, MCP embedded-resource semantics |
 | [`openai-secure-mcp-tunnel.md`](openai-secure-mcp-tunnel.md) | current | outbound-only private access from supported OpenAI products to loopback Hermes GPT |
 | [`cloudflare-tunnel.md`](cloudflare-tunnel.md) | current | public Cloudflare HTTPS proxy deployment and Host allowlist behavior |

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -9,6 +9,9 @@ The first workflow uses the Codex/MCP feature gates. The second uses Operator `w
 
 For documentation authority rules, see [docs/README.md](README.md).
 
+Both workflows support MCP Python SDK 1.28.1+ and 2.x. See the
+[MCP compatibility guide](mcp-compatibility.md) for the transport and test matrix.
+
 ## Workflow A: Codex as an MCP client
 
 ### Install the MCP entry

--- a/docs/mcp-compatibility.md
+++ b/docs/mcp-compatibility.md
@@ -1,38 +1,29 @@
 # MCP Compatibility
 
-- Status: current (v0.8.0, Fabric)
-- Owner: default (implementation: developer profile)
-- Verified: 2026-08-15 against `mcp` 1.28.1 (`mcp.shared.version`)
+- Status: current source (SDK 1/2 compatibility; not a release announcement)
 
-This manifest pins and verifies the Model Context Protocol surface that
-`hermes-gpt` exposes. It is the source of truth for protocol claims; the
-compatibility tests in `test_mcp_compat.py` assert it against the installed
-SDK at test time.
+This manifest describes the MCP surface exposed by both the main server and
+curated Codex server. Package support is `mcp[cli]>=1.28.1,<3`. SDK 1.x remains
+supported; installations may select SDK 2.x without changing Hermes source.
 
-## Minimum supported protocol revision
+## Protocol compatibility
 
-**2024-11-05** (`2024-11-05`).
+The SDK package version and negotiated MCP protocol revision are separate.
+The compatibility tests perform real HTTP `initialize` requests for legacy
+revisions **2024-11-05** and **2025-11-25**, checking the exact negotiated
+revision and Hermes GPT application version on both server surfaces. The
+existing subprocess stdio test also exercises **2025-06-18**.
 
-The server negotiates the highest mutually supported revision at `initialize`
-time and rejects unsupported revisions. Because the minimum is the oldest
-revision the installed SDK supports, every client that speaks at least
-2024-11-05 can interoperate.
+SDK 2 introduces the **2026-07-28** stateless protocol while retaining legacy
+client support. New-protocol clients do not use the legacy initialization
+handshake. These are SDK transport semantics, not a change to Hermes Operator
+authority. See the [SDK migration guide](https://py.sdk.modelcontextprotocol.io/migration/).
 
-## Supported revisions (installed SDK)
-
-The verified `mcp` SDK (1.28.x) declares these protocol revisions:
-
-| Revision | Notes |
-|---|---|
-| `2024-11-05` | Minimum supported; base tools/list + tools/call surface |
-| `2025-03-26` | Added pagination (`nextCursor`) |
-| `2025-06-18` | Added `roots/list`, tool annotations, structured output schema |
-| `2025-11-25` | Latest supported revision (authorization metadata era) |
-
-`mcp.shared.version.LATEST_PROTOCOL_VERSION` is `2025-11-25` at the verified
-version. `test_mcp_compat.py` asserts `2024-11-05` and `2025-11-25` are in the
-running SDK's `SUPPORTED_PROTOCOL_VERSIONS` so a future SDK floor regression
-fails the suite.
+The shared `mcp_compat.HermesMCP` adapter preserves explicit HTTP/SSE options:
+SDK 1 accepts them at construction; SDK 2 accepts them at ASGI app creation.
+Both retain JSON, stateless Streamable HTTP when started with `--http` and
+the existing host/origin restrictions. SDK 2 uses its public app-version
+parameter; only SDK 1 needs the legacy private version assignment.
 
 ## Transport matrix
 
@@ -73,7 +64,7 @@ The MCP specification leaves rendering of embedded resources to the client. Herm
 ## Version advertisement
 
 The `initialize` handshake advertises the hermes-gpt app version in
-`serverInfo.version` (from `versioning.VERSION`, currently `0.8.0`) — not the
+`serverInfo.version` (from `versioning.VERSION`) — not the
 MCP SDK version. This lets a client detect a stale process that is still
 exposing an old schema. `test_mcp_compat.py::test_initialize_advertises_server_version`
 asserts the handshake reports `versioning.VERSION` and that the pinned floor
@@ -92,9 +83,17 @@ Client notes:
   update and cache-refresh behavior; it is the canonical guide and is not
   duplicated here.
 
-## Package floor
+## Package floor and regression coverage
 
-`pyproject.toml` keeps `mcp[cli]>=1.0,<2` as the metadata floor (SDK 1.x
-family). The exact verified version is a test-time fact, not a hard pin, so
-the floor cannot drift silently: `test_mcp_compat.py` fails if the installed
-SDK drops `2024-11-05` or `2025-11-25` support.
+`pyproject.toml` and `requirements.txt` allow `mcp[cli]>=1.28.1,<3`.
+The minimum 1.x version is the previously documented verified SDK, rather
+than the historical untested `>=1.0` metadata floor. SDK 3 is not admitted.
+
+CI runs both SDK families on Python 3.10, 3.11 and 3.12, plus pinned 1.28.1
+and 2.0.0 floor jobs. Tests inspect serialized MCP field aliases, so SDK 2's
+Python snake_case attributes do not alter the expected wire contract.
+The matrix covers tool inventory, annotations, result schemas, binary export,
+authentication and permission gates. Codex Operator aliases return redacted content blocks without an output schema:
+some callbacks return JSON objects and others return plain skill text. Their
+signature uses `Any` instead of promising the original callback's string result.
+Core tools returning typed dictionaries continue to provide structured content.

--- a/mcp_compat.py
+++ b/mcp_compat.py
@@ -1,0 +1,56 @@
+"""Keep Hermes' transport defaults consistent across MCP Python SDK 1 and 2.
+
+SDK 2 renamed FastMCP and moved transport options from the constructor to
+the ASGI factories. Keep that adaptation here; tools use SDK types directly.
+"""
+
+from typing import Any
+
+try:
+    from mcp.server import MCPServer as _Server
+except ImportError:
+    from mcp.server.fastmcp import FastMCP as _Server
+
+    SDK_V2 = False
+else:
+    SDK_V2 = True
+
+
+class HermesMCP(_Server):
+    """A server with explicit, version-independent transport configuration."""
+
+    def __init__(
+        self, name: str, *, version: str, host: str = "127.0.0.1",
+        port: int = 7677, streamable_http_path: str = "/mcp",
+        sse_path: str = "/sse", message_path: str = "/messages/",
+        stateless_http: bool = False, json_response: bool = False,
+        transport_security: Any = None,
+    ) -> None:
+        self._hermes_http_options = {
+            "host": host, "streamable_http_path": streamable_http_path,
+            "stateless_http": stateless_http, "json_response": json_response,
+            "transport_security": transport_security,
+        }
+        self._hermes_sse_options = {
+            "host": host, "sse_path": sse_path, "message_path": message_path,
+            "transport_security": transport_security,
+        }
+        if SDK_V2:
+            super().__init__(name, version=version)
+        else:
+            super().__init__(
+                name, port=port, sse_path=sse_path, message_path=message_path,
+                **self._hermes_http_options,
+            )
+            # SDK 1 has no public app-version constructor parameter.
+            self._mcp_server.version = version
+
+    def streamable_http_app(self, **kwargs: Any) -> Any:
+        if SDK_V2:
+            return super().streamable_http_app(**{**self._hermes_http_options, **kwargs})
+        return super().streamable_http_app(**kwargs)
+
+    def sse_app(self, *args: Any, **kwargs: Any) -> Any:
+        if SDK_V2:
+            return super().sse_app(*args, **{**self._hermes_sse_options, **kwargs})
+        return super().sse_app(*args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "hermes-gpt contributors" }
 ]
 dependencies = [
-  "mcp[cli]>=1.0,<2",
+  "mcp[cli]>=1.28.1,<3",
   "packaging>=23",
   "uvicorn",
   "cryptography>=42",
@@ -83,6 +83,7 @@ py-modules = [
   "finance_worker",
   "codex_core",
   "codex_mcp",
+  "mcp_compat",
   "codex_config",
   "seams",
   "updater",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.0,<2
+mcp[cli]>=1.28.1,<3
 uvicorn
 packaging>=23
 cryptography>=42

--- a/server.py
+++ b/server.py
@@ -668,7 +668,7 @@ def clean_error(tool_name: str, exc: Exception) -> RuntimeError:
     return RuntimeError(f"{tool_name} failed: {exc}")
 
 
-from mcp.server.fastmcp import FastMCP
+from mcp_compat import HermesMCP as FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import CallToolResult, ToolAnnotations
 
@@ -2977,6 +2977,7 @@ def build_server(
         allowed_origins.append(f"{issuer.scheme}://{issuer.netloc}")
     server = FastMCP(
         "hermes-gpt",
+        version=VERSION,
         host=host,
         port=port,
         streamable_http_path="/mcp",
@@ -2989,16 +2990,6 @@ def build_server(
             allowed_origins=list(dict.fromkeys(allowed_origins)),
         ),
     )
-    # Advertise the hermes-gpt app version in the initialize handshake.
-    # mcp 1.28.x: FastMCP.__init__ has no version kwarg and constructs the
-    # low-level MCPServer with only name/instructions/website_url/icons. The
-    # low-level Server.create_initialization_options() falls back to the SDK
-    # distribution version (pkg_version("mcp")) when self.version is unset, so
-    # without this every client sees serverInfo.version="1.28.1" and cannot
-    # detect a stale process exposing an old schema. There is no public FastMCP
-    # hook for the app version in 1.28.x, so set it on the private low-level
-    # server instance (minimal, documented private-API use).
-    server._mcp_server.version = VERSION
     setattr(server, "_hermes_oauth_state", oauth_state)
     if oauth_state is not None:
         # v0.7 S5: persist every token issuance/refresh through token_store.

--- a/test_codex_mcp.py
+++ b/test_codex_mcp.py
@@ -17,7 +17,7 @@ def test_codex_mcp_registry_is_curated_and_complete():
         version="test",
         imports_ready=lambda: True,
         gateway_snapshot=lambda: {"gateway": {"running": False}},
-        gateway_diagnostics_callback=lambda: {},
+        gateway_diagnostics_callback=dict,
         vision_analyze=lambda path, prompt: {},
         web_search=lambda query, limit: {},
         web_extract=lambda urls, limit: {},
@@ -39,17 +39,41 @@ def test_codex_mcp_registry_is_curated_and_complete():
 def test_operator_toolset_is_opt_in_and_namespaced(monkeypatch):
     monkeypatch.setenv(codex_core.CODEX_TOOLSET_ENV, "operator")
     core = codex_core.CodexToolCore(
-        version="test", imports_ready=lambda: True, gateway_snapshot=lambda: {},
-        gateway_diagnostics_callback=lambda: {}, vision_analyze=lambda path, prompt: {},
+        version="test", imports_ready=lambda: True, gateway_snapshot=dict,
+        gateway_diagnostics_callback=dict, vision_analyze=lambda path, prompt: {},
         web_search=lambda query, limit: {}, web_extract=lambda urls, limit: {},
         cron_create_callback=lambda schedule, prompt, dry_run: {},
         skill_create_callback=lambda name, content, dry_run: {},
     )
     def policy() -> str:
         return json.dumps({"success": True, "token": "secret-token-123456789"})
-    server = codex_mcp.build_codex_server(core, operator_tools={"hermes_operator_policy": policy})
+
+    def skill_view(name: str) -> str:
+        return f"# {name}\nPlain skill instructions."
+
+    server = codex_mcp.build_codex_server(core, http=True, operator_tools={
+        "hermes_operator_policy": policy, "hermes_operator_skill_view": skill_view,
+    })
     names = {tool.name for tool in asyncio.run(server.list_tools())}
     assert "hermes_operator_policy" in names
+    from starlette.testclient import TestClient
+
+    with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:7677") as client:
+        for name, arguments in [("hermes_operator_policy", {}), ("hermes_operator_skill_view", {"name": "example"})]:
+            response = client.post("/mcp", headers={"Accept": "application/json, text/event-stream"}, json={
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            })
+            assert response.status_code == 200, response.text
+            result = response.json()["result"]
+            assert not result.get("isError", False), result
+            text = next(c["text"] for c in result["content"] if c["type"] == "text")
+            assert "secret-token-123456789" not in text
+            assert result.get("structuredContent") is None
+            if name == "hermes_operator_policy":
+                assert json.loads(text)["success"] is True
+            else:
+                assert text == "# example\nPlain skill instructions."
 
 
 def test_invalid_toolset_fails_safely(monkeypatch):

--- a/test_codex_mcp.py
+++ b/test_codex_mcp.py
@@ -56,6 +56,9 @@ def test_operator_toolset_is_opt_in_and_namespaced(monkeypatch):
     })
     names = {tool.name for tool in asyncio.run(server.list_tools())}
     assert "hermes_operator_policy" in names
+    for tool in asyncio.run(server.list_tools()):
+        if tool.name.startswith("hermes_operator_"):
+            assert tool.model_dump(by_alias=True).get("outputSchema") is None
     from starlette.testclient import TestClient
 
     with TestClient(server.streamable_http_app(), base_url="http://127.0.0.1:7677") as client:

--- a/test_hermetic_environment.py
+++ b/test_hermetic_environment.py
@@ -50,13 +50,32 @@ def test_hermes_home_is_redirected_to_a_sandbox_without_real_config():
     assert profile in (None, ""), f"HERMES_PROFILE leaks the invoking shell: {profile!r}"
 
 
+def test_token_keys_stay_in_the_sandbox(tmp_path):
+    """Default token-store persistence cannot reach an OS keychain."""
+    import token_store
+
+    try:
+        import keyring
+        from keyring.backends.fail import Keyring
+    except ImportError:
+        pass
+    else:
+        # Fail before resolving a key if a plugin replaced test isolation.
+        assert isinstance(keyring.get_keyring(), Keyring)
+    key, _kid, source = token_store._resolve_key(tmp_path)
+    assert source == "keyfile"
+    assert len(key) == 32
+    assert token_store.key_file_path(tmp_path).is_file()
+
+
 def test_importing_test_ui_chat_does_not_inject_outside_paths():
     """test_ui_chat collection must not mutate global sys.path beyond the repo."""
     code = (
         "import sys, json\n"
         f"sys.path.insert(0, {str(REPO)!r})\n"
+        "before = list(sys.path)\n"
         "import test_ui_chat\n"
-        "print(json.dumps(sys.path))\n"
+        "print(json.dumps([p for p in sys.path if p not in before]))\n"
         "print(json.dumps(sorted(m for m in sys.modules if m == 'hermes_cli')))\n"
     )
     env = dict(os.environ)
@@ -66,6 +85,7 @@ def test_importing_test_ui_chat_does_not_inject_outside_paths():
     proc = subprocess.run(
         [sys.executable, "-c", code],
         capture_output=True,
+        check=False,
         text=True,
         timeout=60,
         env=env,

--- a/test_mcp_compat.py
+++ b/test_mcp_compat.py
@@ -76,53 +76,16 @@ GATED_WRITE_TOOLS = [
 ]
 
 
-@pytest.fixture()
-def sdk_protocol_versions() -> list[str]:
-    from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
+def test_package_metadata_allows_both_sdk_families():
+    """Published metadata admits tested 1.x/2.x releases, not untested 3.x."""
+    from packaging.requirements import Requirement
 
-    return list(SUPPORTED_PROTOCOL_VERSIONS)
-
-
-def test_installed_sdk_floor_is_pinned(sdk_protocol_versions):
-    """The SDK must support the pinned minimum protocol revision."""
-    assert MIN_PROTOCOL_VERSION in sdk_protocol_versions, (
-        f"installed mcp SDK dropped {MIN_PROTOCOL_VERSION}; update docs/mcp-compatibility.md"
-    )
-
-
-def test_installed_sdk_supports_latest_revision(sdk_protocol_versions):
-    """The SDK must support 2025-11-25 when available (it is at verified 1.28.x)."""
-    assert LATEST_PROTOCOL_VERSION in sdk_protocol_versions, (
-        f"installed mcp SDK dropped {LATEST_PROTOCOL_VERSION}; update docs/mcp-compatibility.md"
-    )
-
-
-def test_package_metadata_allows_mcp_1x_floor():
-    """pyproject.toml keeps the mcp SDK 1.x floor (not a hard 1.28 pin)."""
     dist = importlib.metadata.distribution("hermes-gpt")
-    for req in dist.requires or []:
-        if req.lower().startswith("mcp"):
-            assert ">=" in req and "<2" in req, f"mcp floor drifted: {req}"
-
-
-@pytest.mark.parametrize("protocol", [MIN_PROTOCOL_VERSION, LATEST_PROTOCOL_VERSION])
-def test_initialize_negotiation_accepts_protocol(protocol):
-    """FastMCP initialize accepts a supported protocol revision."""
-    from mcp.server.fastmcp import FastMCP
-
-    server = FastMCP("hermes-gpt-test")
-    # FastMCP stores the protocol version it will negotiate.
-    assert getattr(server, "protocol_version", None) in (
-        None,
-        protocol,
-        LATEST_PROTOCOL_VERSION,
-    )
-    # The server's underlying mcp session advertises supported versions.
-    from mcp.server.session import ServerSession
-    from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
-
-    assert protocol in SUPPORTED_PROTOCOL_VERSIONS
-    assert ServerSession is not None
+    requirements = [Requirement(r) for r in dist.requires or []]
+    mcp = next(r for r in requirements if r.name == "mcp")
+    for version in ("1.28.1", "2.0.0", "2.2.0"):
+        assert version in mcp.specifier
+    assert "3.0.0" not in mcp.specifier
 
 
 def test_http_tool_metadata_noauth_when_unconfigured(monkeypatch):
@@ -274,7 +237,7 @@ def test_all_tools_have_valid_input_schema(built_tools):
     """Proof 2: every registered tool exposes a valid MCP inputSchema."""
     assert built_tools, "no tools registered"
     for name, tool in built_tools.items():
-        schema = tool.inputSchema
+        schema = tool.model_dump(by_alias=True)["inputSchema"]
         assert isinstance(schema, dict), f"{name}: inputSchema not a dict"
         assert schema.get("type") == "object", f"{name}: inputSchema.type != object"
         properties = schema.get("properties")
@@ -288,14 +251,14 @@ def test_read_only_flight_deck_tools_carry_read_only_annotation(built_tools):
     for name in READ_ONLY_ANNOTATED_TOOLS:
         tool = built_tools[name]
         assert tool.annotations is not None, f"{name}: annotations missing"
-        assert tool.annotations.readOnlyHint is True, f"{name}: readOnlyHint not set"
+        assert tool.annotations.model_dump(by_alias=True)["readOnlyHint"] is True, f"{name}: readOnlyHint not set"
 
 
 def test_oauth_revoke_carries_destructive_annotation(built_tools):
     """F4: the destructive revoke tool carries destructiveHint for client UI."""
     tool = built_tools["hermes_oauth_revoke"]
     assert tool.annotations is not None, "hermes_oauth_revoke: annotations missing"
-    assert tool.annotations.destructiveHint is True
+    assert tool.annotations.model_dump(by_alias=True)["destructiveHint"] is True
 
 
 def test_flight_deck_tools_have_titles(built_tools):
@@ -327,38 +290,27 @@ def test_build_server_is_stable_across_calls(monkeypatch):
     assert first  # non-empty
 
 
-def test_initialize_advertises_server_version(built_server):
-    """Proof 9: initialize advertises serverInfo.version == versioning.VERSION
-    and negotiates a supported protocol revision that includes the pinned
-    floor (2024-11-05). This makes stale-schema processes detectable."""
-    import anyio
+@pytest.mark.parametrize("protocol", [MIN_PROTOCOL_VERSION, LATEST_PROTOCOL_VERSION])
+def test_initialize_advertises_server_version(protocol):
+    """Test the real HTTP handshake instead of SDK-private session internals."""
+    from starlette.testclient import TestClient
+
+    import server
     import versioning
-    from mcp.client.session import ClientSession
-    from mcp.shared.version import SUPPORTED_PROTOCOL_VERSIONS
 
-    assert built_server._mcp_server.version == versioning.VERSION
-    opts = built_server._mcp_server.create_initialization_options()
-    assert opts.server_version == versioning.VERSION
-
-    async def _handshake():
-        c2s_send, c2s_recv = anyio.create_memory_object_stream()
-        s2c_send, s2c_recv = anyio.create_memory_object_stream()
-        task = asyncio.create_task(
-            built_server._mcp_server.run(c2s_recv, s2c_send, opts)
-        )
-        try:
-            async with ClientSession(s2c_recv, c2s_send) as client:
-                result = await client.initialize()
-                return result
-        finally:
-            task.cancel()
-
-    result = asyncio.run(_handshake())
-    assert result.serverInfo.name == "hermes-gpt"
-    assert result.serverInfo.version == versioning.VERSION
-    assert result.protocolVersion in SUPPORTED_PROTOCOL_VERSIONS
-    # The pinned floor remains negotiable on the running SDK.
-    assert MIN_PROTOCOL_VERSION in SUPPORTED_PROTOCOL_VERSIONS
+    built = server.build_server(http=True)
+    app = server.build_asgi_app(built, http=True)
+    with TestClient(app, base_url="http://127.0.0.1:7677") as client:
+        response = client.post("/mcp", headers={"Accept": "application/json, text/event-stream"}, json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": protocol, "capabilities": {},
+                       "clientInfo": {"name": "pytest", "version": "1"}},
+        })
+        assert response.status_code == 200, response.text
+        result = response.json()["result"]
+        assert result["serverInfo"]["name"] == "hermes-gpt"
+        assert result["serverInfo"]["version"] == versioning.VERSION
+        assert result["protocolVersion"] == protocol
 
 
 def test_gated_write_tools_refuse_without_owner_direct_confirm(built_tools, tmp_path):

--- a/test_mcp_sdk_migration.py
+++ b/test_mcp_sdk_migration.py
@@ -1,0 +1,132 @@
+"""Exercise both real server surfaces at the SDK/wire boundary."""
+
+import importlib
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from versioning import VERSION
+
+
+@pytest.mark.parametrize("surface", ["main", "codex"])
+@pytest.mark.parametrize("protocol", ["2024-11-05", "2025-11-25"])
+def test_http_sdk_compatibility(surface, protocol, monkeypatch, tmp_path):
+    # Import within the test so the original v1-only import is an explicit
+    # regression failure under SDK 2, rather than a collection failure.
+    try:
+        server = importlib.import_module("server")
+    except ImportError as exc:
+        pytest.fail(f"Hermes GPT must load with the installed MCP SDK: {exc}")
+    monkeypatch.setenv("HERMES_GPT_ENABLE_CODEX", "1")
+    monkeypatch.setenv("HERMES_GPT_ENABLE_MCP", "1")
+    monkeypatch.setenv("HERMES_GPT_CODEX_TOOLSET", "operator")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    if surface == "main":
+        built = server.build_server(http=True)
+        app = server.build_asgi_app(built, http=True)
+        policy_tool = "hermes_operator_policy"
+    else:
+        built = server.build_codex_mcp_server(http=True)
+        app = built.streamable_http_app()
+        policy_tool = "hermes_operator_policy"
+
+    with TestClient(app, base_url="http://127.0.0.1:7677") as client:
+        headers = {"Accept": "application/json, text/event-stream"}
+        response = client.post("/mcp", headers=headers, json={
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": protocol, "capabilities": {},
+                       "clientInfo": {"name": "sdk-regression", "version": "1"}},
+        })
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("application/json")
+        assert "mcp-session-id" not in response.headers
+        initialized = response.json()["result"]
+        assert initialized["serverInfo"] == {"name": "hermes-gpt", "version": VERSION}
+        assert initialized["protocolVersion"] == protocol
+        headers["MCP-Protocol-Version"] = protocol
+        response = client.post("/mcp", headers=headers, json={
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {},
+        })
+        assert response.status_code == 200, response.text
+        tools = response.json()["result"]["tools"]
+        assert policy_tool in {t["name"] for t in tools}
+        response = client.post("/mcp", headers=headers, json={
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": policy_tool, "arguments": {}},
+        })
+        assert response.status_code == 200, response.text
+        result = response.json()["result"]
+        assert not result.get("isError", False), result
+        assert result["content"]
+        # The real RPC handler must still refuse a direct write in the
+        # default read-only posture, including through the Codex alias.
+        write_tool = "hermes_skill_create" if surface == "main" else "hermes_operator_skill_create"
+        response = client.post("/mcp", headers=headers, json={
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": write_tool, "arguments": {
+                "name": "sdk-must-not-create", "content": "# test", "dry_run": False,
+            }},
+        })
+        assert response.status_code == 200, response.text
+        result = response.json()["result"]
+        assert not result.get("isError", False), result
+        refusal = json.loads(next(c["text"] for c in result["content"] if c["type"] == "text"))
+        assert refusal["success"] is False
+        assert refusal["error"].startswith("Operator mode is disabled.")
+        assert not (tmp_path / "skills" / "sdk-must-not-create").exists()
+        # An explicit Host outside the default loopback boundary stays denied.
+        response = client.post("/mcp", headers={**headers, "Host": "untrusted.example"}, json={
+            "jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {},
+        })
+        assert response.status_code == 421
+        response = client.post("/mcp", headers={**headers, "Origin": "https://untrusted.example"}, json={
+            "jsonrpc": "2.0", "id": 5, "method": "tools/list", "params": {},
+        })
+        assert response.status_code == 403
+
+
+@pytest.mark.parametrize("surface", ["main", "codex"])
+def test_sdk2_stateless_request_without_initialize(surface, monkeypatch):
+    from mcp_compat import SDK_V2
+
+    if not SDK_V2:
+        pytest.skip("2026-07-28 protocol requires SDK 2")
+    import server
+
+    monkeypatch.setenv("HERMES_GPT_ENABLE_CODEX", "1")
+    monkeypatch.setenv("HERMES_GPT_ENABLE_MCP", "1")
+    built = server.build_server(http=True) if surface == "main" else server.build_codex_mcp_server(http=True)
+    app = server.build_asgi_app(built, http=True) if surface == "main" else built.streamable_http_app()
+    with TestClient(app, base_url="http://127.0.0.1:7677") as client:
+        response = client.post("/mcp", headers={
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": "2026-07-28",
+            "MCP-Method": "tools/list",
+        }, json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list",
+            "params": {"_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+            }},
+        })
+        assert response.status_code == 200, response.text
+        assert "mcp-session-id" not in response.headers
+        tools = response.json()["result"]["tools"]
+        expected = "hermes_operator_policy" if surface == "main" else "hermes_status"
+        assert expected in {t["name"] for t in tools}
+
+
+@pytest.mark.parametrize("surface", ["main", "codex"])
+def test_sse_rejects_untrusted_host_and_origin(surface):
+    import server
+
+    built = server.build_server() if surface == "main" else server.build_codex_mcp_server()
+    app = server.build_asgi_app(built, http=False) if surface == "main" else built.sse_app()
+    # SSE writes the denial response, then raises to close the stream.
+    # Assert what the HTTP client receives rather than re-raising server errors.
+    with TestClient(app, base_url="http://127.0.0.1:7677", raise_server_exceptions=False) as client:
+        response = client.get("/sse", headers={"Host": "untrusted.example"})
+        assert response.status_code == 421
+        response = client.get("/sse", headers={"Origin": "https://untrusted.example"})
+        assert response.status_code == 403

--- a/test_mcp_transport_mode.py
+++ b/test_mcp_transport_mode.py
@@ -15,5 +15,13 @@ def test_http_defaults_to_stateless_json_transport(monkeypatch):
     import server
 
     mcp = server.build_server(http=True)
-    assert mcp.settings.stateless_http is True
-    assert mcp.settings.json_response is True
+    from starlette.testclient import TestClient
+
+    with TestClient(server.build_asgi_app(mcp, http=True), base_url="http://127.0.0.1:7677") as client:
+        response = client.post("/mcp", headers={"Accept": "application/json, text/event-stream"}, json={
+            "jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {},
+        })
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("application/json")
+        assert "mcp-session-id" not in response.headers
+        assert response.json()["result"]["tools"]

--- a/test_operator_codex.py
+++ b/test_operator_codex.py
@@ -112,6 +112,9 @@ def test_nolo_job_metadata_and_audit(monkeypatch, tmp_path):
         def start(self):
             self.target(*self.args)
 
+    # The fake worker PID has no OS identity. Keep the supervisor from
+    # invoking macOS ps through the globally patched subprocess.Popen.
+    monkeypatch.setattr(oc.job_supervisor, "process_identity", lambda pid: None)
     monkeypatch.setattr(oc.subprocess, "Popen", lambda *args, **kwargs: FakeProc())
     monkeypatch.setattr(oc.threading, "Thread", ImmediateThread)
     monkeypatch.setattr(oc.op, "audit_record", lambda **kwargs: captured.update(kwargs) or kwargs)

--- a/test_operator_export.py
+++ b/test_operator_export.py
@@ -36,9 +36,9 @@ def test_export_returns_mcp_embedded_blob_without_local_path(monkeypatch, tmp_pa
 
         result = export.hermes_export_file(str(source))
 
-        assert result.isError is False
-        assert result.structuredContent is not None
-        metadata = result.structuredContent
+        assert result.model_dump(by_alias=True)["isError"] is False
+        assert result.model_dump(by_alias=True)["structuredContent"] is not None
+        metadata = result.model_dump(by_alias=True)["structuredContent"]
         assert metadata["success"] is True
         assert metadata["filename"] == "report.xlsx"
         assert metadata["mime_type"] == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
@@ -56,7 +56,7 @@ def test_export_returns_mcp_embedded_blob_without_local_path(monkeypatch, tmp_pa
 
         embedded = _blob_block(result)
         assert isinstance(embedded.resource, BlobResourceContents)
-        assert embedded.resource.mimeType == metadata["mime_type"]
+        assert embedded.resource.model_dump(by_alias=True)["mimeType"] == metadata["mime_type"]
         assert str(embedded.resource.uri) == metadata["resource_uri"]
         assert base64.b64decode(embedded.resource.blob) == payload
 
@@ -81,9 +81,9 @@ def test_export_requires_workspace_level(monkeypatch, tmp_path) -> None:
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
-    assert result.structuredContent["code"] == "FILE_EXPORT_ERROR"
+    assert result.model_dump(by_alias=True)["structuredContent"]["code"] == "FILE_EXPORT_ERROR"
 
 
 def test_export_requires_nonempty_allowed_paths(monkeypatch, tmp_path) -> None:
@@ -94,7 +94,7 @@ def test_export_requires_nonempty_allowed_paths(monkeypatch, tmp_path) -> None:
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
 
 
@@ -109,9 +109,9 @@ def test_export_rejects_file_outside_allowed_root(monkeypatch, tmp_path) -> None
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
-    assert str(outside) not in json.dumps(result.structuredContent)
+    assert str(outside) not in json.dumps(result.model_dump(by_alias=True)["structuredContent"])
 
 
 def test_export_rejects_symlink_escape_outside_allowed_root(monkeypatch, tmp_path) -> None:
@@ -130,9 +130,9 @@ def test_export_rejects_symlink_escape_outside_allowed_root(monkeypatch, tmp_pat
 
     result = export.hermes_export_file(str(link))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
-    assert "%PDF-outside" not in json.dumps(result.structuredContent)
+    assert "%PDF-outside" not in json.dumps(result.model_dump(by_alias=True)["structuredContent"])
 
 
 def test_export_rejects_secret_path_even_under_allowed_root(monkeypatch, tmp_path) -> None:
@@ -142,9 +142,9 @@ def test_export_rejects_secret_path_even_under_allowed_root(monkeypatch, tmp_pat
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
-    assert "do-not-export" not in json.dumps(result.structuredContent)
+    assert "do-not-export" not in json.dumps(result.model_dump(by_alias=True)["structuredContent"])
 
 
 def test_export_enforces_configured_size_cap(monkeypatch, tmp_path) -> None:
@@ -155,7 +155,7 @@ def test_export_enforces_configured_size_cap(monkeypatch, tmp_path) -> None:
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
 
 
@@ -167,7 +167,7 @@ def test_export_rejects_max_above_hard_cap(monkeypatch, tmp_path) -> None:
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)
 
 
@@ -182,8 +182,8 @@ def test_export_optional_extension_allowlist(monkeypatch, tmp_path) -> None:
     denied_result = export.hermes_export_file(str(denied))
     allowed_result = export.hermes_export_file(str(allowed))
 
-    assert denied_result.isError is True
-    assert allowed_result.isError is False
+    assert denied_result.model_dump(by_alias=True)["isError"] is True
+    assert allowed_result.model_dump(by_alias=True)["isError"] is False
     assert isinstance(_blob_block(allowed_result).resource, BlobResourceContents)
 
 
@@ -195,5 +195,5 @@ def test_export_empty_extension_allowlist_fails_closed(monkeypatch, tmp_path) ->
 
     result = export.hermes_export_file(str(source))
 
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)

--- a/test_server.py
+++ b/test_server.py
@@ -1340,4 +1340,4 @@ def test_v09_connector_surface_acceptance(monkeypatch):
     assert len(set(names)) == len(names), "duplicate tool registration"
 
     # serverInfo.version must track the checkout version, not the SDK version.
-    assert built._mcp_server.version == versioning.VERSION == "0.10.0"
+    assert (built.version if hasattr(built, "version") else built._mcp_server.version) == versioning.VERSION == "0.10.0"

--- a/test_server_export.py
+++ b/test_server_export.py
@@ -21,7 +21,7 @@ def test_export_tool_is_registered_read_only() -> None:
     tool = next(item for item in tools if item.name == "hermes_export_file")
 
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.model_dump(by_alias=True)["readOnlyHint"] is True
 
 
 def test_export_tool_round_trips_binary_through_fastmcp(monkeypatch, tmp_path) -> None:
@@ -36,8 +36,8 @@ def test_export_tool_round_trips_binary_through_fastmcp(monkeypatch, tmp_path) -
         result = asyncio.run(mcp.call_tool("hermes_export_file", {"path": str(source)}))
 
         assert isinstance(result, CallToolResult)
-        assert result.isError is False
-        assert result.structuredContent["filename"] == "report.xlsx"
+        assert result.model_dump(by_alias=True)["isError"] is False
+        assert result.model_dump(by_alias=True)["structuredContent"]["filename"] == "report.xlsx"
         embedded = next(item for item in result.content if isinstance(item, EmbeddedResource))
         assert isinstance(embedded.resource, BlobResourceContents)
         assert base64.b64decode(embedded.resource.blob) == payload
@@ -56,5 +56,5 @@ def test_export_tool_refuses_without_workspace_authority(monkeypatch, tmp_path) 
     result = asyncio.run(mcp.call_tool("hermes_export_file", {"path": str(source)}))
 
     assert isinstance(result, CallToolResult)
-    assert result.isError is True
+    assert result.model_dump(by_alias=True)["isError"] is True
     assert not any(isinstance(item, EmbeddedResource) for item in result.content)


### PR DESCRIPTION
Hermes GPT currently fails to import with MCP Python SDK 2 because `mcp.server.fastmcp` was removed. This extends support to `mcp>=1.28.1,<3` while retaining SDK 1 compatibility, instead of requiring existing users to migrate immediately.

- Add a shared adapter for the renamed server class, explicit HTTP/SSE options, and application-version advertisement. Existing authentication and Operator authority gates remain in place.
- Correct Codex Operator wrapper signatures: aliases can return parsed JSON or plain skill text, so they use unstructured content without an incorrect string output schema. Core dictionary-returning tools retain structured results.
- Replace SDK-private compatibility assertions with actual protocol requests and serialized field checks. Cover legacy negotiation, SDK2 stateless requests, Host/Origin rejection on HTTP/SSE, default write refusal, alias redaction/plain text, and binary exports.
- Add SDK1/2 CI coverage on Python 3.10–3.12, including pinned 1.28.1 and 2.0.0 floors, and enable the real HTTP smoke test.

The first commit fixes test portability separately: compare added sys.path entries instead of rejecting a Python runtime located under Hermes storage; isolate the fake worker PID from macOS process probes; keep token tests off the OS keychain using a process-local failing backend and per-test key files. Production token-store behavior is unchanged.

Validation on macOS / Python 3.11.15, sequential runs with `HERMES_HTTP_TEST=1 python -m pytest -o addopts='' -q -rs`:

| SDK | Passed | Skipped |
| --- | ---: | ---: |
| 1.28.1 | 1,361 | 8 |
| 1.30.0 | 1,361 | 8 |
| 2.0.0 | 1,363 | 6 |
| 2.2.0 | 1,363 | 6 |

Six skips are Windows/Linux-only checks; SDK1 additionally skips the two SDK2-native protocol cases. Existing dependency deprecation warnings remain. A final SDK2.2 rerun on committed head `cc8387e734d3ad18e1b9da07f49418e4d4496993` also passed 1,363 tests. The final explicit `structured_output=False` fix additionally passed targeted tests on all four local SDK versions.

Also passed: project CI Ruff command, whitespace checks, wheel/sdist build, Twine metadata checks, and package hygiene. A fresh environment installed the wheel and completed real stdio initialize/list/call on main (136 tools), Codex core (10), and Codex Operator (42); the final wheel's three runtime modules were compared byte-for-byte with committed HEAD. Independent code review found no blocking production issue; its test/docs recommendations were incorporated.

No release, PyPI publication, or live connector rollout is included.

Fork CI on the final commit [passed all 13 jobs](https://github.com/Marcin-Work/hermes-gpt/actions/runs/34540709335), including eight Python/SDK combinations, lint, web, Windows documentation, compatibility, and build. The initial run caught Python 3.10 inferring structured output from `Any`; the final commit explicitly disables it for mixed-content Operator aliases. Upstream Actions and Vercel preview remain subject to maintainer authorization.
